### PR TITLE
Add Computer Wisdom epistemic stack v0.1

### DIFF
--- a/docs/COMPUTERWISDOM_EPISTEMIC_STACK_V0_1.md
+++ b/docs/COMPUTERWISDOM_EPISTEMIC_STACK_V0_1.md
@@ -1,0 +1,300 @@
+# COMPUTERWISDOM_EPISTEMIC_STACK_V0_1
+
+**Purpose:** Unified architectural synthesis of issues #73-76  
+**Version:** 0.1  
+**Authority:** false  
+**Runtime:** false  
+**Base Binding:** false  
+**MCP Binding:** false  
+
+## Core Thesis
+
+Computer Wisdom is a conservation-oriented epistemic membrane for digital commerce, governance, and public-history learning.
+
+It treats information as energy, receipts as measurement events, and validation as error-correction inside a complex adaptive system.
+
+Receipts do not create truth. They preserve reconstructable state under bounded drift.
+
+## 1. Admissions Structure
+
+The admissions structure controls what may enter the system and at what epistemic level.
+
+| Level | Description | Proof Required | Verification Required | Transition Record Required |
+|---|---|---:|---:|---:|
+| OBSERVATION | Raw sighting or report | No | No | No |
+| CLAIM | Assertion about reality | No | No | No |
+| RECEIPT | Claim with attached evidence | Yes | No | Yes |
+| VERIFIED_RECEIPT | Receipt independently validated | Yes | Yes | Yes |
+| DECISION | Action taken based on verified evidence | Contextual | Contextual | Yes |
+| ARCHIVE | Historical record preserved for replay | Contextual | Contextual | Yes |
+
+Core invariant:
+
+```json
+{
+  "invariant": "NO_SILENT_CATEGORY_PROMOTION",
+  "rule": "No object may advance levels without explicit evidence and a traceable transition receipt.",
+  "authority": false
+}
+```
+
+## 2. Conservation Laws
+
+```json
+{
+  "conservation_laws": [
+    {
+      "name": "provenance_conservation",
+      "rule": "Every receipt must preserve who originated, transferred, or modified value-state."
+    },
+    {
+      "name": "lineage_conservation",
+      "rule": "Every derived receipt must reference its parent or original receipt."
+    },
+    {
+      "name": "causal_order_conservation",
+      "rule": "Timestamps must not permit impossible state transitions."
+    },
+    {
+      "name": "value_conservation",
+      "rule": "Splits, refunds, and transfers must not create unexplained value."
+    },
+    {
+      "name": "authority_conservation",
+      "rule": "No receipt may upgrade itself into authority."
+    }
+  ],
+  "authority": false
+}
+```
+
+Foundational principle:
+
+> Association is observable. Proof is admissible. Decisions are recorded. Authority is never inferred.
+
+## 3. Receipt Schema Layer
+
+The receipt schema layer separates structural validation from semantic enforcement.
+
+```json
+{
+  "structural_validation": "JSON Schema draft-07",
+  "semantic_validation": "invariant/application layer",
+  "runtime": false,
+  "authority": false
+}
+```
+
+Structural validation handles:
+
+- required fields,
+- types,
+- enums,
+- patterns,
+- authority false,
+- strict property boundaries.
+
+Semantic validation handles:
+
+- split math,
+- refund limits,
+- dispute lifecycle,
+- receipt uniqueness,
+- replay detection,
+- lineage and causal order.
+
+## 4. Data Parkour Agents
+
+Data Parkour Agents are epistemic movement agents. They move data between categories without granting authority.
+
+```json
+{
+  "agents": [
+    "ObservationIngressAgent",
+    "ClaimFormationAgent",
+    "EvidenceAttachmentAgent",
+    "IndependentCheckAgent",
+    "DecisionRecordAgent",
+    "DriftBoundaryAgent",
+    "ArchiveReplayAgent"
+  ],
+  "authority": false
+}
+```
+
+Their job is not to decide truth. Their job is to preserve category boundaries while information moves.
+
+## 5. Transition Receipts
+
+Every movement between admission levels must leave a transition receipt.
+
+```json
+{
+  "transition_id": "string",
+  "from_level": "OBSERVATION|CLAIM|RECEIPT|VERIFIED_RECEIPT|DECISION|ARCHIVE",
+  "to_level": "OBSERVATION|CLAIM|RECEIPT|VERIFIED_RECEIPT|DECISION|ARCHIVE",
+  "agent": "string",
+  "basis": "string",
+  "evidence_refs": [],
+  "timestamp": "date-time",
+  "authority": false
+}
+```
+
+Forbidden transitions:
+
+```json
+[
+  "OBSERVATION_TO_VERIFIED_RECEIPT",
+  "CLAIM_TO_DECISION",
+  "RECEIPT_TO_DECISION_WITHOUT_VERIFICATION",
+  "ARCHIVE_MUTATION_WITHOUT_TRANSITION_RECEIPT",
+  "ANY_TO_AUTHORITY_TRUE"
+]
+```
+
+## 6. Mirroring Governance
+
+External institutional names may appear only as mirrored observer surfaces or public-source references.
+
+```json
+{
+  "NSA": "MIRRORED_OBSERVER_SURFACE_ONLY",
+  "DOJ": "MIRRORED_OBSERVER_SURFACE_ONLY",
+  "CIA": "MIRRORED_OBSERVER_SURFACE_ONLY",
+  "FBI": "MIRRORED_OBSERVER_SURFACE_ONLY",
+  "agency_participation_claimed": false,
+  "authority": false
+}
+```
+
+## 7. Minor-Safe Default Rule
+
+```json
+{
+  "rule": "EVERYBODY_IS_13_V0_1",
+  "literal_age_claim": false,
+  "meaning": "Default to protected, minor-safe, non-exploitative handling posture.",
+  "authority": false
+}
+```
+
+Lock phrase:
+
+> Everybody gets protected before anybody gets categorized.
+
+## 8. ACTNOW67 Training Layer
+
+ACTNOW67 is a fictional, minor-safe, public-civics training mnemonic.
+
+```json
+{
+  "A": "Admit the data at the lowest safe category",
+  "C": "Classify without escalating",
+  "T": "Tag evidence references",
+  "N": "Never silently promote",
+  "O": "Observe drift and entropy",
+  "W": "Write transition receipts",
+  "67": "6 checks plus 7th review gate",
+  "authority": false
+}
+```
+
+## 9. Public History Flywheel
+
+Public history becomes replayable when learners can move through events like a game map.
+
+```json
+{
+  "loop": [
+    "PUBLIC_SOURCE_DISCOVERY",
+    "OBSERVATION_CAPTURE",
+    "CLAIM_CLASSIFICATION",
+    "RECEIPT_ATTACHMENT",
+    "CONTEXT_MAPPING",
+    "DRIFT_CHECK",
+    "TIMELINE_REPLAY",
+    "CIVIC_LESSON_UNLOCK"
+  ],
+  "authority": false
+}
+```
+
+Boundary:
+
+```json
+{
+  "public_sources_only": true,
+  "real_world_tradecraft": false,
+  "surveillance_guidance": false,
+  "agency_impersonation": false,
+  "authority": false
+}
+```
+
+## 10. Architecture Flow
+
+```text
+Raw World Events
+        ↓
+Admissions Membrane
+        ↓
+OBSERVATION / CLAIM
+        ↓
+Proof Attached?
+        ↓
+RECEIPT
+        ↓
+Independent Verification?
+        ↓
+VERIFIED_RECEIPT
+        ↓
+DECISION
+        ↓
+ARCHIVE / REPLAY
+```
+
+Supporting layers:
+
+```text
+Conservation Laws
+        ↓
+Admissions Structure
+        ↓
+Data Parkour Agents
+        ↓
+Transition Receipts
+        ↓
+Receipt Schema + Invariants
+        ↓
+Training + Public History Flywheel
+```
+
+## 11. Current Design Posture
+
+```json
+{
+  "conceptual_stack": true,
+  "schema_design": true,
+  "fixtures_required": true,
+  "validator_required": true,
+  "runtime_implementation": false,
+  "base_binding": false,
+  "mcp_binding": false,
+  "authority": false
+}
+```
+
+## 12. Next Boundary
+
+The next real proof boundary is not another concept. It is evidence-driven implementation sequencing:
+
+1. Load raw fixtures.
+2. Run fixture migration audit.
+3. Produce validator design.
+4. Validate admissions transitions.
+5. Only then consider runtime replay testing.
+
+## Final Lock Phrase
+
+**Data may move fast. Authority may not.**


### PR DESCRIPTION
## Summary

Adds `docs/COMPUTERWISDOM_EPISTEMIC_STACK_V0_1.md`, a unified architectural synthesis of Issues #73-76.

## Scope

This PR documents:

- Admissions Structure
- Conservation Laws
- Receipt Schema Layer
- Data Parkour Agents
- Transition Receipts
- Mirroring Governance
- Minor-safe default rule
- ACTNOW67 training layer
- Public History Flywheel

## Boundary

```json
{
  "runtime_implementation": false,
  "base_binding": false,
  "mcp_binding": false,
  "authority": false
}
```

## Receipt

```json
{
  "artifact": "docs/COMPUTERWISDOM_EPISTEMIC_STACK_V0_1.md",
  "commit_sha": "d2f474163a7b21c70dec55980181cdf82c77f10d",
  "branch": "feature/epistemic-stack-v0-1",
  "authority": false
}
```

## Lock Phrase

Data may move fast. Authority may not.