### PR TITLE
GDI Dispatcher Harness V0.1

### DIFF
--- a/tests/test_gdi_dispatcher.py
+++ b/tests/test_gdi_dispatcher.py
@@ -1,0 +1,66 @@
+# tests/test_gdi_dispatcher.py
+"""GDI Dispatcher Harness V0.1.
+
+Validates pure dispatch behavior for multiple coordinator events.
+"""
+
+import copy
+
+from gdi_dispatcher import dispatch_events
+
+
+def test_dispatcher_preserves_order_and_calls_coordinator(monkeypatch):
+    events = [
+        {"candidate_goblin": "g1", "candidate_path": ["a"]},
+        {"candidate_goblin": "g2", "candidate_path": ["b"]},
+    ]
+    calls = []
+
+    def fake_coordinate(event):
+        calls.append(copy.deepcopy(event))
+        return {
+            "report_type": "gdi_witness_observation",
+            "candidate_goblin": event["candidate_goblin"],
+            "candidate_path": event["candidate_path"],
+            "witness": "GC-010",
+            "mode": "witness_only",
+            "authority": False,
+        }
+
+    monkeypatch.setattr("gdi_dispatcher.coordinate_event", fake_coordinate)
+
+    reports = dispatch_events(events)
+
+    assert len(calls) == 2
+    assert calls[0]["candidate_goblin"] == "g1"
+    assert calls[1]["candidate_goblin"] == "g2"
+
+    assert reports[0]["candidate_goblin"] == "g1"
+    assert reports[1]["candidate_goblin"] == "g2"
+
+    for report in reports:
+        assert report["report_type"] == "gdi_witness_observation"
+        assert report["witness"] == "GC-010"
+        assert report["mode"] == "witness_only"
+        assert report["authority"] is False
+
+
+def test_dispatcher_does_not_mutate_input(monkeypatch):
+    event = {"candidate_goblin": "g", "candidate_path": ["x"]}
+    original = copy.deepcopy(event)
+
+    def fake_coordinate(coordinated_event):
+        return {
+            "report_type": "gdi_witness_observation",
+            "candidate_goblin": coordinated_event["candidate_goblin"],
+            "candidate_path": coordinated_event["candidate_path"],
+            "witness": "GC-010",
+            "mode": "witness_only",
+            "authority": False,
+        }
+
+    monkeypatch.setattr("gdi_dispatcher.coordinate_event", fake_coordinate)
+
+    dispatch_events([event])
+
+    assert event == original


### PR DESCRIPTION
Adds contract tests for pure dispatcher behavior.

## Constitutional Drift Classification
- [ ] AUTHORITY_DRIFT
- [ ] ANCHOR_DRIFT
- [ ] SECURITY_DRIFT
- [x] NONE

Status: NULL_DRIFT.

## Required Boundary Checks
- Order preserved.
- Coordinator called once per event.
- Outputs unchanged.
- No input mutation.
- authority false preserved.

## Receipt / Evidence
- Branch: feat/gdi-dispatcher-harness-v0-1
- Commit: 68155e5fd1f2a67597a6f6baf1e94c9b6a57bca7
- Artifact: tests/test_gdi_dispatcher.py

Authority: false