### PR TITLE
Admit Evidence Rendering Schema (ERS) V0.1

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - feature/computerwisdom-alms-runtime-runway-v0-1
       - protocol/v0_1-admission
+      - protocol/ers-v0_1
 
 permissions:
   contents: read

--- a/docs/ers_v0_1.md
+++ b/docs/ers_v0_1.md
@@ -1,0 +1,163 @@
+---
+artifact_id: ERS_V0_1
+artifact_type: protocol
+schema_version: ERS_V0_1
+status: PROPOSED
+lineage_root: f5c98f688296d1cece1cb8ac6635421384756f00
+constitutional_root: 808f2b1c6c339eb46e68a2161da3cca22f7b0eeb
+authority: false
+authority_boundary: NONE
+authority_proof_context: ERS defines structure only and grants no authority, truth, adjudication, execution rights, or institutional privilege.
+admission_manifest: 238
+---
+
+# Evidence Rendering Schema V0.1
+
+**Status:** PROPOSED  
+**Authority:** false  
+**Authority Boundary:** NONE  
+**Lineage Root:** `f5c98f688296d1cece1cb8ac6635421384756f00`  
+**Constitutional Root:** `808f2b1c6c339eb46e68a2161da3cca22f7b0eeb`  
+**Admission Manifest:** Issue #238
+
+---
+
+## Purpose
+
+ERS V0.1 defines the canonical evidence representation used by Computer Wisdom replay, observation, and rendering systems.
+
+ERS defines structure.
+
+ERS does not determine truth.
+
+ERS does not perform adjudication.
+
+ERS does not grant authority.
+
+---
+
+## Core Invariant
+
+> Every rendered conclusion must carry replayable lineage.
+
+---
+
+## Required Structural Block
+
+Every ERS object must include:
+
+```json
+{
+  "artifact_type": "string",
+  "artifact_id": "string",
+  "timestamp": "ISO8601",
+  "lineage_root": "parent_admitted_artifact",
+  "constitutional_root": "808f2b1c6c339eb46e68a2161da3cca22f7b0eeb",
+  "schema_version": "ERS_V0_1",
+  "authority": false,
+  "authority_boundary": "NONE",
+  "hash": "sha256_checksum"
+}
+```
+
+---
+
+## Object Types
+
+ERS V0.1 defines five object types:
+
+1. `event`
+2. `observation`
+3. `dispute`
+4. `adjudication`
+5. `protocol`
+
+---
+
+## Field Semantics
+
+### artifact_type
+
+The category of ERS object.
+
+Allowed values:
+
+- event
+- observation
+- dispute
+- adjudication
+- protocol
+
+### artifact_id
+
+A stable identifier for the artifact.
+
+### timestamp
+
+The ISO8601 timestamp associated with artifact creation or recording.
+
+### lineage_root
+
+The immediate admitted parent artifact, commit, or merge reference.
+
+### constitutional_root
+
+The Constitutional Baseline V1 merge commit:
+
+```text
+808f2b1c6c339eb46e68a2161da3cca22f7b0eeb
+```
+
+### schema_version
+
+Must equal:
+
+```text
+ERS_V0_1
+```
+
+### authority
+
+Must equal:
+
+```json
+false
+```
+
+### authority_boundary
+
+Must equal:
+
+```text
+NONE
+```
+
+### hash
+
+A SHA-256 checksum of the canonical artifact payload.
+
+---
+
+## Non-Claims
+
+ERS does not claim that evidence is true.
+
+ERS does not adjudicate disputes.
+
+ERS does not create execution rights.
+
+ERS does not grant institutional authority.
+
+ERS only defines structure for replayable evidence representation.
+
+---
+
+## Revision Rule
+
+ERS changes must version forward.
+
+Prior schema versions must remain preserved.
+
+No expiry gate is used.
+
+Authority: false.

--- a/examples/adjudication_example.json
+++ b/examples/adjudication_example.json
@@ -1,0 +1,19 @@
+{
+  "artifact_type": "adjudication",
+  "artifact_id": "ers-adjudication-example-v0-1",
+  "timestamp": "2026-06-04T13:43:00Z",
+  "lineage_root": "f5c98f688296d1cece1cb8ac6635421384756f00",
+  "constitutional_root": "808f2b1c6c339eb46e68a2161da3cca22f7b0eeb",
+  "schema_version": "ERS_V0_1",
+  "authority": false,
+  "authority_boundary": "NONE",
+  "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000004",
+  "source": "example",
+  "metadata": {
+    "purpose": "example adjudication object"
+  },
+  "payload": {
+    "target_dispute": "ers-dispute-example-v0-1",
+    "resolution": "example resolution record only; no truth claim"
+  }
+}

--- a/examples/dispute_example.json
+++ b/examples/dispute_example.json
@@ -1,0 +1,19 @@
+{
+  "artifact_type": "dispute",
+  "artifact_id": "ers-dispute-example-v0-1",
+  "timestamp": "2026-06-04T13:42:00Z",
+  "lineage_root": "f5c98f688296d1cece1cb8ac6635421384756f00",
+  "constitutional_root": "808f2b1c6c339eb46e68a2161da3cca22f7b0eeb",
+  "schema_version": "ERS_V0_1",
+  "authority": false,
+  "authority_boundary": "NONE",
+  "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000003",
+  "source": "example",
+  "metadata": {
+    "purpose": "example dispute object"
+  },
+  "payload": {
+    "target_artifact": "ers-observation-example-v0-1",
+    "dispute_reason": "example challenge only; no truth claim"
+  }
+}

--- a/examples/event_example.json
+++ b/examples/event_example.json
@@ -1,0 +1,18 @@
+{
+  "artifact_type": "event",
+  "artifact_id": "ers-event-example-v0-1",
+  "timestamp": "2026-06-04T13:40:00Z",
+  "lineage_root": "f5c98f688296d1cece1cb8ac6635421384756f00",
+  "constitutional_root": "808f2b1c6c339eb46e68a2161da3cca22f7b0eeb",
+  "schema_version": "ERS_V0_1",
+  "authority": false,
+  "authority_boundary": "NONE",
+  "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+  "source": "example",
+  "metadata": {
+    "purpose": "example event object"
+  },
+  "payload": {
+    "event_name": "example_event_recorded"
+  }
+}

--- a/examples/observation_example.json
+++ b/examples/observation_example.json
@@ -1,0 +1,19 @@
+{
+  "artifact_type": "observation",
+  "artifact_id": "ers-observation-example-v0-1",
+  "timestamp": "2026-06-04T13:41:00Z",
+  "lineage_root": "f5c98f688296d1cece1cb8ac6635421384756f00",
+  "constitutional_root": "808f2b1c6c339eb46e68a2161da3cca22f7b0eeb",
+  "schema_version": "ERS_V0_1",
+  "authority": false,
+  "authority_boundary": "NONE",
+  "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000002",
+  "source": "example",
+  "metadata": {
+    "purpose": "example observation object"
+  },
+  "payload": {
+    "observer": "example-observer",
+    "observed_artifact": "ers-event-example-v0-1"
+  }
+}

--- a/examples/protocol_example.json
+++ b/examples/protocol_example.json
@@ -1,0 +1,19 @@
+{
+  "artifact_type": "protocol",
+  "artifact_id": "ers-protocol-example-v0-1",
+  "timestamp": "2026-06-04T13:44:00Z",
+  "lineage_root": "f5c98f688296d1cece1cb8ac6635421384756f00",
+  "constitutional_root": "808f2b1c6c339eb46e68a2161da3cca22f7b0eeb",
+  "schema_version": "ERS_V0_1",
+  "authority": false,
+  "authority_boundary": "NONE",
+  "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000005",
+  "source": "example",
+  "metadata": {
+    "purpose": "example protocol object"
+  },
+  "payload": {
+    "protocol_name": "ERS_V0_1",
+    "version": "0.1"
+  }
+}

--- a/schemas/ers.v0_1.schema.json
+++ b/schemas/ers.v0_1.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/ers.v0_1.schema.json",
+  "title": "Evidence Rendering Schema V0.1",
+  "description": "Canonical ERS_V0_1 object schema. Defines structure only. Authority false with NONE boundary required.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "timestamp",
+    "lineage_root",
+    "constitutional_root",
+    "schema_version",
+    "authority",
+    "authority_boundary",
+    "hash"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "enum": ["event", "observation", "dispute", "adjudication", "protocol"]
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "lineage_root": {
+      "type": "string",
+      "minLength": 1
+    },
+    "constitutional_root": {
+      "const": "808f2b1c6c339eb46e68a2161da3cca22f7b0eeb"
+    },
+    "schema_version": {
+      "const": "ERS_V0_1"
+    },
+    "authority": {
+      "const": false
+    },
+    "authority_boundary": {
+      "const": "NONE"
+    },
+    "hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-fA-F0-9]{64}$"
+    },
+    "source": {
+      "type": ["string", "null"]
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}

--- a/tests/test_ers_v0_1_schema.py
+++ b/tests/test_ers_v0_1_schema.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schemas" / "ers.v0_1.schema.json"
+EXAMPLES_DIR = ROOT / "examples"
+
+EXPECTED_SCHEMA_VERSION = "ERS_V0_1"
+EXPECTED_CONSTITUTIONAL_ROOT = "808f2b1c6c339eb46e68a2161da3cca22f7b0eeb"
+EXPECTED_AUTHORITY = False
+EXPECTED_AUTHORITY_BOUNDARY = "NONE"
+
+REPLAY_CRITICAL_FIELDS = {
+    "artifact_id",
+    "artifact_type",
+    "timestamp",
+    "lineage_root",
+    "constitutional_root",
+    "schema_version",
+    "hash",
+}
+
+GOVERNANCE_FIELDS = {
+    "authority",
+    "authority_boundary",
+}
+
+EXAMPLE_FILES = [
+    "event_example.json",
+    "observation_example.json",
+    "dispute_example.json",
+    "adjudication_example.json",
+    "protocol_example.json",
+]
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_schema_declares_required_replay_and_governance_fields():
+    schema = load_json(SCHEMA_PATH)
+    required = set(schema["required"])
+
+    assert REPLAY_CRITICAL_FIELDS.issubset(required)
+    assert GOVERNANCE_FIELDS.issubset(required)
+
+    assert schema["properties"]["schema_version"]["const"] == EXPECTED_SCHEMA_VERSION
+    assert schema["properties"]["constitutional_root"]["const"] == EXPECTED_CONSTITUTIONAL_ROOT
+    assert schema["properties"]["authority"]["const"] is EXPECTED_AUTHORITY
+    assert schema["properties"]["authority_boundary"]["const"] == EXPECTED_AUTHORITY_BOUNDARY
+
+
+def test_examples_validate_against_schema():
+    schema = load_json(SCHEMA_PATH)
+    validator = jsonschema.Draft202012Validator(schema)
+
+    for filename in EXAMPLE_FILES:
+        artifact = load_json(EXAMPLES_DIR / filename)
+        errors = sorted(validator.iter_errors(artifact), key=lambda error: error.path)
+        assert not errors, f"{filename} failed ERS_V0_1 schema validation: {errors}"
+
+
+def test_examples_preserve_replay_and_governance_boundary():
+    for filename in EXAMPLE_FILES:
+        artifact = load_json(EXAMPLES_DIR / filename)
+
+        for field in REPLAY_CRITICAL_FIELDS:
+            assert field in artifact, f"{filename} missing replay-critical field: {field}"
+
+        for field in GOVERNANCE_FIELDS:
+            assert field in artifact, f"{filename} missing governance field: {field}"
+
+        assert artifact["schema_version"] == EXPECTED_SCHEMA_VERSION
+        assert artifact["constitutional_root"] == EXPECTED_CONSTITUTIONAL_ROOT
+        assert artifact["authority"] is EXPECTED_AUTHORITY
+        assert artifact["authority_boundary"] == EXPECTED_AUTHORITY_BOUNDARY


### PR DESCRIPTION
## Admission Object

This PR admits `ERS_V0_1` through the repository governance path.

Implements Admission Manifest #238.

## Final Branch Commit

`c2dac1f76d453380a6917d1c2f412b17ec53c6d6`

## Lineage Root

`f5c98f688296d1cece1cb8ac6635421384756f00`

## Constitutional Root

`808f2b1c6c339eb46e68a2161da3cca22f7b0eeb`

## Authority Boundary

```yaml
authority: false
authority_boundary: NONE
authority_proof_context: ERS defines structure only and grants no authority, truth, adjudication, execution rights, or institutional privilege.
```

## Deliverables

- `docs/ers_v0_1.md`
- `schemas/ers.v0_1.schema.json`
- `examples/event_example.json`
- `examples/observation_example.json`
- `examples/dispute_example.json`
- `examples/adjudication_example.json`
- `examples/protocol_example.json`
- `tests/test_ers_v0_1_schema.py`

## Core Invariant

Every rendered conclusion must carry replayable lineage.

## Authority

false

Closes #238.