### PR TITLE
Boss Bre: review-bound treasury dashboard to PR 357 witness

### DIFF
--- a/dashboard/treasury_summary.json
+++ b/dashboard/treasury_summary.json
@@ -12,8 +12,22 @@
       "reward_id": "rwd_prod_20260618_001",
       "asset": "JAYWISDOM",
       "amount": "1000",
-      "settlement_status": "PENDING",
-      "lane": "pending"
+      "settlement_status": "REVIEW_BOUND",
+      "lane": "PR_357_tx_0x095eb5cf86b09f3e5dff5a75cff78ce4f6aeaaba7dc80c8d38ff70571994d81a_receipt_0001",
+      "references": {
+        "binding_pr": "https://github.com/jsonwisdom/COMPUTERWISDOM/pull/357",
+        "binding_merge_sha": "6e14f61d820213a5bbd533187a7914a38db0f8ed",
+        "binding_receipt": "projects/cwaas/receipts/JAYWISDOM_BASE_BOSS_BRE_TREASURY_BINDING_0001.md",
+        "base_tx_hash": "0x095eb5cf86b09f3e5dff5a75cff78ce4f6aeaaba7dc80c8d38ff70571994d81a"
+      },
+      "guardrails": {
+        "coinbase_custody_claim": false,
+        "coinbase_endorsement_claim": false,
+        "investment_value_claim": false,
+        "tokenomics_verification_claim": false,
+        "settlement_finality_claim": false,
+        "no_fake_green": true
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Updates `dashboard/treasury_summary.json` so the pending Boss Bre JAYWISDOM reward is now review-bound to the PR #357 Base transaction witness receipt.

## Changes

- Keeps `pending_count: 1` and `settled_count: 0`.
- Changes reward settlement status from `PENDING` to `REVIEW_BOUND`.
- Adds lane reference to PR #357, tx `0x095eb5cf86b09f3e5dff5a75cff78ce4f6aeaaba7dc80c8d38ff70571994d81a`, and receipt `JAYWISDOM_BASE_BOSS_BRE_TREASURY_BINDING_0001.md`.
- Adds explicit guardrails: no Coinbase custody claim, no endorsement claim, no investment value claim, no tokenomics verification claim, no final settlement claim, no fake green.

## Boundary

This is a settlement review dashboard update, not a final settlement closeout. The treasury remains review-bound until the settlement lane is separately approved.