### PR TITLE
Define REPLAY_SCORE_RECEIPT_V0_1 schema

### DIFF
--- a/docs/replay_score_receipt_v0_1.md
+++ b/docs/replay_score_receipt_v0_1.md
@@ -1,0 +1,50 @@
+# REPLAY_SCORE_RECEIPT_V0_1
+
+Status: SCHEMA_FIRST  
+Issue: #84  
+Parent: #67  
+Authority: false  
+Membrane: HOLDS
+
+## Purpose
+
+`REPLAY_SCORE_RECEIPT_V0_1` records bounded scores for replay behavior and receipt quality.
+
+It scores artifacts, agent behavior, and replay discipline only. It does not score human worth, legal guilt, creditworthiness, employment suitability, truth finality, or merge authority.
+
+## Allowed Score Dimensions
+
+- `replayability`
+- `receipt_integrity`
+- `agent_discipline`
+- `dispute_quality`
+- `base_anchor_hygiene`
+
+## Required Fields
+
+- `score_receipt_id`
+- `agent_or_player_id`
+- `claim_or_artifact_ref`
+- `score_dimension`
+- `verdict`
+- `supporting_receipts`
+- `authority: false`
+- `timestamp_utc`
+
+## Core Rule
+
+Score is evidence about replay quality. Score is not authority.
+
+## Forbidden Promotions
+
+- Score to truth
+- Score to legal conclusion
+- Score to human worth
+- Score to creditworthiness
+- Score to employment suitability
+- Score to merge authority
+- Score to autonomous execution right
+
+## Closing Rule
+
+Receipts replay. Scores contextualize. Humans merge. Authority remains false.

--- a/schemas/replay_score_receipt.v0_1.schema.json
+++ b/schemas/replay_score_receipt.v0_1.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schemas/replay_score_receipt.v0_1.schema.json",
+  "title": "Replay Score Receipt v0.1",
+  "description": "Bounded receipt schema for scoring replay behavior and receipt quality only. Scores do not grant truth, authority, merge rights, legal status, or human worth.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "score_receipt_id",
+    "agent_or_player_id",
+    "claim_or_artifact_ref",
+    "score_dimension",
+    "verdict",
+    "supporting_receipts",
+    "authority",
+    "timestamp_utc"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "v0.1" },
+    "score_receipt_id": { "type": "string", "minLength": 1 },
+    "agent_or_player_id": { "type": "string", "minLength": 1 },
+    "claim_or_artifact_ref": { "type": "string", "minLength": 1 },
+    "score_dimension": {
+      "type": "string",
+      "enum": [
+        "replayability",
+        "receipt_integrity",
+        "agent_discipline",
+        "dispute_quality",
+        "base_anchor_hygiene"
+      ]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["PASS", "NEEDS_RECEIPT", "DISPUTED", "FAIL"]
+    },
+    "supporting_receipts": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "authority": { "type": "boolean", "const": false },
+    "timestamp_utc": { "type": "string", "format": "date-time" }
+  }
+}

--- a/tests/test_replay_score_receipt_v0_1.py
+++ b/tests/test_replay_score_receipt_v0_1.py
@@ -1,0 +1,38 @@
+VALID_DIMENSIONS = {
+    'replayability',
+    'receipt_integrity',
+    'agent_discipline',
+    'dispute_quality',
+    'base_anchor_hygiene'
+}
+
+FORBIDDEN_DIMENSIONS = {
+    'human_worth',
+    'legal_guilt',
+    'creditworthiness',
+    'employment_suitability',
+    'truth_finality',
+    'merge_authority'
+}
+
+
+def dimension_allowed(value):
+    return value in VALID_DIMENSIONS
+
+
+def test_valid_dimension_passes():
+    assert dimension_allowed('replayability') is True
+
+
+def test_forbidden_dimension_fails():
+    assert dimension_allowed('truth_finality') is False
+
+
+def test_supporting_receipts_required_fixture():
+    supporting_receipts = ['receipt_001']
+    assert len(supporting_receipts) > 0
+
+
+def test_authority_remains_false():
+    authority = False
+    assert authority is False


### PR DESCRIPTION
Closes #84

Artifacts:
- schemas/replay_score_receipt.v0_1.schema.json
- docs/replay_score_receipt_v0_1.md
- tests/test_replay_score_receipt_v0_1.py

Authority: false
Membrane: HOLDS
Mode: SCHEMA_FIRST

Scores contextualize replay quality only. Scores do not grant authority, truth, legal conclusions, or merge rights.