### PR TITLE
Admit DISPUTE_PROTOCOL_V0_1

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,6 +10,7 @@ on:
       - protocol/v0_1-admission
       - protocol/ers-v0_1
       - protocol/replay-kernel-v0_1
+      - protocol/dispute-protocol-v0_1
 
 permissions:
   contents: read

--- a/docs/dispute_protocol_v0_1.md
+++ b/docs/dispute_protocol_v0_1.md
@@ -1,0 +1,111 @@
+---
+artifact_id: DISPUTE_PROTOCOL_V0_1
+artifact_type: protocol
+status: PROPOSED
+lineage_root: 57bea5c3d116bc5fa267d3e2da98626fb6ed50c6
+constitutional_root: 808f2b1c6c339eb46e68a2161da3cca22f7b0eeb
+authority: false
+authority_boundary: NONE
+authority_proof_context: Dispute Protocol defines structural dispute attachment only and grants no authority, truth, adjudication, semantic correctness, execution rights, or institutional privilege.
+admission_manifest: 242
+---
+
+# Dispute Protocol V0.1
+
+**Status:** PROPOSED  
+**Authority:** false  
+**Authority Boundary:** NONE  
+**Lineage Root:** `57bea5c3d116bc5fa267d3e2da98626fb6ed50c6`  
+**Constitutional Root:** `808f2b1c6c339eb46e68a2161da3cca22f7b0eeb`  
+**Admission Manifest:** Issue #242
+
+---
+
+## Purpose
+
+Dispute Protocol V0.1 defines how disputes attach to `ERS_V0_1` artifacts and `REPLAY_TRACE_V0_1` traces.
+
+Disputes are first-class records.
+
+Disputes reference contested content.
+
+Disputes do not mutate prior records.
+
+Disputes do not assert truth.
+
+Disputes do not adjudicate.
+
+Disputes do not grant authority.
+
+---
+
+## Core Invariant
+
+> Disputes reference structure and lineage only.
+
+No truth adjudication.
+
+No authority escalation.
+
+No semantic resolution.
+
+---
+
+## Required Fields
+
+A `DISPUTE_V0_1` record must include:
+
+- dispute_id
+- target_artifact_id or target_trace_id
+- dispute_type
+- dispute_reason
+- timestamp
+- lineage_root
+- constitutional_root
+- schema_version
+- authority
+- authority_boundary
+- hash
+
+---
+
+## Structural Rules
+
+A dispute attaches to a target by reference only.
+
+A dispute does not modify its target.
+
+A dispute is additive.
+
+A dispute may be replayed alongside its target.
+
+A dispute may be superseded by future versioned artifacts, but prior dispute records remain preserved.
+
+---
+
+## Non-Goals
+
+Dispute Protocol V0.1 does not:
+
+- validate real-world truth
+- score credibility
+- resolve disputes
+- perform adjudication
+- mutate ERS artifacts
+- mutate replay traces
+- erase contested content
+- grant authority
+- infer semantic correctness
+
+---
+
+## Authority Boundary
+
+```yaml
+authority: false
+authority_boundary: NONE
+```
+
+The protocol records contestation only.
+
+**Authority:** false

--- a/examples/dispute_example_v0_1.json
+++ b/examples/dispute_example_v0_1.json
@@ -1,0 +1,13 @@
+{
+  "dispute_id": "dispute-v0-1-example",
+  "target_artifact_id": "ers-event-example-v0-1",
+  "dispute_type": "lineage_reference",
+  "dispute_reason": "Reference preserved without modifying target artifact.",
+  "timestamp": "2026-06-04T00:00:00Z",
+  "lineage_root": "57bea5c3d116bc5fa267d3e2da98626fb6ed50c6",
+  "constitutional_root": "808f2b1c6c339eb46e68a2161da3cca22f7b0eeb",
+  "schema_version": "DISPUTE_V0_1",
+  "authority": false,
+  "authority_boundary": "NONE",
+  "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/schemas/dispute.v0_1.schema.json
+++ b/schemas/dispute.v0_1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DISPUTE_V0_1",
+  "type": "object",
+  "required": [
+    "dispute_id",
+    "timestamp",
+    "lineage_root",
+    "constitutional_root",
+    "schema_version",
+    "authority",
+    "authority_boundary",
+    "hash"
+  ],
+  "properties": {
+    "dispute_id": {"type": "string"},
+    "target_artifact_id": {"type": "string"},
+    "target_trace_id": {"type": "string"},
+    "dispute_type": {"type": "string"},
+    "dispute_reason": {"type": "string"},
+    "timestamp": {"type": "string"},
+    "lineage_root": {"type": "string"},
+    "constitutional_root": {
+      "type": "string",
+      "const": "808f2b1c6c339eb46e68a2161da3cca22f7b0eeb"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "DISPUTE_V0_1"
+    },
+    "authority": {
+      "type": "boolean",
+      "const": false
+    },
+    "authority_boundary": {
+      "type": "string",
+      "const": "NONE"
+    },
+    "hash": {"type": "string"}
+  },
+  "anyOf": [
+    {"required": ["target_artifact_id"]},
+    {"required": ["target_trace_id"]}
+  ]
+}

--- a/src/dispute_protocol_v0_1.py
+++ b/src/dispute_protocol_v0_1.py
@@ -1,0 +1,54 @@
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import jsonschema
+
+SCHEMA_VERSION = "DISPUTE_V0_1"
+CONSTITUTIONAL_ROOT = "808f2b1c6c339eb46e68a2161da3cca22f7b0eeb"
+AUTHORITY = False
+AUTHORITY_BOUNDARY = "NONE"
+
+
+def load_json(path: str | Path) -> Dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def validate_dispute(dispute: Dict[str, Any], schema: Dict[str, Any]) -> None:
+    jsonschema.Draft202012Validator(schema).validate(dispute)
+    if dispute["schema_version"] != SCHEMA_VERSION:
+        raise ValueError("unsupported schema_version")
+    if dispute["constitutional_root"] != CONSTITUTIONAL_ROOT:
+        raise ValueError("constitutional_root mismatch")
+    if dispute["authority"] is not AUTHORITY:
+        raise ValueError("authority must be false")
+    if dispute["authority_boundary"] != AUTHORITY_BOUNDARY:
+        raise ValueError("authority_boundary must be NONE")
+    if not dispute.get("target_artifact_id") and not dispute.get("target_trace_id"):
+        raise ValueError("dispute requires target_artifact_id or target_trace_id")
+
+
+def attach_dispute(target: Dict[str, Any], dispute: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
+    original_target = copy.deepcopy(target)
+    validate_dispute(dispute, schema)
+    envelope = {
+        "target": copy.deepcopy(target),
+        "dispute": copy.deepcopy(dispute),
+        "attachment_type": "additive_reference",
+        "authority": AUTHORITY,
+        "authority_boundary": AUTHORITY_BOUNDARY,
+    }
+    if target != original_target:
+        raise ValueError("target mutation detected")
+    return envelope

--- a/tests/test_dispute_protocol_v0_1.py
+++ b/tests/test_dispute_protocol_v0_1.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+import jsonschema
+
+from src.dispute_protocol_v0_1 import attach_dispute, validate_dispute
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = json.load(open(ROOT / 'schemas' / 'dispute.v0_1.schema.json', encoding='utf-8'))
+
+
+def load_example():
+    return json.load(open(ROOT / 'examples' / 'dispute_example_v0_1.json', encoding='utf-8'))
+
+
+def test_example_validates_against_schema():
+    dispute = load_example()
+    jsonschema.Draft202012Validator(SCHEMA).validate(dispute)
+
+
+def test_boundary_fields_enforced():
+    dispute = load_example()
+    validate_dispute(dispute, SCHEMA)
+    assert dispute['schema_version'] == 'DISPUTE_V0_1'
+    assert dispute['authority'] is False
+    assert dispute['authority_boundary'] == 'NONE'
+
+
+def test_attachment_is_additive_and_non_mutating():
+    target = {'artifact_id': 'ers-event-example-v0-1'}
+    dispute = load_example()
+    original = dict(target)
+
+    envelope = attach_dispute(target, dispute, SCHEMA)
+
+    assert target == original
+    assert envelope['attachment_type'] == 'additive_reference'
+    assert envelope['dispute']['dispute_id'] == dispute['dispute_id']
+
+
+def test_target_reference_exists_as_string():
+    dispute = load_example()
+    assert isinstance(dispute['target_artifact_id'], str)


### PR DESCRIPTION
## Admission Object

This PR admits `DISPUTE_PROTOCOL_V0_1` through the repository governance path.

Implements Admission Manifest #242.

## Final Branch Commit

`de1ad97357446f049d01fdbc50ed6b45a51e0333`

## Lineage Root

`57bea5c3d116bc5fa267d3e2da98626fb6ed50c6`

## Constitutional Root

`808f2b1c6c339eb46e68a2161da3cca22f7b0eeb`

## Authority Boundary

```yaml
authority: false
authority_boundary: NONE
authority_proof_context: Dispute Protocol defines structural dispute attachment only and grants no authority, truth, adjudication, semantic correctness, execution rights, or institutional privilege.
```

## Deliverables

- `docs/dispute_protocol_v0_1.md`
- `schemas/dispute.v0_1.schema.json`
- `src/dispute_protocol_v0_1.py`
- `examples/dispute_example_v0_1.json`
- `tests/test_dispute_protocol_v0_1.py`

## Core Invariant

Disputes are first-class records. They reference, never mutate.

No truth claims. No authority.

## Authority

false

Closes #242.