### PR TITLE
feat(game): add verification game v1 and demo entrypoint

### DIFF
--- a/public-record-verification/game.html
+++ b/public-record-verification/game.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verification Game | Anti-Drift</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 800px;
+      margin: 2rem auto;
+      padding: 1rem;
+      background: #faf9f8;
+      line-height: 1.5;
+    }
+    .game-container {
+      background: white;
+      border-radius: 20px;
+      padding: 2rem;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+    }
+    .claim-card {
+      background: #f0f2f5;
+      padding: 1.5rem;
+      border-radius: 16px;
+      margin: 1.5rem 0;
+      font-size: 1.2rem;
+      border-left: 4px solid #2c5f2d;
+    }
+    .verification-console {
+      background: #1e1e2f;
+      color: #c9d1d9;
+      font-family: monospace;
+      padding: 1rem;
+      border-radius: 12px;
+      margin: 1.5rem 0;
+    }
+    .hash-input {
+      width: 100%;
+      font-family: monospace;
+      padding: 0.75rem;
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      font-size: 0.9rem;
+    }
+    button {
+      background: #2c5f2d;
+      color: white;
+      border: none;
+      padding: 0.75rem 1.5rem;
+      border-radius: 40px;
+      font-size: 1rem;
+      cursor: pointer;
+      margin-top: 1rem;
+      font-weight: bold;
+    }
+    .score {
+      font-size: 1.4rem;
+      font-weight: bold;
+      text-align: right;
+      color: #2c5f2d;
+    }
+    .feedback {
+      margin-top: 1rem;
+      padding: 0.75rem;
+      border-radius: 8px;
+    }
+    .correct { background: #d4edda; color: #155724; border-left: 4px solid #28a745; }
+    .incorrect { background: #f8d7da; color: #721c24; border-left: 4px solid #dc3545; }
+    footer {
+      margin-top: 2rem;
+      font-size: 0.8rem;
+      text-align: center;
+      color: #666;
+      border-top: 1px solid #ddd;
+      padding-top: 1rem;
+    }
+  </style>
+</head>
+<body>
+<div class="game-container">
+  <div style="display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;">
+    <h1>Verification Game</h1>
+    <div class="score">Score: <span id="scoreValue">0</span></div>
+  </div>
+  <p><em>Verify the claim by recomputing its SHA-256 hash using the source document.</em></p>
+
+  <div id="gameArea"></div>
+  <div id="feedback"></div>
+
+  <footer>
+    <p>Authority: false | Receipts are replayable | <a href="index.html">Back to demo</a></p>
+    <p>This site does not ask you to trust it. It gives you the math to verify it.</p>
+  </footer>
+</div>
+
+<script>
+  const receipts = [
+    {
+      claim: "The FY2024 Budget requests $73.3 billion in gross discretionary appropriations for the Department of Housing and Urban Development.",
+      hash: "5ece344efd4d5f5b83c53bfd0e03bd518694f8c4c5f5200b44913c14c2c23bfc",
+      source: "https://crsreports.congress.gov/product/pdf/IF/IF12278",
+      hint: "Look for the HUD FY2024 request figure."
+    }
+  ];
+
+  let currentReceipt = receipts[0];
+  let score = Number(localStorage.getItem("verification_game_score") || "0");
+
+  function renderGame() {
+    document.getElementById("scoreValue").textContent = score;
+    document.getElementById("gameArea").innerHTML = `
+      <div class="claim-card">
+        <strong>Claim to verify:</strong><br>
+        "${currentReceipt.claim}"
+      </div>
+      <p><a href="${currentReceipt.source}" target="_blank" rel="noopener">Open source document</a></p>
+      <p><strong>Hint:</strong> ${currentReceipt.hint}</p>
+      <div class="verification-console">
+        <div>$ printf '%s' "&lt;exact claim text&gt;" | sha256sum</div>
+        <div style="margin-top: 0.5rem;">Receipt hash:</div>
+        <div style="word-break: break-all; background: #0d1117; padding: 0.5rem; border-radius: 6px;">${currentReceipt.hash}</div>
+      </div>
+      <label for="userHash">Your computed hash:</label>
+      <input type="text" id="userHash" class="hash-input" placeholder="Paste 64-character SHA-256 hash">
+      <button id="verifyBtn">Verify and Score</button>
+    `;
+    document.getElementById("verifyBtn").addEventListener("click", verifyAndScore);
+  }
+
+  function verifyAndScore() {
+    const userHash = document.getElementById("userHash").value.trim().toLowerCase();
+    const feedback = document.getElementById("feedback");
+    feedback.className = "feedback";
+
+    if (userHash === currentReceipt.hash) {
+      score += 10;
+      localStorage.setItem("verification_game_score", String(score));
+      document.getElementById("scoreValue").textContent = score;
+      feedback.innerHTML = "<strong>Correct.</strong> The hash matches the receipt. +10 points.";
+      feedback.classList.add("correct");
+    } else {
+      score = Math.max(0, score - 5);
+      localStorage.setItem("verification_game_score", String(score));
+      document.getElementById("scoreValue").textContent = score;
+      feedback.innerHTML = `<strong>Incorrect hash.</strong> Drift detected. Expected:<br><code>${currentReceipt.hash}</code><br>-5 points.`;
+      feedback.classList.add("incorrect");
+    }
+  }
+
+  renderGame();
+</script>
+</body>
+</html>

--- a/public-record-verification/index.html
+++ b/public-record-verification/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Public Record Verification Demo | Anti-Drift</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 800px; margin: 2rem auto; padding: 1rem; line-height: 1.5; background: #faf9f8; }
+    .card { background: white; border-radius: 20px; padding: 2rem; box-shadow: 0 4px 12px rgba(0,0,0,0.05); margin-bottom: 2rem; }
+    .receipt-box { background: #f0f2f5; padding: 1rem; border-radius: 12px; margin: 1rem 0; }
+    .hash { font-family: monospace; word-break: break-all; background: #1e1e2f; color: #c9d1d9; padding: 0.5rem; border-radius: 6px; }
+    button { background: #2c5f2d; color: white; border: none; padding: 0.75rem 1.5rem; border-radius: 40px; cursor: pointer; font-weight: bold; }
+    .game-link { text-align: center; margin-top: 1.5rem; }
+    footer { margin-top: 2rem; font-size: 0.8rem; text-align: center; color: #666; border-top: 1px solid #ddd; padding-top: 1rem; }
+  </style>
+</head>
+<body>
+<div class="card">
+  <h1>Public Record Verification Demo</h1>
+  <p>This demo turns a real public claim into a <strong>replayable receipt packet</strong>. No trust required — only math.</p>
+
+  <h2>Claim</h2>
+  <div class="receipt-box">
+    <em>"The FY2024 Budget requests $73.3 billion in gross discretionary appropriations for the Department of Housing and Urban Development."</em>
+  </div>
+
+  <h2>Source</h2>
+  <p><a href="https://crsreports.congress.gov/product/pdf/IF/IF12278" target="_blank" rel="noopener">CRS Report IF12278 — HUD Appropriations, FY2024</a></p>
+
+  <h2>Receipt Files</h2>
+  <ul>
+    <li><a href="../receipts/demo_receipt_001.json">demo_receipt_001.json</a></li>
+    <li><a href="../receipts/demo_receipt_001.md">demo_receipt_001.md</a></li>
+    <li><a href="../receipts/hud_fy2024_budget_archives.json">hud_fy2024_budget_archives.json</a></li>
+  </ul>
+
+  <h2>Verify Yourself</h2>
+  <ol>
+    <li>Open the source document.</li>
+    <li>Locate the HUD FY2024 budget request figure.</li>
+    <li>Confirm the value: <strong>$73.3 billion</strong>.</li>
+    <li>Copy the exact claim text below.</li>
+  </ol>
+  <pre style="background:#f0f2f5; padding:0.75rem; border-radius:8px; white-space:pre-wrap;">The FY2024 Budget requests $73.3 billion in gross discretionary appropriations for the Department of Housing and Urban Development.</pre>
+  <pre style="background:#1e1e2f; color:#c9d1d9; padding:0.75rem; border-radius:8px; white-space:pre-wrap;">CLAIM='The FY2024 Budget requests $73.3 billion in gross discretionary appropriations for the Department of Housing and Urban Development.'
+printf '%s' "$CLAIM" | sha256sum</pre>
+  <p>The output must match:</p>
+  <code class="hash">5ece344efd4d5f5b83c53bfd0e03bd518694f8c4c5f5200b44913c14c2c23bfc</code>
+
+  <div class="game-link">
+    <a href="game.html"><button>Play Verification Game</button></a>
+  </div>
+</div>
+
+<footer>
+  <p>Authority: false | Receipts are replayable</p>
+  <p>This site does not ask you to trust it. It gives you the math to verify it.<br>Not anti-news. Anti-drift. Public receipts from day one.</p>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a playable verification game and a polished demo entrypoint for the public record verification flow.

## Files added

- `public-record-verification/index.html` — Demo entrypoint with receipt links, replay steps, and game link.
- `public-record-verification/game.html` — Interactive game where players verify claims by recomputing SHA-256 hashes against source documents.

## Features

- Uses the live HUD receipt from Leaf 001.
- Claim: `The FY2024 Budget requests $73.3 billion in gross discretionary appropriations for the Department of Housing and Urban Development.`
- Hash: `sha256:5ece344efd4d5f5b83c53bfd0e03bd518694f8c4c5f5200b44913c14c2c23bfc`
- Authority: false — no privileged signatures, no backend.
- Replay-first design: any stranger can verify the claim in under 2 minutes.
- Game awards points for correct verification and deducts points for drift.
- Local score persistence through localStorage.

## Testing

- [x] Game page committed on isolated Leaf 002 branch.
- [x] Demo entrypoint links to game page.
- [x] Demo entrypoint links to Leaf 001 receipt files.
- [x] Game uses repository receipt hash, not conflicting draft hashes.
- [ ] Required GitHub checks pass.
- [ ] GitHub Pages path verified after merge.

## Next steps

- Add more verified receipts to the game.
- Add drift repair log as a game-history artifact.
- Optional Base/EAS anchor only after public proof.

Canon preserved. Authority false. Receipts ready.