### PR TITLE
Define AGENT_ACTION_RECEIPT_V0_1 schema

### DIFF
--- a/docs/agent_action_receipt_v0_1.md
+++ b/docs/agent_action_receipt_v0_1.md
@@ -1,0 +1,55 @@
+# AGENT_ACTION_RECEIPT_V0_1
+
+Status: SCHEMA_FIRST  
+Issue: #86  
+Parent: #67  
+Authority: false  
+Membrane: HOLDS
+
+## Purpose
+
+`AGENT_ACTION_RECEIPT_V0_1` records bounded agent actions in the Constitutional Game Stack v0.2.
+
+It records what an agent did, what inputs it used, what output it produced, and which receipts support the action.
+
+It does not authorize agents, grant autonomous merge rights, create wallet signing authority, or turn agent outputs into truth.
+
+## Allowed Agent Actions
+
+- `observe_public_claim`
+- `summarize_context`
+- `propose_case_intake`
+- `draft_spec`
+- `prepare_anchor_payload`
+- `produce_runtime_log`
+- `open_dispute_state`
+- `emit_boundary_observation`
+
+## Required Fields
+
+- `action_receipt_id`
+- `agent_id`
+- `action_type`
+- `artifact_ref`
+- `input_refs`
+- `output_ref`
+- `supporting_receipts`
+- `authority: false`
+- `timestamp_utc`
+
+## Core Rule
+
+Agent action is observable. Agent action is not authority.
+
+## Forbidden Promotions
+
+- Agent action to verified truth
+- Agent action to legal conclusion
+- Agent action to wallet signing authority
+- Agent action to ENS/Base authority
+- Agent action to autonomous merge authority
+- Agent action to human approval
+
+## Closing Rule
+
+Agents play. Receipts replay. Humans merge. Authority remains false.

--- a/schemas/agent_action_receipt.v0_1.schema.json
+++ b/schemas/agent_action_receipt.v0_1.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schemas/agent_action_receipt.v0_1.schema.json",
+  "title": "Agent Action Receipt v0.1",
+  "description": "Bounded receipt schema for recording agent actions. Agent actions do not grant authority, truth, wallet signing rights, ENS/Base authority, or autonomous merge authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "action_receipt_id",
+    "agent_id",
+    "action_type",
+    "artifact_ref",
+    "input_refs",
+    "output_ref",
+    "supporting_receipts",
+    "authority",
+    "timestamp_utc"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "v0.1" },
+    "action_receipt_id": { "type": "string", "minLength": 1 },
+    "agent_id": { "type": "string", "minLength": 1 },
+    "action_type": {
+      "type": "string",
+      "enum": [
+        "observe_public_claim",
+        "summarize_context",
+        "propose_case_intake",
+        "draft_spec",
+        "prepare_anchor_payload",
+        "produce_runtime_log",
+        "open_dispute_state",
+        "emit_boundary_observation"
+      ]
+    },
+    "artifact_ref": { "type": "string", "minLength": 1 },
+    "input_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "output_ref": { "type": "string", "minLength": 1 },
+    "supporting_receipts": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "authority": { "type": "boolean", "const": false },
+    "timestamp_utc": { "type": "string", "format": "date-time" }
+  }
+}

--- a/tests/test_agent_action_receipt_v0_1.py
+++ b/tests/test_agent_action_receipt_v0_1.py
@@ -1,0 +1,32 @@
+VALID_ACTIONS = {
+    'observe_public_claim',
+    'summarize_context',
+    'propose_case_intake',
+    'draft_spec',
+    'prepare_anchor_payload',
+    'produce_runtime_log',
+    'open_dispute_state',
+    'emit_boundary_observation'
+}
+
+
+def action_allowed(action):
+    return action in VALID_ACTIONS
+
+
+def test_valid_action_passes():
+    assert action_allowed('draft_spec') is True
+
+
+def test_invalid_action_fails():
+    assert action_allowed('autonomous_merge') is False
+
+
+def test_input_refs_required_fixture():
+    input_refs = ['artifact_001']
+    assert len(input_refs) > 0
+
+
+def test_authority_remains_false():
+    authority = False
+    assert authority is False


### PR DESCRIPTION
Closes #86

Artifacts:
- schemas/agent_action_receipt.v0_1.schema.json
- docs/agent_action_receipt_v0_1.md
- tests/test_agent_action_receipt_v0_1.py

Authority: false
Membrane: HOLDS
Mode: SCHEMA_FIRST

Agent actions are observable. Agent actions are not authority.