### PR TITLE
Add Proof for the President 002 verifier chain v1

### DIFF
--- a/packets/proof_for_the_president_002_replay_packet_v0_1.json
+++ b/packets/proof_for_the_president_002_replay_packet_v0_1.json
@@ -4,10 +4,10 @@
   "claim_text": "Computer Wisdom Leaf 002 proves the replay protocol can repeat beyond the first proof.",
   "claim_hash": "sha256:52324d1cb3f1599ce191657a9c11de7948667c2d47e949c6a2a7722673999271",
   "evidence_layers": {
-    "github_commit": "PENDING_MERGE",
-    "github_issue_or_pr": "PENDING_PR",
-    "base_transaction": "",
-    "eas_uid": "",
+    "github_commit": "https://github.com/jsonwisdom/COMPUTERWISDOM/commit/a61d71d3ecfc61c053ab11692a44b31e13654d23",
+    "github_issue_or_pr": "https://github.com/jsonwisdom/COMPUTERWISDOM/pull/225",
+    "base_transaction": "0x80a8f29114eaeab0f97e4da405dab42504844fe6d37801829e29ef195ae0b6b6",
+    "eas_uid": "0x6e46a27bf0feef3a89db1f235a9d6c7cc8b402f4d2a73e10933357acbf1963e4",
     "archive_uri": ""
   },
   "routing_layers": {
@@ -17,10 +17,10 @@
     "other_routes": []
   },
   "replay_steps": [
-    "Fetch canonical claim_text from github_commit after merge",
+    "Fetch canonical claim_text from github_commit",
     "Recompute claim_hash and match",
     "Verify source PR and merged file on master",
-    "Verify Base transaction when supplied",
+    "Verify Base transaction and EAS UID",
     "Verify archive_uri when supplied",
     "Classify replayability status"
   ],
@@ -30,9 +30,10 @@
     "partial_evidence": "trigger_recovery"
   },
   "classification": {
-    "status": "MAINTAIN",
+    "status": "ANCHORED",
     "promotion_allowed": false,
-    "authority": false
+    "authority": false,
+    "reason": "GitHub evidence and Base/EAS anchor are present. Archive layer remains pending."
   },
   "parent_leaf": "PROOF_FOR_THE_PRESIDENT_001",
   "protocol_version": "v1",

--- a/verifier_chains/proof_for_the_president_002_verifier_chain_v1.json
+++ b/verifier_chains/proof_for_the_president_002_verifier_chain_v1.json
@@ -1,0 +1,22 @@
+{
+  "artifact": "COMPUTERWISDOM_REPLAY_VERIFIER_CHAIN_V1",
+  "claim_hash": "sha256:52324d1cb3f1599ce191657a9c11de7948667c2d47e949c6a2a7722673999271",
+  "packet_id": "PROOF_FOR_THE_PRESIDENT_002",
+  "verifications": [
+    {
+      "verifier_id": "verifier:computerwisdom-session-operator-v1",
+      "verification_timestamp": "2026-06-03T14:50:00Z",
+      "verification_mode": "OPERATOR_REPORTED",
+      "output_classification": {
+        "status": "ANCHORED",
+        "promotion_allowed": false,
+        "reason": "GitHub evidence and Base/EAS anchor receipt are present. Archive layer remains pending. Authority remains false."
+      },
+      "replay_result": {
+        "reconstructable": true,
+        "survival_test": "NOT_RUN"
+      }
+    }
+  ],
+  "authority": false
+}


### PR DESCRIPTION
Add verifier chain v1 for PROOF_FOR_THE_PRESIDENT_002.

Links packet, replay state, and verified Base anchor into append-only public history.

Authority remains false.