### PR TITLE
Boss Bre: Coinbase MCP readiness and dry-run adapter

### DIFF
--- a/projects/cwaas/adapters/coinbase_mcp_adapter_v1.sh
+++ b/projects/cwaas/adapters/coinbase_mcp_adapter_v1.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# coinbase_mcp_adapter_v1.sh
+# Status: DRY_RUN_ONLY
+# Doctrine: preview-first, receipt-first, human-gated, no fake green.
+# This harness does not move funds and does not perform chain actions.
+
+MODE="${1:-dry-run}"
+RECEIPTS_DIR="${RECEIPTS_DIR:-receipts/cwaas/agent-pay/coinbase-mcp}"
+IDENTITY_BINDING="${IDENTITY_BINDING:-JAYWISDOM.eth}"
+ASSET="${ASSET:-USDC}"
+NETWORK="${NETWORK:-base-mainnet}"
+AMOUNT="${AMOUNT:-0.00}"
+WORK_REFERENCE="${WORK_REFERENCE:-unset}"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+SAFE_TS="$(date -u +%Y%m%d-%H%M%S)"
+
+mkdir -p "$RECEIPTS_DIR"
+
+case "$MODE" in
+  dry-run|preview)
+    ;;
+  *)
+    echo "ERROR: unsupported mode: $MODE" >&2
+    echo "Allowed modes: dry-run, preview" >&2
+    exit 64
+    ;;
+esac
+
+PREVIEW_RECEIPT="$RECEIPTS_DIR/coinbase_mcp_preview_${SAFE_TS}.json"
+APPROVAL_STUB="$RECEIPTS_DIR/coinbase_mcp_approval_required_${SAFE_TS}.json"
+
+cat > "$PREVIEW_RECEIPT" <<EOF
+{
+  "receipt_type": "COINBASE_MCP_ADAPTER_PREVIEW_V1",
+  "adapter": "coinbase-mcp-v1",
+  "mode": "$MODE",
+  "dry_run_only": true,
+  "funds_moved": false,
+  "chain_action": false,
+  "identity_binding": "$IDENTITY_BINDING",
+  "payment_payload": {
+    "asset": "$ASSET",
+    "network": "$NETWORK",
+    "amount": "$AMOUNT",
+    "work_reference": "$WORK_REFERENCE"
+  },
+  "required_gate": "human_approval",
+  "created_at": "$TS"
+}
+EOF
+
+sha256sum "$PREVIEW_RECEIPT" > "$PREVIEW_RECEIPT.sha256"
+PREVIEW_HASH="$(cut -d ' ' -f1 "$PREVIEW_RECEIPT.sha256")"
+
+cat > "$APPROVAL_STUB" <<EOF
+{
+  "receipt_type": "COINBASE_MCP_APPROVAL_REQUIRED_V1",
+  "adapter": "coinbase-mcp-v1",
+  "preview_receipt": "$PREVIEW_RECEIPT",
+  "preview_hash": "$PREVIEW_HASH",
+  "approved": false,
+  "approval_route": "/approve-agent-pay",
+  "status": "BLOCKED_PENDING_HUMAN_APPROVAL",
+  "created_at": "$TS"
+}
+EOF
+
+sha256sum "$APPROVAL_STUB" > "$APPROVAL_STUB.sha256"
+
+echo "COINBASE_MCP_ADAPTER_V1_DRY_RUN_COMPLETE"
+echo "preview_receipt=$PREVIEW_RECEIPT"
+echo "preview_hash=$PREVIEW_HASH"
+echo "approval_required=$APPROVAL_STUB"
+echo "funds_moved=false"
+echo "chain_action=false"

--- a/projects/cwaas/specs/COINBASE_MCP_READINESS_CHECKLIST_V1.md
+++ b/projects/cwaas/specs/COINBASE_MCP_READINESS_CHECKLIST_V1.md
@@ -1,0 +1,36 @@
+# COINBASE_MCP_READINESS_CHECKLIST_V1
+
+Status: REVIEW_ONLY
+Lane: CWaaS / Agent Pay
+Repository: jsonwisdom/COMPUTERWISDOM
+Branch: boss-bre-coinbase-mcp-review-v1
+
+## Purpose
+
+This checklist records the Boss Bre review gate for the Coinbase MCP adapter lane.
+
+The checklist is evidence, not narrative. Any unchecked item keeps the adapter in preview-only dry-run mode.
+
+## Checklist
+
+```text
+[ ] Preview receipt + replay PASS present
+[ ] Human approval receipt present (/approve-agent-pay)
+[ ] Identity binding (JAYWISDOM.eth) verified
+[ ] Payment payload schema compliant
+[ ] Adapter in DRY_RUN mode only
+[ ] External adapter activity blocked until human gate is satisfied
+[ ] Receipt + hash written back on every step
+[ ] No funds moved, no chain action in preview
+[ ] Full replay trace for every adapter run
+```
+
+## Boss Bre Lock
+
+```text
+No premature execution.
+No funds moved in preview.
+No chain action in preview.
+No adapter green without receipts.
+No fake green.
+```


### PR DESCRIPTION
## Summary

Adds the governed Coinbase MCP integration lane for CWaaS Agent Pay.

## Changes

- Adds `COINBASE_MCP_READINESS_CHECKLIST_V1.md`
- Adds `coinbase_mcp_adapter_v1.sh` dry-run harness

## Boss Bre Lock

- Preview-first
- Receipt-first
- Human-gated
- Dry-run only
- No funds moved in preview
- No chain action in preview
- No fake green

## Review Notes

This PR does not modify the locked confirmed receipt spec directly. The prior full-spec update was blocked by connector safety checks, so the readiness checklist is added as a separate review artifact.
