### PR TITLE
docs(governance): add self replay dry-run receipt V0.1

### DIFF
--- a/docs/governance/SELF_REPLAY_DRY_RUN_RECEIPT_V0_1.md
+++ b/docs/governance/SELF_REPLAY_DRY_RUN_RECEIPT_V0_1.md
@@ -1,0 +1,23 @@
+# SELF REPLAY DRY RUN RECEIPT V0.1
+
+**artifact:** `SELF_REPLAY_DRY_RUN_RECEIPT_V0_1`
+**role:** quality_assurance_dry_run
+**does_not_upgrade_classification:** true
+**authority:** false
+**no_fake_green:** true
+
+## Purpose
+
+Defines a clean-room self-test of the independent fork replay instructions without claiming independent external reproduction.
+
+## Classification
+
+```json
+{
+  "replay_type": "SELF_REPLAY_DRY_RUN",
+  "independent_actor": false,
+  "result": "DRY_RUN_SUCCESS",
+  "classification_effect": "NONE",
+  "authority": false,
+  "no_fake_green": true
+}


### PR DESCRIPTION
# COMPUTERWISDOM Pull Request

## Summary

Describe the change in plain language.

## Constitutional Drift Classification

Select one or more:

- [ ] NO_DRIFT
- [ ] DOCS_ONLY_DRIFT
- [ ] OPERATIONAL_DRIFT
- [ ] SECURITY_DRIFT
- [ ] AUTHORITY_DRIFT
- [ ] ANCHOR_DRIFT

## Required Boundary Checks

- [ ] Anchor Boundary Preserved
- [ ] Security Boundary Preserved
- [ ] Layer Law Preserved
- [ ] Observer Authority Transfer: NONE
- [ ] No Ghost Anchors Introduced
- [ ] No Production Claims Without Receipts
- [ ] Generated Outputs Classified As Evidence, Not Truth By Themselves

## Receipt / Evidence

Provide links, hashes, commits, attestations, logs, or reproduction steps.

```text
Receipt Evidence:

```

## Constitutional Amendment Required?

- [ ] NO
- [ ] YES

If YES, explain why this PR changes repo purpose, authority boundaries, anchor status, security posture, or observer roles.

## Rollback / Revocation Path

Explain how this change can be reverted, revoked, disabled, or quarantined if wrong.

```text
Rollback Path:

```

## Closing Assertion

- [ ] This PR preserves replay, lineage, and bounded authority.
