### PR TITLE
Goblin Court Jurisdiction v0.1

### DIFF
--- a/_truth/goblin_court/docket.jsonl
+++ b/_truth/goblin_court/docket.jsonl
@@ -1,0 +1,1 @@
+{"artifact":"GOBLIN_COURT_JURISDICTION_V0_1","case_id":"GIRTH-001","status":"RECEIPT_BOUND","authority":false,"membrane_state":"HOLDS","runtime_parity":"PENDING","drift":0}


### PR DESCRIPTION
Creates Goblin Court jurisdiction surface.

## Constitutional Drift Classification

- [x] NO_DRIFT
- [ ] AUTHORITY_DRIFT
- [ ] ANCHOR_DRIFT
- [ ] SECURITY_DRIFT

**drift_classification:** ZERO
**authority:** false
**membrane_state:** HOLDS

## Required Boundary Checks

- [x] Authority remains false
- [x] No observer authority transfer

Observer Authority Transfer: ABSENT

## Receipt / Evidence

- Added _truth/goblin_court/docket.jsonl

## Rollback / Revocation Path

Revert PR and remove added file.

This PR preserves replay, lineage, and bounded authority.