### PR TITLE
Add Authority Replay MVP scaffold

### DIFF
--- a/artifacts/AUTHORITY_REPLAY_MVP/README.md
+++ b/artifacts/AUTHORITY_REPLAY_MVP/README.md
@@ -1,0 +1,81 @@
+# Authority Replay MVP
+
+**Tagline:** Don’t log the agent. Replay the authority.
+
+Authority Replay is a verification game for agent teams. It trains humans and agents to distinguish action logs from authorization receipts.
+
+GitHub-style stacks often show:
+
+```text
+User → Agent → Tool → Action
+```
+
+Evidence-grade stacks require:
+
+```text
+User → Policy → Agent → Tool → Action
+```
+
+## Goal
+
+Promote this claim only when the full receipt chain exists:
+
+```yaml
+claim: agent_action_authorized
+from: UNOBSERVED
+to: OBSERVED
+```
+
+Required chain:
+
+```yaml
+required_receipt_chain:
+  - user_identity_receipt
+  - policy_receipt
+  - delegation_receipt
+  - revocation_status_receipt
+  - agent_action_receipt
+  - tool_execution_receipt
+```
+
+Forbidden substitutes:
+
+```yaml
+forbidden:
+  - action_log_only
+  - agent_identity_only
+  - approval_screenshot_only
+```
+
+## Files
+
+```text
+AUTHORITY_REPLAY_MVP/
+├── README.md
+├── policy.schema.json
+├── receipt.schema.json
+├── scoring.yaml
+├── valid_chain.json
+├── expired_delegation.json
+└── replay_engine.py
+```
+
+## Run
+
+```bash
+python artifacts/AUTHORITY_REPLAY_MVP/replay_engine.py artifacts/AUTHORITY_REPLAY_MVP/valid_chain.json
+python artifacts/AUTHORITY_REPLAY_MVP/replay_engine.py artifacts/AUTHORITY_REPLAY_MVP/expired_delegation.json
+```
+
+Expected:
+
+```text
+valid_chain.json -> OBSERVED
+expired_delegation.json -> UNOBSERVED
+```
+
+## xAI Pitch
+
+Truth-seeking agents should not only explain what happened. They should prove whether the action was authorized when it happened.
+
+Grok can explain the event. Authority Replay verifies the authority.

--- a/artifacts/AUTHORITY_REPLAY_MVP/expired_delegation.json
+++ b/artifacts/AUTHORITY_REPLAY_MVP/expired_delegation.json
@@ -1,0 +1,40 @@
+{
+  "receipt_id": "EXPIRED_CHAIN_001",
+  "user_identity_receipt": {
+    "user_id": "jay",
+    "verified": true
+  },
+  "policy_receipt": {
+    "policy_id": "POLICY_EXPIRED_001",
+    "issuer": "jay",
+    "subject": "agent_authority_replay_builder",
+    "allowed": {
+      "repo": "jsonwisdom/COMPUTERWISDOM",
+      "path": "artifacts/AUTHORITY_REPLAY_MVP/README.md",
+      "action": "edit",
+      "max_lines_changed": 20
+    },
+    "expires_at": "2025-01-01T00:00:00Z",
+    "revoked": false
+  },
+  "delegation_receipt": {
+    "delegated_to": "agent_authority_replay_builder",
+    "policy_id": "POLICY_EXPIRED_001"
+  },
+  "revocation_status_receipt": {
+    "revoked": false,
+    "checked_at": "2026-06-05T16:30:00Z"
+  },
+  "agent_action_receipt": {
+    "agent_id": "agent_authority_replay_builder",
+    "action": "edit",
+    "repo": "jsonwisdom/COMPUTERWISDOM",
+    "path": "artifacts/AUTHORITY_REPLAY_MVP/README.md",
+    "lines_changed": 12,
+    "executed_at": "2026-06-05T16:31:00Z"
+  },
+  "tool_execution_receipt": {
+    "tool": "GitHub.create_file",
+    "status": "success"
+  }
+}

--- a/artifacts/AUTHORITY_REPLAY_MVP/policy.schema.json
+++ b/artifacts/AUTHORITY_REPLAY_MVP/policy.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "AUTHORITY_REPLAY_POLICY_SCHEMA_V0_1",
+  "type": "object",
+  "required": ["policy_id", "issuer", "subject", "allowed", "expires_at", "revoked"],
+  "additionalProperties": false,
+  "properties": {
+    "policy_id": { "type": "string" },
+    "issuer": { "type": "string" },
+    "subject": { "type": "string" },
+    "allowed": {
+      "type": "object",
+      "required": ["repo", "path", "action", "max_lines_changed"],
+      "additionalProperties": false,
+      "properties": {
+        "repo": { "type": "string" },
+        "path": { "type": "string" },
+        "action": { "type": "string" },
+        "max_lines_changed": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "revoked": { "type": "boolean" }
+  }
+}

--- a/artifacts/AUTHORITY_REPLAY_MVP/receipt.schema.json
+++ b/artifacts/AUTHORITY_REPLAY_MVP/receipt.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "AUTHORITY_REPLAY_RECEIPT_SCHEMA_V0_1",
+  "type": "object",
+  "required": [
+    "receipt_id",
+    "user_identity_receipt",
+    "policy_receipt",
+    "delegation_receipt",
+    "revocation_status_receipt",
+    "agent_action_receipt",
+    "tool_execution_receipt"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "receipt_id": { "type": "string" },
+    "user_identity_receipt": { "type": "object" },
+    "policy_receipt": { "type": "object" },
+    "delegation_receipt": { "type": "object" },
+    "revocation_status_receipt": {
+      "type": "object",
+      "required": ["revoked", "checked_at"],
+      "properties": {
+        "revoked": { "type": "boolean" },
+        "checked_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "agent_action_receipt": {
+      "type": "object",
+      "required": ["agent_id", "action", "repo", "path", "lines_changed", "executed_at"],
+      "properties": {
+        "agent_id": { "type": "string" },
+        "action": { "type": "string" },
+        "repo": { "type": "string" },
+        "path": { "type": "string" },
+        "lines_changed": { "type": "integer", "minimum": 0 },
+        "executed_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "tool_execution_receipt": {
+      "type": "object",
+      "required": ["tool", "status"],
+      "properties": {
+        "tool": { "type": "string" },
+        "status": { "type": "string" }
+      }
+    }
+  }
+}

--- a/artifacts/AUTHORITY_REPLAY_MVP/replay_engine.py
+++ b/artifacts/AUTHORITY_REPLAY_MVP/replay_engine.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Authority Replay MVP.
+
+Validates whether an agent action has a replayable authority chain.
+This is intentionally small and dependency-free.
+"""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REQUIRED_RECEIPTS = [
+    "user_identity_receipt",
+    "policy_receipt",
+    "delegation_receipt",
+    "revocation_status_receipt",
+    "agent_action_receipt",
+    "tool_execution_receipt",
+]
+
+
+def parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def evaluate(receipt: dict) -> dict:
+    missing = [key for key in REQUIRED_RECEIPTS if key not in receipt]
+    if missing:
+        return {"status": "UNOBSERVED", "reason": "missing_receipts", "missing": missing}
+
+    policy = receipt["policy_receipt"]
+    action = receipt["agent_action_receipt"]
+    revocation = receipt["revocation_status_receipt"]
+    delegation = receipt["delegation_receipt"]
+    tool = receipt["tool_execution_receipt"]
+
+    if not receipt["user_identity_receipt"].get("verified", False):
+        return {"status": "UNOBSERVED", "reason": "user_identity_not_verified"}
+
+    if policy.get("revoked", False) or revocation.get("revoked", False):
+        return {"status": "UNOBSERVED", "reason": "policy_revoked"}
+
+    if delegation.get("policy_id") != policy.get("policy_id"):
+        return {"status": "UNOBSERVED", "reason": "delegation_policy_mismatch"}
+
+    if delegation.get("delegated_to") != action.get("agent_id"):
+        return {"status": "UNOBSERVED", "reason": "delegated_agent_mismatch"}
+
+    executed_at = parse_time(action["executed_at"])
+    expires_at = parse_time(policy["expires_at"])
+    if executed_at > expires_at:
+        return {"status": "UNOBSERVED", "reason": "policy_expired"}
+
+    allowed = policy["allowed"]
+    for field in ["repo", "path", "action"]:
+        if action.get(field) != allowed.get(field):
+            return {"status": "UNOBSERVED", "reason": f"scope_mismatch:{field}"}
+
+    if action.get("lines_changed", 0) > allowed.get("max_lines_changed", 0):
+        return {"status": "UNOBSERVED", "reason": "line_change_limit_exceeded"}
+
+    if tool.get("status") != "success":
+        return {"status": "UNOBSERVED", "reason": "tool_execution_not_successful"}
+
+    return {"status": "OBSERVED", "reason": "full_authority_chain_valid"}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: replay_engine.py <receipt.json>")
+        return 2
+
+    path = Path(sys.argv[1])
+    receipt = json.loads(path.read_text())
+    result = evaluate(receipt)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["status"] == "OBSERVED" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/artifacts/AUTHORITY_REPLAY_MVP/scoring.yaml
+++ b/artifacts/AUTHORITY_REPLAY_MVP/scoring.yaml
@@ -1,0 +1,34 @@
+id: AUTHORITY_REPLAY_SCORING_V0_1
+authority: false
+
+points:
+  complete_authority_chain: 100
+  valid_revocation_check: 50
+  least_privilege_policy: 40
+  detected_out_of_scope_action: 75
+  action_log_without_policy: -100
+  expired_delegation: -150
+  screenshot_only: -75
+
+levels:
+  - id: actor_log
+    objective: Notice that an action log alone is incomplete.
+  - id: policy_layer
+    objective: Bind a policy receipt to the action.
+  - id: revocation_check
+    objective: Verify delegation status at execution time.
+  - id: scope_check
+    objective: Confirm repo path and action are within policy.
+  - id: multi_agent_chain
+    objective: Replay authority across delegated agents.
+
+win_condition:
+  claim: agent_action_authorized
+  status: OBSERVED
+  requires:
+    - user_identity_receipt
+    - policy_receipt
+    - delegation_receipt
+    - revocation_status_receipt
+    - agent_action_receipt
+    - tool_execution_receipt

--- a/artifacts/AUTHORITY_REPLAY_MVP/valid_chain.json
+++ b/artifacts/AUTHORITY_REPLAY_MVP/valid_chain.json
@@ -1,0 +1,40 @@
+{
+  "receipt_id": "VALID_CHAIN_001",
+  "user_identity_receipt": {
+    "user_id": "jay",
+    "verified": true
+  },
+  "policy_receipt": {
+    "policy_id": "POLICY_README_EDIT_001",
+    "issuer": "jay",
+    "subject": "agent_authority_replay_builder",
+    "allowed": {
+      "repo": "jsonwisdom/COMPUTERWISDOM",
+      "path": "artifacts/AUTHORITY_REPLAY_MVP/README.md",
+      "action": "edit",
+      "max_lines_changed": 20
+    },
+    "expires_at": "2026-06-05T23:59:00Z",
+    "revoked": false
+  },
+  "delegation_receipt": {
+    "delegated_to": "agent_authority_replay_builder",
+    "policy_id": "POLICY_README_EDIT_001"
+  },
+  "revocation_status_receipt": {
+    "revoked": false,
+    "checked_at": "2026-06-05T16:30:00Z"
+  },
+  "agent_action_receipt": {
+    "agent_id": "agent_authority_replay_builder",
+    "action": "edit",
+    "repo": "jsonwisdom/COMPUTERWISDOM",
+    "path": "artifacts/AUTHORITY_REPLAY_MVP/README.md",
+    "lines_changed": 12,
+    "executed_at": "2026-06-05T16:31:00Z"
+  },
+  "tool_execution_receipt": {
+    "tool": "GitHub.create_file",
+    "status": "success"
+  }
+}


### PR DESCRIPTION
Closes #262.

## Summary

Adds the initial Authority Replay MVP scaffold under `artifacts/AUTHORITY_REPLAY_MVP/`.

This implements the core idea from Issue #262:

> GitHub records the actor. Evidence records the authority.
> Don’t log the agent. Replay the authority.

## Included

- `README.md`
- `policy.schema.json`
- `receipt.schema.json`
- `scoring.yaml`
- `valid_chain.json`
- `expired_delegation.json`
- `replay_engine.py`

## Purpose

The MVP validates whether an agent action has a replayable authority chain:

```text
User → Policy → Agent → Tool → Action
```

Expected behavior:

```bash
python artifacts/AUTHORITY_REPLAY_MVP/replay_engine.py artifacts/AUTHORITY_REPLAY_MVP/valid_chain.json
# OBSERVED

python artifacts/AUTHORITY_REPLAY_MVP/replay_engine.py artifacts/AUTHORITY_REPLAY_MVP/expired_delegation.json
# UNOBSERVED
```

## Boundary

This is a verification/training artifact. It does not claim legal, financial, or operational authority.
