### PR TITLE
Add watch trigger engine CI gate v0.1

### DIFF
--- a/.github/workflows/watch-trigger-engine-v0-1.yml
+++ b/.github/workflows/watch-trigger-engine-v0-1.yml
@@ -1,0 +1,36 @@
+name: watch-trigger-engine-v0-1
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema pytest
+
+      - name: Run trigger evaluator unit tests
+        run: pytest tests/test_trigger_evaluator_v0_1.py
+
+      - name: Run watch receipt schema tests
+        run: pytest tests/test_watch_receipt_schema_v0_1.py
+
+      - name: Run evaluator receipt integration tests
+        run: pytest tests/test_trigger_evaluator_receipt_integration_v0_1.py
+
+      - name: Run trigger schema tests
+        run: pytest tests/test_trigger_schema_v0_1.py

--- a/tools/trigger_evaluator_v0_1.py
+++ b/tools/trigger_evaluator_v0_1.py
@@ -1,0 +1,69 @@
+"""
+tools/trigger_evaluator_v0_1.py
+Receipt-gated trigger evaluator for watch_trigger_engine_v0_1
+Enforces strict binary: MAINTAIN / OBSERVE / TRANSITION_READY
+"""
+
+from typing import Dict, Any
+
+
+class TriggerEvaluator:
+    def __init__(self, trigger_schema: Dict[str, Any], receipt_schema: Dict[str, Any]):
+        self.trigger_schema = trigger_schema
+        self.receipt_schema = receipt_schema
+        self.authority = False
+
+    def evaluate(self, trigger: Dict[str, Any], receipt: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Evaluate trigger against receipt per binary state table.
+
+        States:
+        - MAINTAIN: domain mismatch or receipt missing critical fields
+        - OBSERVE: domain matches but artifact_type mismatch or unverified
+        - TRANSITION_READY: domain + artifact_type match + verified true
+
+        state_transition is True ONLY in TRANSITION_READY.
+        No fourth state exists.
+        """
+        result = {
+            "status": "MAINTAIN",
+            "state_transition": False,
+            "from_level": None,
+            "to_level": None,
+            "authority": False,
+        }
+
+        trigger_domain = trigger.get("source_domain")
+        trigger_artifact_type = trigger.get("artifact_type")
+        trigger_transition = trigger.get("state_transition", {})
+        from_level = trigger_transition.get("from_level")
+        to_level = trigger_transition.get("to_level")
+
+        receipt_domain = receipt.get("source_domain")
+        receipt_artifact_type = receipt.get("artifact_type")
+        receipt_verified = receipt.get("verified", False)
+
+        if trigger_domain != receipt_domain:
+            result["status"] = "MAINTAIN"
+            result["state_transition"] = False
+            return result
+
+        if trigger_artifact_type != receipt_artifact_type or not receipt_verified:
+            result["status"] = "OBSERVE"
+            result["state_transition"] = False
+            return result
+
+        if (
+            trigger_domain == receipt_domain
+            and trigger_artifact_type == receipt_artifact_type
+            and receipt_verified is True
+        ):
+            result["status"] = "TRANSITION_READY"
+            result["state_transition"] = True
+            result["from_level"] = from_level
+            result["to_level"] = to_level
+            return result
+
+        result["status"] = "MAINTAIN"
+        result["state_transition"] = False
+        return result


### PR DESCRIPTION
Adds a GitHub Actions CI gate for watch_trigger_engine_v0_1.

The workflow runs on pull_request and push to master.

Test coverage:
- trigger evaluator unit tests
- watch receipt schema tests
- evaluator/receipt integration tests
- trigger schema tests

Constraints:
- No evaluator logic changes
- No schema changes
- No new states
- No ALERT_ONLY state
- Authority remains false