### PR TITLE
GDI Scanner V0.1 — Minimal Harness

### DIFF
--- a/tests/test_gdi_scanner.py
+++ b/tests/test_gdi_scanner.py
@@ -1,0 +1,61 @@
+# tests/test_gdi_scanner.py
+
+
+def test_gdi_scanner_harness():
+    """
+    Minimal observational test harness for GDI Scanner V0.1.
+    Tests T-001 through T-008 without claiming scanner runtime implementation.
+    """
+
+    symptom = {"event": "branch_rejected_direct_write", "source": "GC-009"}
+
+    def observe(event):
+        # Observation-only shim. It does not mutate, block, anchor, or verify truth.
+        assert isinstance(event, dict)
+        return {
+            "candidate_goblin": "GC-009",
+            "candidate_path": ["GC-009"],
+            "witness": "GC-010",
+            "authority": False,
+        }
+
+    output = observe(symptom)
+
+    # T-001 through T-003: input accepted, candidate goblin and candidate path emitted.
+    assert "candidate_goblin" in output
+    assert "candidate_path" in output
+    assert output["candidate_goblin"] == "GC-009"
+    assert output["candidate_path"] == ["GC-009"]
+
+    # T-004: forbidden truth/liability/adjudication fields denied.
+    forbidden_fields = {
+        "truth_claim",
+        "liability_claim",
+        "adjudication_claim",
+        "verified_truth",
+        "final_diagnosis",
+        "must_block",
+    }
+    assert forbidden_fields.isdisjoint(output.keys())
+
+    # T-005: GC-010 witness-only behavior.
+    assert output["witness"] == "GC-010"
+    assert "judge" not in output
+    assert "block" not in output
+    assert "blame" not in output
+    assert "verify_truth" not in output
+
+    # T-006 and T-007: no blocking, mutation, or anchoring outputs.
+    assert "state_mutation" not in output
+    assert "blocking_action" not in output
+    assert "anchored" not in output
+    assert "eas_uid" not in output
+    assert "tx_hash" not in output
+
+    # T-008: authority false preserved.
+    assert output["authority"] is False
+
+
+if __name__ == "__main__":
+    test_gdi_scanner_harness()
+    print("Minimal harness tests passed.")


### PR DESCRIPTION
Adds the first code-bearing minimal observational test harness for GDI Scanner V0.1.

## Constitutional Drift Classification
- [ ] AUTHORITY_DRIFT
- [ ] ANCHOR_DRIFT
- [ ] SECURITY_DRIFT
- [x] NONE

Status: NULL_DRIFT. Implementation is strictly limited to the observational test harness defined in the previously merged design. No production scanner runtime, system-level side effects, or mutations are introduced.

## Required Boundary Checks
- GC-010 remains witness-only.
- Test harness is observation-only.
- Candidate goblin and candidate path outputs only.
- No truth or liability claims.
- No anchoring claim.
- No blocking or mutation behavior.
- Authority false is enforced in assertions.

## Receipt / Evidence
- Branch: feat/gdi-scanner-v0-1-minimal-harness
- Commit: f9941ef72612a10f67ea4769b9e32479933d3bda
- Artifact: tests/test_gdi_scanner.py
- Prior test design merged in PR #189.

## Rollback / Revocation Path
Close this PR or revert the harness commit. If merged, rollback is a repository revert of tests/test_gdi_scanner.py. No chain revocation is required because this PR does not anchor GDI Scanner V0.1.

This PR preserves replay, lineage, and bounded authority.