### PR TITLE
Fix receipt hash status metadata v0.1

### DIFF
--- a/receipts/drafts/receipt_chain_v0_1.json
+++ b/receipts/drafts/receipt_chain_v0_1.json
@@ -9,14 +9,20 @@
       "title": "Classical State Preparation for Variational Quantum Algorithms via Reinforcement Learning",
       "arxiv_id": "2605.23138v1",
       "hash": "65fb435a2f43225097a40c3e495453cc24f62fd333691d35927c13b43721089c",
-      "verification": "assistant_observed_source_and_claims"
+      "verification": "assistant_observed_source_and_claims",
+      "hash_algorithm": "SHA-256",
+      "hash_basis": "raw_arxiv_pdf_bytes",
+      "hash_status": "pending_local_recompute"
     },
     {
       "artifact_id": "joy://2026-05-29/arxiv-2605.01574-001",
       "title": "Hybrid Quantum Reinforcement Learning with QAOA for Improved Vehicle Routing Optimization",
       "arxiv_id": "2605.01574v1",
       "hash": "903d92f593b0ef82adaa19b05e2a72bfc917e5b24e587c90d6692df562888460",
-      "verification": "assistant_verified_abstract"
+      "verification": "assistant_verified_abstract",
+      "hash_algorithm": "SHA-256",
+      "hash_basis": "raw_arxiv_pdf_bytes",
+      "hash_status": "pending_local_recompute"
     }
   ],
   "steps": [
@@ -59,5 +65,13 @@
     "cognitive_security": "Receipts at each boundary prevent narrative drift"
   },
   "status": "provisional",
-  "notes": "Architectural synthesis only. No authority upgrade. No policy weight."
+  "notes": "Architectural synthesis only. No authority upgrade. No policy weight.",
+  "hash_protocol": {
+    "algorithm": "SHA-256",
+    "basis": "raw_arxiv_pdf_bytes",
+    "normalization": "NONE",
+    "verification_method": "local_sha256sum",
+    "status": "pending_local_recompute",
+    "authority": false
+  }
 }


### PR DESCRIPTION
## Summary

Updates `receipts/drafts/receipt_chain_v0_1.json` so existing source hashes are explicitly marked as pending local recompute.

## Constitutional Drift Classification

- [ ] AUTHORITY_DRIFT
- [ ] ANCHOR_DRIFT
- [ ] SECURITY_DRIFT
- [x] NONE

## Required Boundary Checks

- [x] One file only: `receipts/drafts/receipt_chain_v0_1.json`
- [x] No runtime code
- [x] No schema changes
- [x] No authority upgrade
- [x] No policy weight
- [x] No hash verification claim

## Receipt / Evidence

- Branch: `fix/receipt-chain-hash-status-v0-1`
- Commit: `d30109deddba906db33d5318d4164390a0f64e12`
- Changed files: `1`
- File: `receipts/drafts/receipt_chain_v0_1.json`
- Hash status: `pending_local_recompute`
- Authority: `false`

## Rollback / Revocation Path

Close this PR without merge, or revert the merge commit if accepted incorrectly.

This PR preserves replay, lineage, and bounded authority.