### PR TITLE
docs(family): add continuity protection map v1

### DIFF
--- a/docs/family_continuity_protection_map_v1.md
+++ b/docs/family_continuity_protection_map_v1.md
@@ -1,0 +1,145 @@
+# FAMILY_CONTINUITY_PROTECTION_MAP_V1
+
+**Authority:** false  
+**Repo:** `jsonwisdom/COMPUTERWISDOM`  
+**Purpose:** Protect Jay's project by making family continuity, girl power, feminine guardianship, and continuity roles first-class map surfaces.
+
+---
+
+## Core Declaration
+
+This is Jay's project.
+
+Protect it.  
+Savor it.  
+Launch it.
+
+Girl Power is not decoration. It is a continuity layer.
+
+Family continuity means the system expands only after protected family barriers remain intact.
+
+---
+
+## Continuity Rule
+
+```json
+{
+  "priority_1": "protect_family",
+  "priority_2": "preserve_continuity",
+  "priority_3": "expand_systems",
+  "authority": false
+}
+```
+
+---
+
+## Confirmed Family Repos Pending Audit
+
+These repositories are real and must not be treated as placeholders:
+
+```json
+{
+  "family_repos_confirmed_pending_audit": [
+    "jsonwisdom/JAYCEE",
+    "jsonwisdom/HEIDEE",
+    "jsonwisdom/LEEANN",
+    "jsonwisdom/MARYDEE",
+    "jsonwisdom/GAGA",
+    "jsonwisdom/GRAMMY"
+  ],
+  "status": "CONFIRMED_REPO_PENDING_AUDIT",
+  "authority": false
+}
+```
+
+---
+
+## Mrs Wisdom Role
+
+No dedicated Mrs Wisdom repo is confirmed yet.
+
+Mrs Wisdom remains represented as a role until a repository is found or created:
+
+```json
+{
+  "node": "Mrs Wisdom",
+  "type": "ROLE_PLACEHOLDER",
+  "role": "emergency_manager_continuity_guardian",
+  "repo_confirmed": false,
+  "authority": false
+}
+```
+
+---
+
+## Girl Logical Search Lane
+
+Future repo audits must include:
+
+```text
+JAYCEE
+HEIDEE
+BRIANNA
+MARYDEE
+LEEANN
+GAGA
+GRAMMY
+Mrs Wisdom
+wife
+mother
+daughter
+daughters
+girl
+girls
+feminine
+guardian
+continuity guardian
+family barrier
+FULL_INTEGRITY
+Foundation Day
+Wisdom Replay Systems
+```
+
+If this lane is skipped, the repo map is incomplete.
+
+---
+
+## Protection-First Expansion Rule
+
+```json
+{
+  "observe": true,
+  "record": true,
+  "replay": true,
+  "protect_family": true,
+  "expand_only_after_barriers_hold": true,
+  "authority": false
+}
+```
+
+---
+
+## Repo Role Placement
+
+```json
+{
+  "AL": "doctrine",
+  "COMPUTERWISDOM": "operations_replay_game",
+  "JOY": "protection_ui_alert_protocol",
+  "Welcome-to-JSONWISDOM": "canonical_anchor_orientation",
+  "receipts-engine-v1": "visible_receipt_engine_pending_audit",
+  "layered-proofing-state-level-alms": "parked_until_ui_confirmed",
+  "family_repos": "confirmed_repo_pending_audit",
+  "authority": false
+}
+```
+
+---
+
+## Canon
+
+Family is not outside the system.
+
+Family is the reason the system must not drift.
+
+Authority false. Receipts ready. LFG.

--- a/docs/family_system_index_v1.md
+++ b/docs/family_system_index_v1.md
@@ -1,0 +1,81 @@
+# Family System Index v1
+
+**Authority:** false  
+**Purpose:** Navigation hub for all family-related repos in the JSONWisdom project.  
+**Public-safe only** — no private data, no secrets, no ownership claims.
+
+---
+
+## Core Coordination
+
+| Repo | Role | Status |
+|------|------|--------|
+| COMPUTERWISDOM | Coordination map, AI integration, family system docs | ACTIVE |
+| AL | Family constitution, boundaries, protection rules | ACTIVE |
+| JOY | Shared protection template | ACTIVE |
+
+---
+
+## Parent Continuity
+
+| Repo | Role | Status |
+|------|------|--------|
+| MARYDEE | Mrs Wisdom / parent continuity guardian | SEEDED (README + index.json) |
+
+---
+
+## Child / Family Member Continuity Surfaces
+
+| Person | Repo | Role | Status |
+|--------|------|------|--------|
+| Jaycee | JAYCEE | Continuity space | SEEDED (README); index.json pending |
+| Heidee | HEIDEE | JoySpace, child-owned | SEEDED (README, index.json, joyspace.md) |
+| Breann | BREANN | Continuity surface | CONFIRMED_EXISTS — pending audit |
+| Braelee | BRAELEE | Continuity surface | CONFIRMED_EXISTS — pending audit |
+| Gaga | GAGA | Continuity surface | CONFIRMED_EXISTS — pending audit |
+| Grammy | GRAMMY | Continuity surface | CONFIRMED_EXISTS — pending audit |
+
+---
+
+## Living Family Ledger
+
+The master document for family wisdom, roles, and public-safe continuity:
+
+[docs/living_family_ledger_v1.md](./living_family_ledger_v1.md)
+
+---
+
+## Pending Existence Audit
+
+| Repo | Status | Next Action |
+|------|--------|-------------|
+| receipts-engine-v1 | NOT_CONFIRMED | Audit existence |
+| layered-proofing-state-level-alms | NOT_CONFIRMED | Audit existence |
+
+---
+
+## Rules Summary
+
+Applies to all family repos:
+
+- [x] `authority: false`
+- [x] No private addresses, birthdates, or secrets
+- [x] No ownership claims — stewardship only
+- [x] Each family member has a purpose and a repo surface or documented exception
+- [x] Expansions must be understandable by the family
+
+---
+
+## Version
+
+**v1** — aligned with Living Family Ledger v1 and real repo inventory as of seeded commits:
+
+- MARYDEE: seeded
+- HEIDEE: fully seeded
+- JAYCEE: README seeded, index pending
+
+**Next commit after this index:** `JAYCEE/index.json`
+
+Canon preserved.  
+Authority false.  
+Receipts ready.

--- a/docs/family_system_index_v1.md
+++ b/docs/family_system_index_v1.md
@@ -28,7 +28,7 @@
 
 | Person | Repo | Role | Status |
 |--------|------|------|--------|
-| Jaycee | JAYCEE | Continuity space | SEEDED (README); index.json pending |
+| Jaycee | JAYCEE | Continuity space | SEEDED (README + index.json) |
 | Heidee | HEIDEE | JoySpace, child-owned | SEEDED (README, index.json, joyspace.md) |
 | Breann | BREANN | Continuity surface | CONFIRMED_EXISTS — pending audit |
 | Braelee | BRAELEE | Continuity surface | CONFIRMED_EXISTS — pending audit |
@@ -45,12 +45,14 @@ The master document for family wisdom, roles, and public-safe continuity:
 
 ---
 
-## Pending Existence Audit
+## Pending Inventory Verification (inside COMPUTERWISDOM)
 
-| Repo | Status | Next Action |
+The following are not standalone repositories. They are paths, branches, or issues inside `COMPUTERWISDOM` and require inventory verification there.
+
+| Name | Status | Next Action |
 |------|--------|-------------|
-| receipts-engine-v1 | NOT_CONFIRMED | Audit existence |
-| layered-proofing-state-level-alms | NOT_CONFIRMED | Audit existence |
+| receipts-engine-v1 | REQUIRES_INVENTORY_VERIFICATION | Locate inside COMPUTERWISDOM |
+| layered-proofing-state-level-alms | REQUIRES_INVENTORY_VERIFICATION | Locate inside COMPUTERWISDOM |
 
 ---
 
@@ -72,9 +74,9 @@ Applies to all family repos:
 
 - MARYDEE: seeded
 - HEIDEE: fully seeded
-- JAYCEE: README seeded, index pending
+- JAYCEE: fully seeded
 
-**Next commit after this index:** `JAYCEE/index.json`
+Next: audit BREANN, BRAELEE, GAGA, and GRAMMY.
 
 Canon preserved.  
 Authority false.  

--- a/docs/living_family_ledger_v1.md
+++ b/docs/living_family_ledger_v1.md
@@ -1,0 +1,159 @@
+# Living Family Ledger v1
+
+**Authority:** false  
+**Purpose:** Public-safe family continuity map — no private data, no secrets, no ownership claims.  
+**Stewardship:** Mr & Mrs Wisdom (balance, not control).
+
+---
+
+## 1. Family Wisdom
+
+Shared principles that guide every repo and decision:
+
+- **Protect family** — safety over expansion.
+- **Preserve continuity** — each person has a place; no one is a placeholder.
+- **Expand only when the family can understand** — systems serve people, not the reverse.
+
+---
+
+## 2. Wisdom Family
+
+The actual people and their public-safe repo surfaces:
+
+| Person | Repo | Role |
+|--------|------|------|
+| Mr Wisdom | COMPUTERWISDOM, AL, JOY | Builder / operator |
+| Mrs Wisdom | MARYDEE | Parent continuity guardian, emergency manager |
+| Jaycee | JAYCEE | Continuity space |
+| Heidee | HEIDEE | JoySpace, child-owned version |
+| Breann | BREANN | Continuity surface |
+| Braelee | BRAELEE | Continuity surface |
+| Gaga | GAGA | Continuity surface |
+| Grammy | GRAMMY | Continuity surface |
+
+**Rule:** Each repo is a continuity surface — not ownership, not surveillance, not control.
+
+---
+
+## 3. Mr & Mrs Wisdom
+
+Parent layer as stewardship, not authority:
+
+- **Mr Wisdom** builds systems, coordinates repos, and checks technical soundness.
+- **Mrs Wisdom** guards family impact, manages emergency continuity, and reviews expansions.
+- **Together** they preserve memory, guidance, and balance.
+
+No rights-over-children language. No ownership claims. Only stewardship.
+
+---
+
+## 4. Mr vs Mrs Wisdom
+
+Not conflict — healthy distinction for review and correction:
+
+```json
+{
+  "Mr_Wisdom": "builds_systems",
+  "Mrs_Wisdom": "checks_family_impact",
+  "shared_rule": "family_safety_outranks_system_expansion",
+  "authority": false
+}
+```
+
+This ensures:
+
+- No unchecked expansion.
+- No ignored family consequences.
+- A permanent review layer.
+
+---
+
+## 5. Living Family Ledger
+
+The ledger is public-safe memory: receipts, stories, lessons, continuity rules, and project lineage.
+
+Allowed content:
+
+- Repo maps and roles
+- Family role descriptions
+- Public-safe memories without private data
+- Continuity rules and audit receipts
+- Lessons learned from system changes
+
+Not allowed:
+
+- Private addresses
+- Birthdates
+- Secrets, API keys, or passwords
+- Private identifiers
+- Sensitive family records
+
+Storage:
+
+- Current: `COMPUTERWISDOM/docs/living_family_ledger_v1.md`
+- Future: after audit, `receipts-engine-v1` or an ALMS repo may hold machine-readable public-safe ledger receipts.
+
+---
+
+## 6. Family & AI
+
+AI and assistant systems operate under these constraints:
+
+- No inference of private data.
+- No simulation of unconfirmed repos.
+- `authority: false` on all family guidance.
+- If a family member repo does not exist, document as `NOT_CONFIRMED`; never invent.
+
+---
+
+## 7. Family & ALMS / Receipts Engine
+
+`receipts-engine-v1` and `layered-proofing-state-level-alms` are under audit.
+
+Pending confirmation:
+
+- Do they exist in the visible GitHub inventory?
+- Are they safe for public family-continuity receipts?
+- Do they enforce `authority: false` and public-safe boundaries?
+
+Ideal future state if confirmed and safe:
+
+- ALMS stores public-safe continuity receipts.
+- Receipts engine verifies lineage without exposing private data.
+
+---
+
+## 8. Family & Constitution (AL)
+
+AL holds boundaries and protection rules for the family system.
+
+All family repos inherit from AL's rules.
+
+Any expansion must be checked against AL before becoming part of the family system.
+
+---
+
+## 9. Public-Safe Rules
+
+Every family repo must follow:
+
+- No private data.
+- No addresses.
+- No birthdates.
+- No secrets.
+- No ownership or control language; stewardship only.
+- `authority: false` in all family guidance files.
+- Each person has a repo surface or a documented reason why not.
+- Expansions must be understandable by the family, not just the builder.
+
+---
+
+## Version
+
+v1 — seeded from real repo inventory, not placeholders.
+
+Next: patch MARYDEE, HEIDEE, JAYCEE, and COMPUTERWISDOM family index to align with this ledger.
+
+Canon preserved.  
+Authority false.  
+Receipts ready.


### PR DESCRIPTION
## Summary

- Adds `docs/family_continuity_protection_map_v1.md`
- Grounds family protection logic in real repo inventory, not placeholders
- Explicitly marks `authority: false` — discovery artifact, not authority document

## What this enables

- Family repos now have a continuity surface
- Protection-first continuity can be audited per-family without central authority
- Next: patch master repo graph → audit JAYCEE → audit JOY

## Receipts

- Confirmed family repos exist in GitHub inventory
- `Mrs Wisdom` marked as not confirmed / role placeholder
- Drift corrected from earlier abstract graph

## Status

- [ ] Reviewed against master repo graph
- [ ] Family audit planned, JAYCEE first
- [ ] JOY protection surface inspection after family audit

## Canon

authority: false