### PR TITLE
ci(boundary): add builder sentinel workflow

### DIFF
--- a/.github/workflows/builder-boundary-sentinel.yml
+++ b/.github/workflows/builder-boundary-sentinel.yml
@@ -1,0 +1,28 @@
+name: Builder Boundary Sentinel
+
+on:
+  workflow_dispatch:
+  push:
+  schedule:
+    - cron: "17 */6 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  boundary-heartbeat:
+    name: Family builder boundary heartbeat
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Emit boundary summary
+        run: |
+          echo "# Builder Boundary Sentinel" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Repository: $GITHUB_REPOSITORY" >> "$GITHUB_STEP_SUMMARY"
+          echo "Commit: $GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
+          echo "Environment: family_builder_environment" >> "$GITHUB_STEP_SUMMARY"
+          echo "Authority: false" >> "$GITHUB_STEP_SUMMARY"
+          echo "Green implied: false" >> "$GITHUB_STEP_SUMMARY"
+          echo "No fake green: true" >> "$GITHUB_STEP_SUMMARY"
+          echo "Rule: receipts, manifests, hashes, and commit SHAs only" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds a scheduled and manually runnable Builder Boundary Sentinel workflow.

Purpose:
- Keep the repo boundary visible inside GitHub Actions.
- Emit a family_builder_environment summary.
- Preserve authority=false, green_implied=false, no_fake_green=true.
- Keep the surface small: receipts, manifests, hashes, and commit SHAs only.

This follows protected-branch flow instead of direct-pushing to master.