### PR TITLE
GDI Orchestrator V0.1 Module

### DIFF
--- a/gdi_orchestrator.py
+++ b/gdi_orchestrator.py
@@ -1,0 +1,31 @@
+"""GDI Orchestrator V0.1.
+
+Single public entrypoint for the GDI pipeline.
+
+Responsibilities:
+- Accept raw input events.
+- Normalize iterable input without mutating original input.
+- Forward to dispatch_events(events).
+- Return dispatcher output unchanged.
+
+Boundary:
+- No decisions.
+- No mutation.
+- No metadata.
+- No authority.
+"""
+
+from gdi_dispatcher import dispatch_events
+
+__all__ = ["run_gdi_pipeline"]
+
+
+def run_gdi_pipeline(events):
+    """Return dispatcher outputs for events through the public GDI entrypoint."""
+    if events is None:
+        return []
+
+    if not isinstance(events, (list, tuple)):
+        events = list(events)
+
+    return dispatch_events(events)

--- a/tests/test_gdi_orchestrator.py
+++ b/tests/test_gdi_orchestrator.py
@@ -1,0 +1,80 @@
+# tests/test_gdi_orchestrator.py
+"""GDI Orchestrator Harness V0.1.
+
+Validates single public entrypoint forwarding to dispatcher.
+"""
+
+import copy
+
+from gdi_orchestrator import run_gdi_pipeline
+
+
+def test_orchestrator_returns_dispatcher_output_unchanged(monkeypatch):
+    events = [
+        {"event": "one"},
+        {"event": "two"},
+    ]
+    expected = [
+        {
+            "report_type": "gdi_witness_observation",
+            "candidate_goblin": "GC-010",
+            "candidate_path": ["GC-010"],
+            "witness": "GC-010",
+            "mode": "witness_only",
+            "authority": False,
+        },
+        {
+            "report_type": "gdi_witness_observation",
+            "candidate_goblin": "GC-009",
+            "candidate_path": ["GC-009", "GC-010"],
+            "witness": "GC-010",
+            "mode": "witness_only",
+            "authority": False,
+        },
+    ]
+
+    def fake_dispatch(dispatched_events):
+        assert dispatched_events == events
+        return expected
+
+    monkeypatch.setattr("gdi_orchestrator.dispatch_events", fake_dispatch)
+
+    assert run_gdi_pipeline(events) == expected
+
+
+def test_orchestrator_returns_empty_list_for_none(monkeypatch):
+    def fake_dispatch(dispatched_events):
+        raise AssertionError("dispatcher must not be called for None")
+
+    monkeypatch.setattr("gdi_orchestrator.dispatch_events", fake_dispatch)
+
+    assert run_gdi_pipeline(None) == []
+
+
+def test_orchestrator_normalizes_iterable_without_mutating_events(monkeypatch):
+    event = {"event": "branch_rejected_direct_write"}
+    original = copy.deepcopy(event)
+    captured = []
+
+    def event_iterable():
+        yield event
+
+    def fake_dispatch(dispatched_events):
+        captured.extend(dispatched_events)
+        return [
+            {
+                "report_type": "gdi_witness_observation",
+                "candidate_goblin": "GC-009",
+                "candidate_path": ["GC-009", "GC-010"],
+                "witness": "GC-010",
+                "mode": "witness_only",
+                "authority": False,
+            }
+        ]
+
+    report = run_gdi_pipeline(event_iterable())
+
+    assert event == original
+    assert captured == [event]
+    assert report[0]["witness"] == "GC-010"
+    assert report[0]["authority"] is False


### PR DESCRIPTION
Adds gdi_orchestrator.py as a single public entrypoint over the dispatcher.

## Constitutional Drift Classification
- [ ] AUTHORITY_DRIFT
- [ ] ANCHOR_DRIFT
- [ ] SECURITY_DRIFT
- [x] NONE

Status: NULL_DRIFT.

## Required Boundary Checks
- Single public entrypoint.
- No decisions.
- No mutation.
- No metadata.
- No authority.
- Returns dispatcher output unchanged.

## Receipt / Evidence
- Branch: feat/gdi-orchestrator-v0-1-module
- Commit: 574f119b7d4a327bab701f1a7c1546723c423442
- Artifact: gdi_orchestrator.py

Authority: false