### PR TITLE
Boss Bre: Agent Pay confirmed payment eligibility receipt

### DIFF
--- a/projects/cwaas/specs/AGENT_PAY_CONFIRMED_PAYMENT_ELIGIBILITY_0001.md
+++ b/projects/cwaas/specs/AGENT_PAY_CONFIRMED_PAYMENT_ELIGIBILITY_0001.md
@@ -1,0 +1,73 @@
+# AGENT_PAY_CONFIRMED_PAYMENT_ELIGIBILITY_0001
+
+type: AGENT_PAY_CONFIRMED_PAYMENT_ELIGIBILITY_V1  
+status: ELIGIBLE_PENDING_TRANSACTION_WITNESS  
+lane: AGENT_PAY / Treasury / Eligibility
+
+## Purpose
+
+Declares that all prerequisites for a confirmed payment receipt are satisfied except the real transaction witness from Coinbase/Base.
+
+This receipt does not claim:
+
+- payment execution
+- settlement
+- chain action
+- EAS witness
+- authority
+- endorsement
+
+It only states that the system is ready for a real payment adapter call if and only if a human authorizes it.
+
+## Prerequisites
+
+```text
+preview_receipt: PREVIEW_1_V2
+approval_receipt: APPROVAL_0001
+payment_payload: PAYLOAD_0001
+dryrun_adapter_receipt: AGENT_PAY_ADAPTER_DRYRUN_0001
+dryrun_replay_trace: TRACE_AGENT_PAY_ADAPTER_DRYRUN_0001
+```
+
+All prerequisites must be present and replay-verified before this receipt can be treated as eligible.
+
+## Eligibility Summary
+
+```text
+preview_verified: true
+approval_verified: true
+payload_verified: true
+dryrun_verified: true
+replay_chain_intact: true
+transaction_witness_present: false
+```
+
+## Eligibility Status
+
+```text
+eligibility_status: ELIGIBLE_PENDING_TRANSACTION_WITNESS
+execution_authority: false
+payment_authority: false
+settlement_authority: false
+```
+
+## Boss Brenda Lock
+
+```text
+No preview receipt, no eligibility.
+No approval receipt, no eligibility.
+No dry-run adapter, no eligibility.
+No replay trace, no eligibility.
+No transaction witness, no confirmed payment.
+No fake green.
+```
+
+## What This Unlocks
+
+With this eligibility receipt in place, the Agent Pay lane may proceed to:
+
+- generate a real confirmed payment receipt after a transaction witness exists
+- generate a transaction witness placeholder
+- integrate eligibility into the Agent Pay workflow
+
+This artifact does not authorize payment. It only records structural readiness pending a real transaction witness and human approval.


### PR DESCRIPTION
## Summary

Adds the Agent Pay confirmed payment eligibility receipt as a separate governed artifact.

## Artifact

- `projects/cwaas/specs/AGENT_PAY_CONFIRMED_PAYMENT_ELIGIBILITY_0001.md`

## Boss Bre guardrails

- Eligibility is pending transaction witness
- `transaction_witness_present: false`
- `execution_authority: false`
- `payment_authority: false`
- `settlement_authority: false`
- Does not claim payment execution, settlement, chain action, EAS witness, authority, or endorsement
- Preserves: No transaction witness, no confirmed payment. No fake green.

## Status

Review-only eligibility gate. No funds moved. No chain action.