### PR TITLE
fix: harden receipt schema - add $schema, $id, evidence enforcement

### DIFF
--- a/schemas/receipt.schema.json
+++ b/schemas/receipt.schema.json
@@ -1,19 +1,111 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/jsonwisdom/COMPUTERWISDOM/schemas/receipt.schema.json",
   "title": "IPE Receipt Manifest",
   "type": "object",
-  "required": ["receipt_id", "document_title", "document_class", "issuing_institution", "source_url", "retrieval_timestamp", "access_method", "hashes", "fragments", "privacy_review", "orphaned_claims"],
+  "additionalProperties": false,
+  "required": [
+    "receipt_id",
+    "document_title",
+    "document_class",
+    "issuing_institution",
+    "source_url",
+    "retrieval_timestamp",
+    "access_method",
+    "hashes",
+    "fragments",
+    "privacy_review",
+    "orphaned_claims"
+  ],
   "properties": {
-    "receipt_id": {"type": "string"},
-    "document_title": {"type": "string"},
-    "document_class": {"type": "string", "enum": ["statute", "charter", "executive_order", "regulation", "ordinance", "policy", "strategic_plan", "mission_statement", "website_copy", "agenda", "minutes", "report", "dataset", "other"]},
-    "issuing_institution": {"type": "string"},
-    "source_url": {"type": "string"},
-    "retrieval_timestamp": {"type": "string"},
-    "access_method": {"type": "string", "enum": ["public_web", "public_records_request", "official_archive", "authorized_api", "physical_inspection", "manual_upload", "other_lawful_access"]},
-    "hashes": {"type": "object", "required": ["sha256"], "properties": {"sha256": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"}}},
-    "fragments": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["fragment_id", "locator", "text"], "properties": {"fragment_id": {"type": "string"}, "locator": {"type": "string"}, "text": {"type": "string"}}}},
-    "privacy_review": {"type": "object", "required": ["private_data_detected", "review_status"], "properties": {"private_data_detected": {"type": "boolean"}, "review_status": {"type": "string", "enum": ["passed", "redaction_required", "excluded"]}, "redaction_method": {"type": "string"}, "notes": {"type": "string"}}},
-    "claims": {"type": "array"},
-    "orphaned_claims": {"type": "integer", "minimum": 0, "maximum": 0}
+    "receipt_id": { "type": "string", "minLength": 1 },
+    "document_title": { "type": "string", "minLength": 1 },
+    "document_class": {
+      "type": "string",
+      "enum": ["statute", "charter", "executive_order", "regulation", "ordinance", "policy", "strategic_plan", "mission_statement", "website_copy", "agenda", "minutes", "report", "dataset", "other"]
+    },
+    "issuing_institution": { "type": "string", "minLength": 1 },
+    "source_url": { "type": "string", "format": "uri" },
+    "retrieval_timestamp": { "type": "string", "format": "date-time" },
+    "access_method": {
+      "type": "string",
+      "enum": ["public_web", "public_records_request", "official_archive", "authorized_api", "physical_inspection", "manual_upload", "other_lawful_access"]
+    },
+    "hashes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha256"],
+      "properties": {
+        "sha256": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
+        "metadata_sha256": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" }
+      }
+    },
+    "file_size_bytes": { "type": "integer", "minimum": 0 },
+    "fragments": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["fragment_id", "locator", "text"],
+        "properties": {
+          "fragment_id": { "type": "string", "minLength": 1 },
+          "locator": { "type": "string", "minLength": 1 },
+          "text": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "privacy_review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["private_data_detected", "review_status"],
+      "properties": {
+        "private_data_detected": { "type": "boolean" },
+        "review_status": { "type": "string", "enum": ["passed", "redaction_required", "excluded"] },
+        "redaction_method": { "type": "string" },
+        "notes": { "type": "string" }
+      }
+    },
+    "claims": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["claim_id", "claim_text", "evidence_mapping"],
+        "properties": {
+          "claim_id": { "type": "string", "minLength": 1 },
+          "claim_text": { "type": "string", "minLength": 1 },
+          "evidence_mapping": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "supports": { "$ref": "#/$defs/evidence_links" },
+              "contradicts": { "$ref": "#/$defs/evidence_links" }
+            },
+            "anyOf": [
+              { "required": ["supports"] },
+              { "required": ["contradicts"] }
+            ]
+          }
+        }
+      }
+    },
+    "orphaned_claims": { "type": "integer", "minimum": 0, "maximum": 0 }
+  },
+  "$defs": {
+    "evidence_links": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["receipt_id", "fragment_id", "relationship"],
+        "properties": {
+          "receipt_id": { "type": "string", "minLength": 1 },
+          "fragment_id": { "type": "string", "minLength": 1 },
+          "relationship": { "type": "string", "enum": ["supports", "contradicts", "context"] }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Hardens the deployed IPE receipt schema after audit of IPE-SCHEMA-001.

## Governance Receipt

**Receipt ID:** `IPE-SCHEMA-002`

This PR tightens the receipt schema so the schema better enforces the IPE invariants:

- no ghost evidence
- no unsupported claims
- no loose receipt structure
- fragment-level evidence mapping for claims

## Changes

- Adds `$schema` and `$id`
- Sets `additionalProperties: false`
- Adds stronger `minLength` checks
- Adds URI and date-time formats
- Structures `claims[]`
- Requires claim evidence mapping to include `supports` or `contradicts`
- Enforces evidence links with `receipt_id`, `fragment_id`, and `relationship`
- Requires evidence arrays to have at least one item

## IPE Rule

Schema deployed → weakness observed → fix proposed → gate review → merge or reject.

## Validation Checklist

- [ ] Schema parses as JSON
- [ ] Required fields remain aligned with IPE-SCHEMA-001
- [ ] Access method enum remains aligned
- [ ] `orphaned_claims` remains locked to `0`
- [ ] Evidence mapping is fragment-level
- [ ] CI/verify passes before merge

## Status

Design hardened. Deployment pending until PR checks pass and merge is completed.

The gate gets to judge the law that governs the gate.