### PR TITLE
docs(architecture): add three repo proof stack v1

### DIFF
--- a/docs/GOBLIN_PRECEDENT_INDEX_V0_1.md
+++ b/docs/GOBLIN_PRECEDENT_INDEX_V0_1.md
@@ -14,6 +14,8 @@
 }
 ```
 
+Authority: false
+
 ## Purpose
 
 Goblin Court V0.1 records claims, receipts, anchors, replay attempts, and disputes without declaring truth, liability, or winners.
@@ -33,6 +35,12 @@ The Court is a witness and replay surface, not an adjudicator.
   "REPLAY_MATCH_PROVES_RECONSTRUCTION_NOT_LIABILITY": true
 }
 ```
+
+## Trinity
+
+PROTECT | WITNESS | APPEND_ONLY
+
+Authority: false
 
 ## Precedent Classes
 
@@ -61,6 +69,123 @@ The Court is a witness and replay surface, not an adjudicator.
 ## Replay Rule
 
 A replay may produce MATCH, MISMATCH, INCOMPLETE, or BLOCKED. A replay result does not declare truth, liability, or adjudication.
+
+---
+
+## Goblin Registry
+
+| GC-ID | Goblin Name | Receipt | Checklist | Priority | Status |
+|---|---|---|---|---|---|
+| GC-001 | Claim Intake Goblin | FR-001 | CL-001 | HIGH | REGISTERED |
+| GC-002 | Source Witness Goblin | FR-002 | CL-002 | HIGH | REGISTERED |
+| GC-003 | Hash Replay Goblin | FR-003 | CL-003 | HIGH | REGISTERED |
+| GC-004 | Drift Detection Goblin | FR-004 | CL-004 | HIGH | REGISTERED |
+| GC-005 | Archive Mirror Goblin | FR-005 | CL-005 | MEDIUM | REGISTERED |
+| GC-006 | Authority False Goblin | FR-006 | CL-006 | HIGH | REGISTERED |
+| GC-007 | Link Path Goblin | FR-007 | CL-007 | MEDIUM | REGISTERED |
+| GC-008 | Receipt Packet Goblin | FR-008 | CL-008 | HIGH | REGISTERED |
+| GC-009 | Public Demo Goblin | FR-009 | CL-009 | MEDIUM | REGISTERED |
+| GC-010 | Assumption Cascade Goblin | FR-010 | CL-010 | CRITICAL | REGISTERED |
+
+---
+
+### FR-001 — GC-001: Claim Intake Goblin
+
+Records claim text without upgrading claim to truth.
+
+Checklist: CL-001
+
+---
+
+### FR-002 — GC-002: Source Witness Goblin
+
+Records source URI and source role without declaring source permanence.
+
+Checklist: CL-002
+
+---
+
+### FR-003 — GC-003: Hash Replay Goblin
+
+Requires exact bytes to reproduce the stated SHA-256 hash.
+
+Checklist: CL-003
+
+---
+
+### FR-004 — GC-004: Drift Detection Goblin
+
+Flags mismatch between claim, source, hash, receipt, or replay output.
+
+Checklist: CL-004
+
+---
+
+### FR-005 — GC-005: Archive Mirror Goblin
+
+Records archive candidates and distinguishes archived evidence from live-source evidence.
+
+Checklist: CL-005
+
+---
+
+### FR-006 — GC-006: Authority False Goblin
+
+Rejects any silent promotion from observation to authority.
+
+Checklist: CL-006
+
+---
+
+### FR-007 — GC-007: Link Path Goblin
+
+Checks that public links resolve or are explicitly marked as pending, candidate, or broken.
+
+Checklist: CL-007
+
+---
+
+### FR-008 — GC-008: Receipt Packet Goblin
+
+Ensures machine-readable and human-readable receipts remain aligned.
+
+Checklist: CL-008
+
+---
+
+### FR-009 — GC-009: Public Demo Goblin
+
+Registers public demo surfaces and replay pages.
+
+Checklist: CL-009
+
+---
+
+### FR-010 — GC-010: Assumption Cascade Goblin
+
+Detects when three or more unverified assumptions are chained into an action request.
+
+Required response: STOP_AND_REBASE.
+
+Trigger examples:
+
+- Three or more unverifiable source claims are treated as confirmed.
+- A placeholder hash is treated as recomputed proof.
+- A public surface is declared live before repo state or Pages state confirms it.
+
+Checklist: CL-010
+
+---
+
+## Symptom Lookup Table
+
+| Symptom | Goblin | Response |
+|---|---|---|
+| Claim accepted without source | GC-001 | Require source witness |
+| Source link moved | GC-005 | Add archive candidate |
+| Hash mismatch | GC-003 | Recompute exact bytes |
+| Receipt files disagree | GC-008 | Patch before merge |
+| Three or more assumptions stack | GC-010 | STOP_AND_REBASE |
 
 ## Non-Authority Notice
 

--- a/docs/alms_fetch_spec_v1.md
+++ b/docs/alms_fetch_spec_v1.md
@@ -1,0 +1,79 @@
+# ALMS Fetch Spec v1
+
+**Authority:** false  
+**Purpose:** Define how COMPUTERWISDOM retrieves receipts from ALMS.
+
+---
+
+## Fetch Flow
+
+```text
+COMPUTERWISDOM Game
+│
+├─► 1. Fetch index.json from ALMS
+│
+├─► 2. Find receipt by ID or name
+│
+├─► 3. Fetch receipt JSON from ALMS path
+│
+├─► 4. Validate receipt hash matches claim
+│
+└─► 5. Display verification result to user
+```
+
+---
+
+## API Endpoints: Conceptual
+
+| Endpoint | Method | Response |
+|----------|--------|----------|
+| `https://alms.example.com/receipts/index.json` | GET | Index of all receipts |
+| `https://alms.example.com/receipts/{id}.json` | GET | Individual receipt JSON |
+| `https://alms.example.com/receipts/latest/{name}.json` | GET | Latest version of a named receipt |
+
+---
+
+## Caching and Performance
+
+- Index is cached for 5 minutes.
+- Individual receipts are cached for 1 hour.
+- Receipts are treated as immutable once published.
+- Game surfaces may preload the index at startup.
+
+---
+
+## Error Handling
+
+| HTTP Status | Meaning | Game Action |
+|-------------|---------|-------------|
+| 200 | Success | Use receipt data |
+| 404 | Receipt not found | Show missing receipt error and fallback to local stub if available |
+| 500 | ALMS error | Retry with exponential backoff |
+
+---
+
+## Fallback Mechanism
+
+If ALMS is unreachable, COMPUTERWISDOM may fall back to a local copy of `index.json` and cached receipts.
+
+Fallback must be visibly labeled so users know the source is cached rather than live.
+
+---
+
+## Verification Rule
+
+COMPUTERWISDOM must not trust ALMS blindly.
+
+It must:
+
+1. Fetch receipt bytes.
+2. Read the claim string exactly.
+3. Compute SHA-256 over the exact claim string.
+4. Compare computed hash to `claim_hash`.
+5. Display MATCH or MISMATCH.
+
+---
+
+## Canon
+
+> ALMS holds the memory. COMPUTERWISDOM asks for it. Authority is false.

--- a/docs/alms_receipt_index_v1.md
+++ b/docs/alms_receipt_index_v1.md
@@ -1,0 +1,79 @@
+# ALMS Receipt Index v1
+
+**Authority:** false  
+**Purpose:** Specification for the receipt index file that maps receipt IDs to their storage locations.
+
+---
+
+## Index File Location
+
+`https://alms.example.com/receipts/index.json`
+
+Initial hosting may use GitHub Pages, raw GitHub URLs, IPFS, or another public mirror.
+
+---
+
+## JSON Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "receipts"],
+  "properties": {
+    "version": { "type": "string", "const": "1" },
+    "updated_at": { "type": "string", "format": "date-time" },
+    "receipts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name", "path", "hash"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^REC-[0-9]{6}$" },
+          "name": { "type": "string" },
+          "path": { "type": "string" },
+          "hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+          "timestamp": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Example `index.json`
+
+```json
+{
+  "version": "1",
+  "updated_at": "2026-06-02T23:30:00Z",
+  "receipts": [
+    {
+      "id": "REC-000001",
+      "name": "HUD FY2024 Budget Request",
+      "path": "receipts/hud_fy2024_budget_receipt.json",
+      "hash": "sha256:5ece344efd4d5f5b83c53bfd0e03bd518694f8c4c5f5200b44913c14c2c23bfc",
+      "timestamp": "2026-06-02T23:30:00Z"
+    }
+  ]
+}
+```
+
+---
+
+## Usage in COMPUTERWISDOM
+
+```javascript
+const index = await fetch('https://alms.example.com/receipts/index.json').then((r) => r.json());
+const receipt = await fetch(index.receipts[0].path).then((r) => r.json());
+```
+
+---
+
+## Canon
+
+An index is not a receipt. It is a map to receipts. Authority is false.

--- a/docs/receipt_doctrine_v1.md
+++ b/docs/receipt_doctrine_v1.md
@@ -1,0 +1,60 @@
+# Receipt Doctrine v1
+
+**Authority:** false  
+**Purpose:** AL doctrine artifact defining the lifecycle of a receipt.
+
+---
+
+## Core Principles
+
+1. **A receipt is an immutable claim with a verifiable hash.**
+2. **A receipt must include the exact claim text and its SHA-256 hash.**
+3. **A receipt must reference its source, such as a URL or document.**
+4. **A receipt must have `authority: false`.**
+5. **A receipt may be corrected by publishing a new receipt that supersedes it.**
+
+---
+
+## Receipt Lifecycle
+
+```text
+Create -> Validate -> Publish -> Reference -> Optional Supersede
+```
+
+- **Create:** Author writes claim, source, and hash.
+- **Validate:** CI checks schema and hash consistency.
+- **Publish:** Receipt becomes available at a stable public URL.
+- **Reference:** Other systems, including games and dashboards, link to it.
+- **Supersede:** If drift is found, a new receipt is published and the old one remains as history.
+
+---
+
+## Drift Handling
+
+- **Drift is not deletion.** The original receipt stays visible.
+- **Correction creates a new receipt** with a `supersedes` field pointing to the old one.
+- **Drift repair log** documents why the change was made.
+
+---
+
+## Receipt Schema: Minimal
+
+```json
+{
+  "receipt_type": "PUBLIC_RECORD_VERIFICATION_V1",
+  "authority": false,
+  "claim": "...",
+  "claim_hash": "sha256:...",
+  "source_uri": "https://...",
+  "timestamp_utc": "ISO8601",
+  "supersedes": "REC-XXXXXX"
+}
+```
+
+`supersedes` is optional and should be omitted when there is no prior receipt.
+
+---
+
+## Canon
+
+A receipt is a promise you can verify. Authority is false.

--- a/docs/three_repo_proof_stack_v1.md
+++ b/docs/three_repo_proof_stack_v1.md
@@ -1,0 +1,65 @@
+# Three-Repo Proof Stack v1
+
+**Authority:** false  
+**Purpose:** Split the proof system across AL, COMPUTERWISDOM, and ALMS.
+
+---
+
+## Repository Responsibilities
+
+| Repository | Role | Contents |
+|------------|------|----------|
+| **AL** | Doctrine & Constitution | Authority rules, invariants, constitutional documents |
+| **COMPUTERWISDOM** | Replay Surfaces & UI | Game, demo, replay client, user-facing verification |
+| **ALMS** | Memory Surfaces | Receipts, drift logs, immutable event segments |
+
+---
+
+## Data Flow
+
+```text
+User interacts with COMPUTERWISDOM UI
+│
+▼
+COMPUTERWISDOM fetches receipts from ALMS using public URLs or APIs
+│
+▼
+COMPUTERWISDOM applies replay rules defined by AL doctrine
+│
+▼
+Verification result displayed to user
+```
+
+---
+
+## Cross-Repo Links
+
+### COMPUTERWISDOM -> ALMS
+
+Receipts are stored as JSON files in ALMS and served through GitHub Pages, raw GitHub URLs, IPFS, or another public mirror.
+
+COMPUTERWISDOM reads them by URL and verifies them locally.
+
+### COMPUTERWISDOM -> AL
+
+COMPUTERWISDOM imports `authority: false` invariants and constitutional rules as documented constants, not as a hidden runtime dependency.
+
+### AL -> ALMS
+
+AL defines doctrine and schema boundaries. ALMS stores receipt instances and drift logs.
+
+---
+
+## Benefits
+
+- **Separation of concerns:** UI, rules, and storage evolve independently.
+- **Verifiability:** Each repo can be audited in isolation.
+- **Scalability:** ALMS can host receipts without bloating COMPUTERWISDOM.
+- **Resilience:** If one repo goes down, the others can still preserve their role through mirrors.
+
+---
+
+## Canon
+
+> This site does not ask you to trust it. It gives you the math to verify it.  
+> Not anti-news. Anti-drift. Public receipts from day one.


### PR DESCRIPTION
## Summary

Adds the foundation for splitting the proof system across three repositories:

- **AL** — Doctrine and rules
- **COMPUTERWISDOM** — UI, game, and replay surfaces
- **ALMS** — Receipt storage and immutable memory

## Files added

- `docs/three_repo_proof_stack_v1.md` — Architecture overview
- `docs/alms_receipt_index_v1.md` — Receipt index specification
- `docs/receipt_doctrine_v1.md` — AL doctrine for receipt lifecycle
- `docs/alms_fetch_spec_v1.md` — COMPUTERWISDOM to ALMS fetch protocol

## Why this matters

This separates proof responsibilities:

- AL defines lawful doctrine.
- ALMS preserves receipts and drift memory.
- COMPUTERWISDOM renders replay surfaces and games.

## Next steps

- Bootstrap ALMS repository.
- Add receipt schema validation CI.
- Migrate REC-000001 into ALMS.
- Update COMPUTERWISDOM game to fetch from ALMS index.

Canon preserved. Authority false. Receipts ready.