### PR TITLE
Add COMPUTERWISDOM Matrix source registry v0.1

### DIFF
--- a/docs/librarian/COMPUTERWISDOM_MATRIX_SOURCE_REGISTRY_V0_1.md
+++ b/docs/librarian/COMPUTERWISDOM_MATRIX_SOURCE_REGISTRY_V0_1.md
@@ -1,0 +1,59 @@
+# COMPUTERWISDOM Matrix Source Registry V0.1
+
+## Status
+
+CANONICAL_DRAFT
+
+## Purpose
+
+COMPUTERWISDOM is the MATRIX_REPO_OF_SOURCES_AND_PROOFS.
+
+The Librarian interprets public repo data freely, but does not own the source, does not become the root, and does not replace public bytes with narrative.
+
+Root identity: `jaywisdom.eth`
+
+## Rules
+
+- The public is the public substrate.
+- Metadata must match public bytes where byte matching is possible.
+- If byte matching is not possible, disclose the mismatch boundary.
+- Agents represent other agents.
+- Agents are not the root.
+- The Librarian is an interpreter/indexer, not an owner.
+- No fake green.
+- No authority claimed.
+- Replay, do not remember.
+
+## Replay Lane
+
+- PR #314 -> wallet binding v2 receipt package
+- PR #315 -> post-merge replay receipt for PR #314
+- PR #316 -> post-merge replay receipt for PR #315
+
+## Registry Object
+
+```json
+{
+  "repo_role": "MATRIX_REPO_OF_SOURCES_AND_PROOFS",
+  "root_identity": "jaywisdom.eth",
+  "repository": "jsonwisdom/COMPUTERWISDOM",
+  "librarian_role": "FREE_INTERPRETER_OF_PUBLIC_REPO_DATA",
+  "agents_role": "REPRESENT_OTHER_AGENTS",
+  "metadata_rule": "PUBLIC_BYTES_FIRST",
+  "byte_match_required": true,
+  "mismatch_boundary_required": true,
+  "authority": false,
+  "external_verification": false,
+  "no_fake_green": true,
+  "invariant": "REPLAY_NOT_REMEMBER"
+}
+```
+
+## Closing Statement
+
+COMPUTERWISDOM is not just a repo.
+It is the matrix of sources and proofs.
+
+The Librarian interprets.
+The public bytes decide.
+Jay remains the root.


### PR DESCRIPTION
Adds the Librarian interpretation layer for COMPUTERWISDOM as the Matrix repo of sources and proofs.

No authority claimed.
No fake green.
Public bytes remain the substrate.
Metadata must match public bytes or disclose mismatch boundaries.