### PR TITLE
Fix receipt chain local hash mismatch v0.1

### DIFF
--- a/receipts/drafts/receipt_chain_v0_1.json
+++ b/receipts/drafts/receipt_chain_v0_1.json
@@ -12,7 +12,9 @@
       "verification": "assistant_observed_source_and_claims",
       "hash_algorithm": "SHA-256",
       "hash_basis": "raw_arxiv_pdf_bytes",
-      "hash_status": "pending_local_recompute"
+      "hash_status": "local_recompute_mismatch",
+      "local_recompute_sha256": "4a0d94decd7e1a5699a63e09b345ee5dc4446a030f9ecf386ea5cbb6ed001355",
+      "hash_verified": false
     },
     {
       "artifact_id": "joy://2026-05-29/arxiv-2605.01574-001",
@@ -22,7 +24,9 @@
       "verification": "assistant_verified_abstract",
       "hash_algorithm": "SHA-256",
       "hash_basis": "raw_arxiv_pdf_bytes",
-      "hash_status": "pending_local_recompute"
+      "hash_status": "local_recompute_mismatch",
+      "local_recompute_sha256": "4cd272864f1cffbdd5b86c695f65e9b8f185e4c56bc9020fb26f56d805566d6e",
+      "hash_verified": false
     }
   ],
   "steps": [
@@ -71,7 +75,9 @@
     "basis": "raw_arxiv_pdf_bytes",
     "normalization": "NONE",
     "verification_method": "local_sha256sum",
-    "status": "pending_local_recompute",
-    "authority": false
+    "status": "local_recompute_mismatch",
+    "authority": false,
+    "mismatch_policy": "preserve_recorded_hashes_and_record_local_recompute",
+    "verified": false
   }
 }


### PR DESCRIPTION
## Summary

Records local SHA-256 recompute mismatch for the two arXiv PDF sources in `receipts/drafts/receipt_chain_v0_1.json`.

## Constitutional Drift Classification

- [ ] AUTHORITY_DRIFT
- [ ] ANCHOR_DRIFT
- [ ] SECURITY_DRIFT
- [x] NONE

## Required Boundary Checks

- [x] One file only: `receipts/drafts/receipt_chain_v0_1.json`
- [x] No runtime code
- [x] No schema changes
- [x] No authority upgrade
- [x] No policy weight
- [x] No hash verification claim

## Receipt / Evidence

- Branch: `fix/receipt-chain-hash-mismatch-v0-1`
- Commit: `7f4212f`
- Changed files: `1`
- File: `receipts/drafts/receipt_chain_v0_1.json`
- Hash status: `local_recompute_mismatch`
- Verified: `false`
- Authority: `false`

Local recompute outputs:

```text
4a0d94decd7e1a5699a63e09b345ee5dc4446a030f9ecf386ea5cbb6ed001355  2605.23138v1.pdf
4cd272864f1cffbdd5b86c695f65e9b8f185e4c56bc9020fb26f56d805566d6e  2605.01574v1.pdf
```

## Rollback / Revocation Path

Close this PR without merge, or revert the merge commit if accepted incorrectly.

This PR preserves replay, lineage, and bounded authority.