### PR TITLE
Add Clown Court docket

### DIFF
--- a/_truth/clown_court/docket.jsonl
+++ b/_truth/clown_court/docket.jsonl
@@ -1,0 +1,1 @@
+{"artifact":"CLOWN_COURT_JURISDICTION_V0_1","case_id":"CLOWN-001","status":"INITIAL_DOCKET_SURFACE","authority":false,"membrane_state":"HOLDS","runtime_parity":"PENDING","drift":0}


### PR DESCRIPTION
# COMPUTERWISDOM Pull Request

## Summary

Adds the initial Clown Court docket surface as a repository-local jurisdiction artifact.

## Constitutional Drift Classification

Select one or more:

- [x] NO_DRIFT
- [x] DOCS_ONLY_DRIFT
- [ ] OPERATIONAL_DRIFT
- [ ] SECURITY_DRIFT
- [ ] AUTHORITY_DRIFT
- [ ] ANCHOR_DRIFT

**drift_classification:** ZERO
**authority:** false
**membrane_state:** HOLDS

## Required Boundary Checks

- [x] Anchor Boundary Preserved
- [x] Security Boundary Preserved
- [x] Layer Law Preserved
- [x] Observer Authority Transfer: NONE
- [x] No Ghost Anchors Introduced
- [x] No Production Claims Without Receipts
- [x] Generated Outputs Classified As Evidence, Not Truth By Themselves

Observer Authority Transfer: ABSENT

## Receipt / Evidence

```text
Receipt Evidence:
- Added _truth/clown_court/docket.jsonl
- Branch: feature/clown-court-jurisdiction-v0-1
- Head SHA: a812a608278c1ed08b22baceb2d15b993198ca18
- Changed files: 1
```

## Constitutional Amendment Required?

- [x] NO
- [ ] YES

This PR does not change repo purpose, authority boundaries, anchor status, security posture, or observer roles.

## Rollback / Revocation Path

```text
Rollback Path:
Revert PR #58 and remove _truth/clown_court/docket.jsonl.
No external anchor, authority state, production claim, or runtime parity claim is affected.
```

## Closing Assertion

- [x] This PR preserves replay, lineage, and bounded authority.
