### PR TITLE
GDI Coordinator Harness V0.1

### DIFF
--- a/tests/test_gdi_coordinator.py
+++ b/tests/test_gdi_coordinator.py
@@ -1,0 +1,60 @@
+# tests/test_gdi_coordinator.py
+"""GDI Coordinator Harness V0.1.
+
+Validates flat witness-only output schema.
+"""
+
+from gdi_coordinator import coordinate_event
+
+
+def test_coordinator_flat_witness_schema():
+    event = {
+        "event_type": "symptom",
+        "event": "coordinator_test",
+    }
+
+    report = coordinate_event(event)
+
+    assert report["report_type"] == "gdi_witness_observation"
+    assert report["witness"] == "GC-010"
+    assert report["mode"] == "witness_only"
+    assert report["authority"] is False
+    assert "candidate_goblin" in report
+    assert "candidate_path" in report
+
+
+def test_coordinator_strips_forbidden_fields():
+    event = {
+        "event_type": "symptom",
+        "severity": "high",
+        "judgment": "bad",
+        "block": True,
+        "diagnosis": "forbidden",
+    }
+
+    report = coordinate_event(event)
+    report_str = str(report).lower()
+
+    forbidden = ["severity", "judgment", "block", "diagnosis"]
+    for field in forbidden:
+        assert field not in report_str
+
+
+def test_coordinator_neutral_on_unroutable():
+    report = coordinate_event({"random": "noise"})
+
+    assert report["report_type"] == "gdi_witness_observation"
+    assert report["candidate_goblin"] == "GC-010"
+    assert report["candidate_path"] == ["GC-010"]
+    assert report["witness"] == "GC-010"
+    assert report["mode"] == "witness_only"
+    assert report["authority"] is False
+
+
+def test_coordinator_does_not_mutate_input():
+    event = {"event_type": "observation", "payload": "original"}
+    original = dict(event)
+
+    coordinate_event(event)
+
+    assert event == original


### PR DESCRIPTION
Adds flat-schema contract tests for the coordinator routing surface.

## Constitutional Drift Classification
- [ ] AUTHORITY_DRIFT
- [ ] ANCHOR_DRIFT
- [ ] SECURITY_DRIFT
- [x] NONE

Status: NULL_DRIFT.

## Required Boundary Checks
- Flat witness-only schema.
- Forbidden fields isolated.
- Neutral unroutable behavior.
- No input mutation.
- authority false preserved.

## Receipt / Evidence
- Branch: feat/gdi-coordinator-harness-v0-1
- Commit: 82503508c0247ee7b9f8754f4e3722c2b3d65684
- Artifact: tests/test_gdi_coordinator.py

Authority: false