### PR TITLE
Add RUN_REPLAY_002 report template

### DIFF
--- a/reports/run_replay_002_report_v0_1.json
+++ b/reports/run_replay_002_report_v0_1.json
@@ -1,0 +1,20 @@
+{
+  "artifact": "RUN_REPLAY_002_REPORT_TEMPLATE",
+  "leaf_id": "PROOF_FOR_THE_PRESIDENT_002",
+  "replay_audit_id": null,
+  "verification_metadata": {
+    "commit_sha": "099b16259745e1da02f80d4447a2d63a4b0b59ec",
+    "timestamp_utc": null
+  },
+  "protocol_results": {
+    "evidence_hash_validated": null,
+    "on_chain_anchor_verified": null,
+    "replay_sequence_status": "PENDING"
+  },
+  "final_classification": {
+    "status": "FULLY_REPLAYABLE_CANDIDATE",
+    "promotion_allowed": false,
+    "authority": false
+  },
+  "verifier_signature": null
+}


### PR DESCRIPTION
Adds the scaffolding RUN_REPLAY_002_REPORT_TEMPLATE to the reports/ directory to support future audit workflows for Leaf 002.

- Status: FULLY_REPLAYABLE_CANDIDATE
- Purpose: Provides the schema for documenting verification steps: evidence hash, on-chain anchor, replay sequence.
- Constraints: authority is false. This PR is limited to template addition; no protocol execution or data retrieval has occurred.

Post-merge verification checklist:
- [ ] Confirm reports/run_replay_002_report_v0_1.json exists in the repository.
- [ ] Confirm the file structure matches the RUN_REPLAY_002_REPORT_TEMPLATE specification exactly.
- [ ] Confirm protocol result fields are null and status is FULLY_REPLAYABLE_CANDIDATE.
- [ ] Confirm no unrelated files or protocol logic modifications were included.
- [ ] Confirm authority remains false.