### PR TITLE
Add external replay witness checklist

### DIFF
--- a/docs/governance/EXTERNAL_REPLAY_WITNESS_CHECKLIST_V0_1.md
+++ b/docs/governance/EXTERNAL_REPLAY_WITNESS_CHECKLIST_V0_1.md
@@ -1,0 +1,14 @@
+# EXTERNAL REPLAY WITNESS CHECKLIST V0.1
+
+**artifact:** `EXTERNAL_REPLAY_WITNESS_CHECKLIST_V0_1`  
+**role:** witness_validation_layer  
+**does_not_prove_reproduction:** true  
+**requires_external_actor:** true  
+**authority:** false  
+**no_fake_green:** true  
+
+This checklist is not evidence. It is a quality gate for evidence.
+
+No witness receipt = no reproduction.  
+No PR = no acceptance.  
+No bypass = no fake green.


### PR DESCRIPTION
Adds V0.1 witness validation checklist for independent external replayers.

role=witness_validation_layer
does_not_prove_reproduction=true
requires_external_actor=true
authority=false
no_fake_green=true