### PR TITLE
Add post-merge replay receipt for PR 315

### DIFF
--- a/receipts/arena/POST_MERGE_REPLAY_PR_315.json
+++ b/receipts/arena/POST_MERGE_REPLAY_PR_315.json
@@ -1,0 +1,19 @@
+{
+  "artifact": "POST_MERGE_REPLAY_PR_315",
+  "repo": "jsonwisdom/COMPUTERWISDOM",
+  "pr": 315,
+  "status": "POST_MERGE_REPLAY_RECEIPT",
+  "authority": false,
+  "no_fake_green": true,
+  "eas_submitted": false,
+  "zora_emission": false,
+  "membrane": "INTACT",
+  "notes": "Receipt records that PR #315 was merged and replayed from master. It does not create authority, truth, liability, or external verification.",
+  "generated_at_utc": "2026-06-11T04:32:51Z",
+  "current_branch": "master",
+  "master_head": "ec040239b42600b6b3a9e6e210cf136587b7cd84",
+  "merge_commit": "ec040239b42600b6b3a9e6e210cf136587b7cd84",
+  "shadow_goblin_commit": "aa11ddf9c5ce4e4b26bb47bdc493beda907dccb7",
+  "master_contains_shadow_goblin_commit": true,
+  "receipt_canonical_sha256": "9f4048b4d17fcda9f6399de1df5003c711c0577fba85573f372c5f6861ac5139"
+}


### PR DESCRIPTION
Adds post-merge replay receipt for PR #315.

Receipt:

```text
receipts/arena/POST_MERGE_REPLAY_PR_315.json
```

Verified:

- PR #315 merged into master.
- Master head: ec040239b42600b6b3a9e6e210cf136587b7cd84.
- Shadow Goblin commit is contained in master.
- EAS submitted: false.
- Zora emission: false.
- Authority: false.
- NO_FAKE_GREEN = TRUE.