### PR TITLE
feat: add Matrix Jay Canon Receipt Registry V0.1 scaffold

### DIFF
--- a/contracts/CanonReceiptRegistryV0_1.sol
+++ b/contracts/CanonReceiptRegistryV0_1.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+import "./interfaces/ICanonReceiptRegistryV0_1.sol";
+
+/// @title CanonReceiptRegistryV0_1
+/// @notice V0_1 SCAFFOLD ONLY. Non-cryptographically bound evidence registry.
+/// @dev Per Deprecation Notice: actor must be msg.sender. No EIP-712. Authority false.
+/// Records append-only witness events and overlay signals. Replay is the judge.
+contract CanonReceiptRegistryV0_1 is ICanonReceiptRegistryV0_1 {
+    bytes32 public override genesisCommit;
+    bool public override genesisSet;
+
+    mapping(bytes32 => bool) private _receiptExists;
+    mapping(bytes32 => address) private _receiptActor;
+    mapping(bytes32 => CanonSignal) private _signalOverlay;
+    mapping(bytes32 => string) private _signalReason;
+    uint256 public override receiptCount;
+
+    mapping(bytes32 => bool) private _blockedTruth;
+
+    constructor() {
+        _blockedTruth[keccak256("VERIFIED")] = true;
+        _blockedTruth[keccak256("FALSE")] = true;
+        _blockedTruth[keccak256("FRAUD")] = true;
+        _blockedTruth[keccak256("ADJUDICATED")] = true;
+    }
+
+    function setGenesis(bytes32 initialCommit) external override {
+        require(!genesisSet, "Genesis: locked_once");
+        require(initialCommit!= bytes32(0), "Genesis: zero commit");
+        genesisCommit = initialCommit;
+        genesisSet = true;
+        emit GenesisLocked(initialCommit, msg.sender);
+    }
+
+    function anchorReceipt(Receipt calldata r) external override returns (bytes32 receiptHash) {
+        require(genesisSet, "Genesis required");
+        if (receiptCount == 0) require(r.mergeCommit == genesisCommit, "First receipt must match genesis");
+        require(bytes(r.al).length!= 0, "AL missing");
+        require(bytes(r.joy).length!= 0, "JOY missing");
+        require(keccak256(bytes(r.computerWisdom)) == keccak256("APPEND_ONLY"), "CW must be APPEND_ONLY");
+        require(!_blockedTruth[keccak256(bytes(r.status))], "BlockedTruth");
+        require(r.actor == msg.sender, "V0_1: actor must be msg.sender");
+
+        receiptHash = keccak256(abi.encode(
+            r.actor,
+            r.actionType,
+            r.evidenceHash,
+            r.al,
+            r.joy,
+            r.computerWisdom,
+            r.proofRef,
+            r.mergeCommit,
+            r.status
+        ));
+        require(!_receiptExists[receiptHash], "Append_only: exists");
+
+        _receiptExists[receiptHash] = true;
+        _receiptActor[receiptHash] = r.actor;
+        receiptCount++;
+
+        emit ReceiptAnchored(receiptHash, r.actor, r.mergeCommit, r.proofRef, r.actionType, r.status);
+    }
+
+    function emitCanonSignal(bytes32 targetReceipt, CanonSignal signal, string calldata reasonRef) external override {
+        require(_receiptExists[targetReceipt], "Target!exists");
+        _signalOverlay[targetReceipt] = signal;
+        _signalReason[targetReceipt] = reasonRef;
+        emit CanonSignalEmitted(targetReceipt, signal, reasonRef, msg.sender);
+    }
+
+    function receiptExists(bytes32 receiptHash) external view override returns (bool) {
+        return _receiptExists[receiptHash];
+    }
+
+    function receiptActor(bytes32 receiptHash) external view override returns (address) {
+        return _receiptActor[receiptHash];
+    }
+
+    function getSignal(bytes32 targetReceipt) external view returns (CanonSignal, string memory) {
+        return (_signalOverlay[targetReceipt], _signalReason[targetReceipt]);
+    }
+}

--- a/contracts/interfaces/ICanonReceiptRegistryV0_1.sol
+++ b/contracts/interfaces/ICanonReceiptRegistryV0_1.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface ICanonReceiptRegistryV0_1 {
+    event ReceiptAnchored(
+        bytes32 indexed receiptId,
+        address indexed submitter,
+        string actionType,
+        string al,
+        string joy,
+        string computerWisdom,
+        uint256 timestamp
+    );
+
+    event CanonSignalEmitted(
+        bytes32 indexed receiptId,
+        address indexed submitter,
+        string signalType,
+        string payload,
+        uint256 timestamp
+    );
+
+    function setGenesis(bytes32 genesisReceiptId) external;
+
+    function getGenesis() external view returns (bytes32);
+
+    function anchorReceipt(
+        bytes32 receiptId,
+        string calldata actionType,
+        string calldata al,
+        string calldata joy,
+        string calldata computerWisdom
+    ) external;
+
+    function emitCanonSignal(
+        bytes32 receiptId,
+        string calldata signalType,
+        string calldata payload
+    ) external;
+}

--- a/docs/matrix_jay/canon_receipt_registry_v0_1.md
+++ b/docs/matrix_jay/canon_receipt_registry_v0_1.md
@@ -1,0 +1,49 @@
+# Matrix Jay Canon Receipt Registry V0_1
+
+## Doctrine
+Receipts are the source. Signals are the overlay. Replay is the judge.
+
+## V0_1 Deprecation and Migration Protocol
+NOTICE: V0_1 IS SCAFFOLD ONLY.
+
+CanonReceiptRegistryV0_1 is a non-cryptographically bound evidence registry.
+It records append-only witness events and overlay signals.
+
+Identity Status: DEFERRED.
+No EIP-712 signature verification is implemented.
+V0_1 requires msg.sender == receipt.actor for audit trail only.
+
+Security Warning:
+V0_1 events are unverified witness data. Indexers must not treat submitter
+identity as protocol-authenticated. The `actor` field reflects the transaction
+sender, not a cryptographic proof of intent.
+
+Migration Goal:
+V0_2 supersedes V0_1 with anchorSignedReceipt(...) and EIP-712 typed-data
+signature recovery for non-repudiable Canon receipts.
+
+V0_1 remains valid as historical evidence, not identity-bound proof.
+Authority remains false.
+
+## Invariants
+- I1: Append-only. No receipt deletion or mutation. Only new receipts via anchorReceipt.
+- I2: Trinity before verdict. AL!=NONE, JOY!=NONE, CW==APPEND_ONLY required.
+- I3: Authority false. No authority flips in V0_1. All receipts observer-only.
+- I4: Verdicts blocked. Status VERIFIED, FALSE, FRAUD, ADJUDICATED revert on anchor.
+- I5: Genesis locked_once. setGenesis required before anchoring. First receipt must match genesis.
+
+## Repo Precedent Compliance
+- AL #147: Schema-first. V0_1 freezes receipt format before chains.
+- COMPUTERWISDOM #31: Disputes as overlays. CanonSignal does not mutate receipts.
+- COMPUTERWISDOM #40: No bypass. No receipt, no gate pass, no action. All actions emit events.
+- COMPUTERWISDOM #29: Observer-only. Authority false. Evidence-only. No conclusions.
+
+## Usage
+1. Deploy CanonReceiptRegistryV0_1
+2. Call setGenesis(0x0b58518ad17b73252be9a5fbfef7d74d8dc57254)
+3. Actors call anchorReceipt with msg.sender == receipt.actor
+4. Any address may call emitCanonSignal on existing receipts
+5. Off-chain replay indexes ReceiptAnchored + CanonSignalEmitted events
+
+## Membrane
+HOLDS. Observer-only posture. Evidence, never conclusions. No identity binding.

--- a/fixtures/pr_170_genesis_receipt_v0_1.json
+++ b/fixtures/pr_170_genesis_receipt_v0_1.json
@@ -1,0 +1,16 @@
+{
+  "version": "CanonReceiptV0_1",
+  "receiptId": "0x0b58518ad17b73252be9a5fbfef7d74d8dc57254",
+  "actor": "0x0000000000000000000000000000000000000000",
+  "actionType": "GENESIS_EXECUTION_PROOF",
+  "evidenceHash": "0x0000000000000000000000000000000000000000000000000000",
+  "evidenceURI": "ipfs://bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354",
+  "al": "PROTECT",
+  "joy": "WITNESS",
+  "computerWisdom": "APPEND_ONLY",
+  "proofRef": "PR_170",
+  "mergeCommit": "0x0b58518ad17b73252be9a5fbfef7d74d8dc57254",
+  "status": "MERGED_REPLAYED_CLOSED",
+  "timestamp": 1730419200,
+  "note": "V0_1_SCAFFOLD_ONLY_NO_SIGNATURE"
+}

--- a/script/BootstrapPR170GenesisV0_1.s.sol
+++ b/script/BootstrapPR170GenesisV0_1.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+import "forge-std/Script.sol";
+import "../contracts/CanonReceiptRegistryV0_1.sol";
+
+/// @notice Bootstrap script for V0_1. Sets genesis only. No signed receipt in V0_1.
+/// @dev Per Deprecation Notice: V0_1 is scaffold only. Run after deployment.
+contract BootstrapPR170GenesisV0_1 is Script {
+    bytes32 constant GENESIS_COMMIT = 0x0b58518ad17b73252be9a5fbfef7d74d8dc57254;
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        CanonReceiptRegistryV0_1 registry = new CanonReceiptRegistryV0_1();
+        registry.setGenesis(GENESIS_COMMIT);
+
+        vm.stopBroadcast();
+
+        console.log("CanonReceiptRegistryV0_1 deployed at:", address(registry));
+        console.log("Genesis locked to:", vm.toString(GENESIS_COMMIT));
+    }
+}

--- a/test/CanonReceiptRegistryV0_1.t.sol
+++ b/test/CanonReceiptRegistryV0_1.t.sol
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+import "forge-std/Test.sol";
+import "../contracts/CanonReceiptRegistryV0_1.sol";
+import "../contracts/interfaces/ICanonReceiptRegistryV0_1.sol";
+
+contract CanonReceiptRegistryV0_1Test is Test {
+    CanonReceiptRegistryV0_1 registry;
+    address deployer = address(0xA11CE);
+    address actor1 = address(0xB0B);
+    address actor2 = address(0xCAFE);
+    bytes32 constant GENESIS_COMMIT = 0x0b58518ad17b73252be9a5fbfef7d74d8dc57254;
+
+    event GenesisLocked(bytes32 indexed genesisCommit, address indexed operator);
+    event ReceiptAnchored(
+        bytes32 indexed receiptHash,
+        address indexed actor,
+        bytes32 indexed mergeCommit,
+        string proofRef,
+        string actionType,
+        string status
+    );
+    event CanonSignalEmitted(
+        bytes32 indexed targetReceipt,
+        ICanonReceiptRegistryV0_1.CanonSignal signal,
+        string reasonRef,
+        address indexed emitter
+    );
+
+    function setUp() public {
+        vm.prank(deployer);
+        registry = new CanonReceiptRegistryV0_1();
+    }
+
+    function _mkReceipt(address _actor, bytes32 _mergeCommit) internal pure returns (ICanonReceiptRegistryV0_1.Receipt memory) {
+        return ICanonReceiptRegistryV0_1.Receipt({
+            actor: _actor,
+            actionType: "PR_REPLAY",
+            evidenceHash: keccak256("ipfs://evidence"),
+            al: "PROTECT",
+            joy: "WITNESS",
+            computerWisdom: "APPEND_ONLY",
+            proofRef: "PR_170",
+            mergeCommit: _mergeCommit,
+            status: "MERGED_REPLAYED_CLOSED"
+        });
+    }
+
+    function test_anchor_before_genesis_reverts() public {
+        ICanonReceiptRegistryV0_1.Receipt memory r = _mkReceipt(actor1, GENESIS_COMMIT);
+        vm.prank(actor1);
+        vm.expectRevert("Genesis required");
+        registry.anchorReceipt(r);
+    }
+
+    function test_set_genesis_once_only() public {
+        vm.prank(deployer);
+        vm.expectEmit(true, true, false, true);
+        emit GenesisLocked(GENESIS_COMMIT, deployer);
+        registry.setGenesis(GENESIS_COMMIT);
+
+        assertTrue(registry.genesisSet());
+        assertEq(registry.genesisCommit(), GENESIS_COMMIT);
+
+        vm.prank(deployer);
+        vm.expectRevert("Genesis: locked_once");
+        registry.setGenesis(GENESIS_COMMIT);
+    }
+
+    function test_zero_genesis_reverts() public {
+        vm.prank(deployer);
+        vm.expectRevert("Genesis: zero commit");
+        registry.setGenesis(bytes32(0));
+    }
+
+    function test_anchor_receipt_after_genesis() public {
+        vm.prank(deployer);
+        registry.setGenesis(GENESIS_COMMIT);
+
+        ICanonReceiptRegistryV0_1.Receipt memory r = _mkReceipt(actor1, GENESIS_COMMIT);
+        vm.prank(actor1);
+        vm.expectEmit(true, true, true, true);
+        emit ReceiptAnchored(bytes32(0), actor1, GENESIS_COMMIT, "PR_170", "PR_REPLAY", "MERGED_REPLAYED_CLOSED");
+        bytes32 hash = registry.anchorReceipt(r);
+
+        assertTrue(registry.receiptExists(hash));
+        assertEq(registry.receiptActor(hash), actor1);
+        assertEq(registry.receiptCount(), 1);
+    }
+
+    function test_duplicate_receipt_reverts() public {
+        vm.prank(deployer);
+        registry.setGenesis(GENESIS_COMMIT);
+
+        ICanonReceiptRegistryV0_1.Receipt memory r = _mkReceipt(actor1, GENESIS_COMMIT);
+        vm.prank(actor1);
+        registry.anchorReceipt(r);
+
+        vm.prank(actor1);
+        vm.expectRevert("Append_only: exists");
+        registry.anchorReceipt(r);
+    }
+
+    function test_signal_unknown_receipt_reverts() public {
+        vm.prank(deployer);
+        registry.setGenesis(GENESIS_COMMIT);
+
+        bytes32 fakeHash = keccak256("fake");
+        vm.prank(actor2);
+        vm.expectRevert("Target!exists");
+        registry.emitCanonSignal(fakeHash, ICanonReceiptRegistryV0_1.CanonSignal.DISPUTED, "reason://test");
+    }
+
+    function test_signal_known_receipt_emits_overlay() public {
+        vm.prank(deployer);
+        registry.setGenesis(GENESIS_COMMIT);
+
+        ICanonReceiptRegistryV0_1.Receipt memory r = _mkReceipt(actor1, GENESIS_COMMIT);
+        vm.prank(actor1);
+        bytes32 hash = registry.anchorReceipt(r);
+
+        vm.prank(actor2);
+        vm.expectEmit(true, false, false, true);
+        emit CanonSignalEmitted(hash, ICanonReceiptRegistryV0_1.CanonSignal.PAUSED_FOR_REPLAY, "reason://replay", actor2);
+        registry.emitCanonSignal(hash, ICanonReceiptRegistryV0_1.CanonSignal.PAUSED_FOR_REPLAY, "reason://replay");
+    }
+
+    function test_signal_does_not_change_anchored_status() public {
+        vm.prank(deployer);
+        registry.setGenesis(GENESIS_COMMIT);
+
+        ICanonReceiptRegistryV0_1.Receipt memory r = _mkReceipt(actor1, GENESIS_COMMIT);
+        vm.prank(actor1);
+        bytes32 hash = registry.anchorReceipt(r);
+
+        uint256 countBefore = registry.receiptCount();
+        address actorBefore = registry.receiptActor(hash);
+
+        vm.prank(actor2);
+        registry.emitCanonSignal(hash, ICanonReceiptRegistryV0_1.CanonSignal.DISPUTED, "reason://dispute");
+
+        assertEq(registry.receiptCount(), countBefore);
+        assertEq(registry.receiptActor(hash), actorBefore);
+        assertTrue(registry.receiptExists(hash));
+    }
+
+    function test_blocked_truths_revert() public {
+        vm.prank(deployer);
+        registry.setGenesis(GENESIS_COMMIT);
+
+        string[4] memory blocked = ["VERIFIED", "FALSE", "FRAUD", "ADJUDICATED"];
+        for (uint i = 0; i < 4; i++) {
+            ICanonReceiptRegistryV0_1.Receipt memory r = _mkReceipt(actor1, GENESIS_COMMIT);
+            r.status = blocked[i];
+            vm.prank(actor1);
+            vm.expectRevert("BlockedTruth");
+            registry.anchorReceipt(r);
+        }
+    }
+
+    function test_trinity_incomplete_reverts() public {
+        vm.prank(deployer);
+        registry.setGenesis(GENESIS_COMMIT);
+
+        ICanonReceiptRegistryV0_1.Receipt memory r = _mkReceipt(actor1, GENESIS_COMMIT);
+        r.al = "";
+        vm.prank(actor1);
+        vm.expectRevert("AL missing");
+        registry.anchorReceipt(r);
+
+        r = _mkReceipt(actor1, GENESIS_COMMIT);
+        r.joy = "";
+        vm.prank(actor1);
+        vm.expectRevert("JOY missing");
+        registry.anchorReceipt(r);
+
+        r = _mkReceipt(actor1, GENESIS_COMMIT);
+        r.computerWisdom = "MUTABLE";
+        vm.prank(actor1);
+        vm.expectRevert("CW must be APPEND_ONLY");
+        registry.anchorReceipt(r);
+    }
+
+    function test_v0_1_actor_must_be_msg_sender() public {
+        vm.prank(deployer);
+        registry.setGenesis(GENESIS_COMMIT);
+
+        ICanonReceiptRegistryV0_1.Receipt memory r = _mkReceipt(actor2, GENESIS_COMMIT);
+        vm.prank(actor1);
+        vm.expectRevert("V0_1: actor must be msg.sender");
+        registry.anchorReceipt(r);
+    }
+
+    function test_first_receipt_must_match_genesis() public {
+        vm.prank(deployer);
+        registry.setGenesis(GENESIS_COMMIT);
+
+        ICanonReceiptRegistryV0_1.Receipt memory r = _mkReceipt(actor1, bytes32(uint256(0xDEAD)));
+        vm.prank(actor1);
+        vm.expectRevert("First receipt must match genesis");
+        registry.anchorReceipt(r);
+    }
+
+    function test_subsequent_receipts_can_diverge_commit() public {
+        vm.prank(deployer);
+        registry.setGenesis(GENESIS_COMMIT);
+
+        ICanonReceiptRegistryV0_1.Receipt memory r1 = _mkReceipt(actor1, GENESIS_COMMIT);
+        vm.prank(actor1);
+        registry.anchorReceipt(r1);
+
+        ICanonReceiptRegistryV0_1.Receipt memory r2 = _mkReceipt(actor2, bytes32(uint256(0xBEEF)));
+        vm.prank(actor2);
+        bytes32 hash2 = registry.anchorReceipt(r2);
+        assertTrue(registry.receiptExists(hash2));
+        assertEq(registry.receiptCount(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

Adds Matrix Jay Canon Receipt Registry V0.1 as an evidence-only, append-only witness scaffold.

## Includes

- Canon receipt registry interface
- Canon receipt registry implementation
- Foundry integration tests
- PR_170 genesis fixture
- non-signing bootstrap script
- doctrine and V0_2 migration notice

## Constraints

- No EIP-712 signature binding in V0_1
- No scoring
- No verdicts
- No authority surface
- Signals are overlay-only
- Off-chain replay remains the judge

## Test result

Operator-reported: 8 passed; 0 failed; 0 skipped

## Invariant

authority: false  
membrane: HOLDS