### PR TITLE
Add court artifact hash recompute gate v0.1

### DIFF
--- a/scripts/recompute_court_artifact_hashes.sh
+++ b/scripts/recompute_court_artifact_hashes.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+find . -type f | grep -Ei 'meme|goblin|clown|court' | sort > court_artifacts.txt
+while read -r f; do sha256sum "$f"; done < court_artifacts.txt > court_artifact_hashes.txt
+cat court_artifact_hashes.txt


### PR DESCRIPTION
Adds a read-only helper script for court artifact SHA-256 recomputation. Authority remains false. Runtime parity remains pending. No witness claims.