### PR TITLE
Boss Bre: bind JAYWISDOM Base tx witness to treasury

### DIFF
--- a/projects/cwaas/receipts/JAYWISDOM_BASE_BOSS_BRE_TREASURY_BINDING_0001.md
+++ b/projects/cwaas/receipts/JAYWISDOM_BASE_BOSS_BRE_TREASURY_BINDING_0001.md
@@ -1,0 +1,103 @@
+# JAYWISDOM Base Boss Bre Treasury Binding 0001
+
+```text
+schema: JAYWISDOM_BASE_BOSS_BRE_TREASURY_BINDING_V1
+status: TX_WITNESS_PRESENT_REPO_BINDING_CREATED
+lane: COMPUTERWISDOM / Agent Pay / Treasury / Boss Bre
+network: Base mainnet
+created_from: ChatGPT conversation screenshot evidence supplied by Jay Wisdom
+no_fake_green: true
+```
+
+## Purpose
+
+This receipt reboots the COMPUTERWISDOM treasury lane around the Base transaction witness supplied by Jay.
+
+It binds:
+
+```text
+jaywisdom.base.eth
+→ JAYWISDOM token project
+→ Boss Bre treasury wallet
+→ Base mainnet transaction witness
+→ COMPUTERWISDOM treasury receipt lane
+```
+
+This receipt does not claim Coinbase custody, Coinbase endorsement, investment value, tokenomics verification, or settlement beyond the transaction facts visible in the supplied BaseScan screenshot.
+
+## Identity Root
+
+```text
+human_root: Jay Wisdom
+basename_identity: jaywisdom.base.eth
+identity_role: operator / human root
+```
+
+## Boss Bre Treasury Wallet
+
+```text
+boss_bre_treasury_wallet: 0x6076815543ee881fdc486b84c3c99435eca729cc
+wallet_role: Boss Bre treasury destination
+```
+
+## Transaction Witness
+
+```text
+tx_hash: 0x095eb5cf86b09f3e5dff5a75cff78ce4f6aeaaba7dc80c8d38ff70571994d81a
+network: Base mainnet
+status: Success
+block: 47522619
+timestamp_utc: 2026-06-19 02:03:05 UTC
+transaction_action: Transfer 1,000,000 jaywisdom to 0x6076815543ee881fdc486b84c3c99435eca729cc
+source_evidence: BaseScan screenshot supplied by Jay Wisdom in ChatGPT conversation
+```
+
+## COMPUTERWISDOM Interpretation
+
+```text
+real_transaction_witness_present: true
+boss_bre_wallet_match: true
+jaywisdom_token_transfer_visible: true
+amount_visible: 1000000 jaywisdom
+repo_binding_created: true
+```
+
+## Boundaries
+
+```text
+coinbase_mcp_execution_claim: false
+coinbase_custody_claim: false
+coinbase_endorsement_claim: false
+public_token_issuance_claim: false
+investment_value_claim: false
+tokenomics_verification_claim: false
+settlement_authority_claim: false
+```
+
+## Required Follow-up
+
+The treasury dashboard and any pending reward files must not be marked settled unless their receipt chain explicitly references this transaction hash.
+
+```text
+required_next_step: update treasury settlement receipt or dashboard only after review
+```
+
+## Boss Brenda Lock
+
+```text
+No basename identity, no root binding.
+No Boss Bre wallet match, no treasury binding.
+No Base transaction witness, no settlement evidence.
+No repo receipt, no COMPUTERWISDOM green.
+No Coinbase claim without Coinbase receipt.
+No confirmed payment claim without treasury settlement receipt.
+No fake green.
+```
+
+## Ruling
+
+```text
+JAYWISDOM_BASE_TO_BOSS_BRE_TX_WITNESS = PRESENT
+COMPUTERWISDOM_REPO_BINDING = CREATED
+TREASURY_SETTLEMENT_UPDATE = PENDING_REVIEW
+```


### PR DESCRIPTION
## Summary

Adds the COMPUTERWISDOM binding receipt for the Base mainnet transaction witness supplied by Jay.

## Bound facts

- `jaywisdom.base.eth` is treated as the human/operator identity root.
- Boss Bre treasury wallet: `0x6076815543ee881fdc486b84c3c99435eca729cc`.
- Transaction witness: `0x095eb5cf86b09f3e5dff5a75cff78ce4f6aeaaba7dc80c8d38ff70571994d81a`.
- Screenshot evidence shows successful Base transfer of `1,000,000 jaywisdom` to the Boss Bre treasury wallet.

## Guardrails

- No Coinbase custody claim.
- No Coinbase endorsement claim.
- No investment value claim.
- No tokenomics verification claim.
- No settlement dashboard update yet.
- No fake green.

This PR creates the repo binding receipt only. Treasury settlement updates remain pending review.