### PR TITLE
Define GOBLIN_VERIFIER_V0_1 bounded transition checker

### DIFF
--- a/docs/goblin_verifier_v0_1.md
+++ b/docs/goblin_verifier_v0_1.md
@@ -1,0 +1,54 @@
+# GOBLIN_VERIFIER_V0_1
+
+Status: SPEC_FIRST  
+Issue: #82  
+Parent: #67  
+Authority: false  
+Membrane: HOLDS
+
+## Purpose
+
+`GOBLIN_VERIFIER_V0_1` defines a bounded transition checker for the Constitutional Game Stack v0.2.
+
+The verifier gates transitions. It does not adjudicate truth.
+
+## Allowed Outputs
+
+- `PASS_TO_EXISTENCE_CHECK`
+- `NEEDS_RECEIPT`
+- `GHOST_PROMOTION_BLOCKED`
+- `DUPLICATE_FOUND`
+- `DISPUTE_REQUIRED`
+- `INVALID_TRANSITION`
+
+## Core Invariant
+
+`NO_SILENT_CATEGORY_PROMOTION`
+
+The verifier must never upgrade observation, witness output, score, anchor, or agent action into verified truth or authority.
+
+## Boundary Rules
+
+- Observations may be surfaced.
+- Claims may be routed.
+- Missing receipts require `NEEDS_RECEIPT`.
+- Ghost promotion attempts require `GHOST_PROMOTION_BLOCKED`.
+- Invalid transitions require `INVALID_TRANSITION`.
+- Contradictions or unresolved conflicts require `DISPUTE_REQUIRED`.
+- Duplicate surfaces require `DUPLICATE_FOUND`.
+
+## Non-Goals
+
+- No runtime automation yet
+- No external witness calls
+- No scoring implementation
+- No wallet signing
+- No Base anchoring
+- No ENS changes
+- No social-credit surface
+- No truth-finality claim
+- No autonomous merge authority
+
+## Closing Rule
+
+Goblin Verifier gates transitions only. Humans merge. Authority remains false.

--- a/schemas/goblin_verifier.v0_1.schema.json
+++ b/schemas/goblin_verifier.v0_1.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schemas/goblin_verifier.v0_1.schema.json",
+  "title": "Goblin Verifier v0.1",
+  "description": "Bounded transition checker for Constitutional Game Stack v0.2. Gates transitions only. Does not adjudicate truth or grant authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "authority",
+    "input_ref",
+    "requested_transition",
+    "verifier_output",
+    "invariant"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "v0.1"
+    },
+    "authority": {
+      "type": "boolean",
+      "const": false
+    },
+    "input_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "requested_transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from_state", "to_state"],
+      "properties": {
+        "from_state": { "type": "string", "minLength": 1 },
+        "to_state": { "type": "string", "minLength": 1 }
+      }
+    },
+    "verifier_output": {
+      "type": "string",
+      "enum": [
+        "PASS_TO_EXISTENCE_CHECK",
+        "NEEDS_RECEIPT",
+        "GHOST_PROMOTION_BLOCKED",
+        "DUPLICATE_FOUND",
+        "DISPUTE_REQUIRED",
+        "INVALID_TRANSITION"
+      ]
+    },
+    "invariant": {
+      "type": "string",
+      "const": "NO_SILENT_CATEGORY_PROMOTION"
+    }
+  }
+}

--- a/tests/test_goblin_verifier_v0_1.py
+++ b/tests/test_goblin_verifier_v0_1.py
@@ -1,0 +1,29 @@
+VALID_OUTPUTS = {
+    'PASS_TO_EXISTENCE_CHECK',
+    'NEEDS_RECEIPT',
+    'GHOST_PROMOTION_BLOCKED',
+    'DUPLICATE_FOUND',
+    'DISPUTE_REQUIRED',
+    'INVALID_TRANSITION'
+}
+
+
+def verifier_output_allowed(output):
+    return output in VALID_OUTPUTS
+
+
+def test_allowed_output_passes():
+    assert verifier_output_allowed('PASS_TO_EXISTENCE_CHECK') is True
+
+
+def test_ghost_promotion_blocked_exists():
+    assert verifier_output_allowed('GHOST_PROMOTION_BLOCKED') is True
+
+
+def test_invalid_output_fails():
+    assert verifier_output_allowed('TRUTH_FINALITY') is False
+
+
+def test_authority_remains_false():
+    authority = False
+    assert authority is False


### PR DESCRIPTION
Closes #82

Artifacts:
- schemas/goblin_verifier.v0_1.schema.json
- docs/goblin_verifier_v0_1.md
- tests/test_goblin_verifier_v0_1.py

Authority: false
Membrane: HOLDS
Mode: SPEC_FIRST

Goblin Verifier gates transitions only. It does not adjudicate truth.