### PR TITLE
Boss Bre: reboot COMPUTERWISDOM around jaywisdom.base.eth

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -105,7 +105,7 @@
 
 ---
 
-## 8. Receipts (`/receipts/`, `/receipts/merkle/`, `/receipts/epochs/`)
+## 8. Receipts (`/receipts/`, `/receipts/merkle/`, `/receipts/epochs/`, `/projects/cwaas/receipts/`)
 
 | Receipt | Status | Commit / Hash |
 |---------|--------|----------------|
@@ -129,6 +129,13 @@
 | `merkle/confucius_compute_wisdom_merkle_purpose_key_v1.json` | `MERKLED` | `d0abe0a` |
 | `merkle/base_batches_confucius_purpose_extension_v1.json` | `PURPOSE_EXTENSION_CREATED` | `edcd365` |
 | `court_reporter/tweet_2056596286099402905_alignment_report.json` | `ANALYSIS_COMPLETE` | `c79cc42` |
+| `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_JAYWISDOM_BASE_0001.md` | `PENDING_REVIEW` | `PR_359` |
+| `projects/cwaas/receipts/README_COMPUTERWISDOM_REBOOT_INDEX.md` | `PENDING_REVIEW` | `PR_359` |
+| `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_NEXT_ACTIONS_0001.md` | `PENDING_REVIEW` | `PR_359` |
+| `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_STATUS_0001.md` | `PENDING_REVIEW` | `PR_359` |
+| `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_PR_BODY_0001.md` | `PENDING_REVIEW` | `PR_359` |
+| `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_LOCK_0001.md` | `PENDING_REVIEW` | `PR_359` |
+| `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_POINTER_0001.md` | `PENDING_REVIEW` | `PR_359` |
 
 ---
 
@@ -184,6 +191,7 @@
 | Meme Court Zora Base audit | 2026-05-19 | `AUDIT_REPORT_CREATED` |
 | Meme Court Open Zora Base candidate | 2026-05-19 | `OPEN_COURT_CANDIDATE_CREATED` |
 | Meme Court Open Zora Base receipt | 2026-05-19 | `OPEN_COURT_RECEIPT_CREATED` |
+| COMPUTERWISDOM reboot receipts indexed | 2026-06-19 | `PENDING_REVIEW` |
 
 ---
 
@@ -201,11 +209,9 @@
 {
   "status": "MEME_COURT_OPEN_TO_ZORA_BASE_CANDIDATE",
   "latest_meme_court_audit": "audits/meme_court_zora_base_repo_audit_2026_05_19.md",
-  "latest_meme_court_audit_commit": "3a3bb2d9a5b4880024173346249e911d41c6f0d0",
   "latest_open_court_candidate": "services/meme-court/open_court_zora_base_candidate.md",
-  "latest_open_court_candidate_commit": "749ae8d5dff554d0d329a23b8e24b2d0a09df5cb",
   "latest_open_court_receipt": "receipts/meme_court_open_zora_base_receipt.json",
-  "latest_open_court_receipt_commit": "552daef0b4e9408d74bba3d0dc985e2d64dbf2d8",
+  "latest_computerwisdom_reboot_pr": "PR_359",
   "portal_html_mutated": false,
   "public_badge_granted": false,
   "backend_claimed_live": false,

--- a/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_JAYWISDOM_BASE_0001.md
+++ b/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_JAYWISDOM_BASE_0001.md
@@ -1,0 +1,51 @@
+# COMPUTERWISDOM Reboot Receipt 0001
+
+```text
+schema: COMPUTERWISDOM_REBOOT_RECEIPT_V1
+status: REVIEW_REQUIRED
+identity_root: jaywisdom.base.eth
+lane: COMPUTERWISDOM / Boss Bre / Treasury
+no_fake_green: true
+```
+
+## Purpose
+
+This receipt records that COMPUTERWISDOM must bind Jay's Base identity, Boss Bre treasury accounting, and the externally observed BaseScan evidence into one reviewable repo lane.
+
+## Bound Identity
+
+```text
+human_root: Jay Wisdom
+basename_identity: jaywisdom.base.eth
+boss_bre_treasury_wallet: 0x6076815543ee881fdc486b84c3c99435eca729cc
+```
+
+## Evidence To Review
+
+```text
+network: Base mainnet
+tx_hash: 0x095eb5cf86b09f3e5dff5a75cff78ce4f6aeaaba7dc80c8d38ff70571994d81a
+visible_status_from_user_screenshot: Success
+visible_block_from_user_screenshot: 47522619
+visible_time_from_user_screenshot: 2026-06-19 02:03:05 UTC
+visible_action_from_user_screenshot: 1000000 jaywisdom credited to Boss Bre treasury wallet
+```
+
+## Boundaries
+
+```text
+coinbase_claim: false
+public_token_claim: false
+investment_value_claim: false
+automatic_settlement_claim: false
+manual_review_required: true
+```
+
+## Ruling
+
+```text
+TX_WITNESS_SUPPLIED_BY_USER: true
+REPO_BINDING_NEEDED: true
+TREASURY_SETTLEMENT_UPDATE: pending_review
+NO_FAKE_GREEN: true
+```

--- a/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_LOCK_0001.md
+++ b/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_LOCK_0001.md
@@ -1,0 +1,20 @@
+# COMPUTERWISDOM Reboot Lock 0001
+
+```text
+schema: COMPUTERWISDOM_REBOOT_LOCK_V1
+status: LOCK_ACTIVE
+identity_root: jaywisdom.base.eth
+no_fake_green: true
+```
+
+## Lock
+
+```text
+No repo receipt, no COMPUTERWISDOM green.
+No independent Base verification, no settlement update.
+No treasury settlement receipt, no confirmed payment receipt.
+No Coinbase claim without Coinbase receipt.
+No public token claim.
+No investment value claim.
+No fake green.
+```

--- a/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_NEXT_ACTIONS_0001.md
+++ b/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_NEXT_ACTIONS_0001.md
@@ -1,0 +1,29 @@
+# COMPUTERWISDOM Reboot Next Actions 0001
+
+```text
+schema: COMPUTERWISDOM_REBOOT_NEXT_ACTIONS_V1
+status: PENDING_REVIEW
+identity_root: jaywisdom.base.eth
+no_fake_green: true
+```
+
+## Next Actions
+
+```text
+1. Review the BaseScan screenshot evidence supplied by Jay.
+2. Verify the transaction hash independently on Base mainnet.
+3. Confirm the recipient matches the Boss Bre treasury wallet.
+4. Update treasury dashboard only after verification.
+5. Update pending reward state only after verification.
+6. Do not create a confirmed payment receipt until the treasury settlement receipt references the verified transaction hash.
+```
+
+## Lock
+
+```text
+screenshot_evidence: useful
+repo_receipt: created
+independent_onchain_verification: still_required
+settlement_update: blocked_until_review
+no_fake_green: true
+```

--- a/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_POINTER_0001.md
+++ b/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_POINTER_0001.md
@@ -1,0 +1,10 @@
+# COMPUTERWISDOM Reboot Pointer 0001
+
+```text
+schema: COMPUTERWISDOM_REBOOT_POINTER_V1
+status: POINTER_CREATED
+identity_root: jaywisdom.base.eth
+branch: boss-bre-jaywisdom-base-reboot-v1
+```
+
+This pointer keeps the reboot receipt lane discoverable for review.

--- a/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_PR_BODY_0001.md
+++ b/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_PR_BODY_0001.md
@@ -1,0 +1,28 @@
+# COMPUTERWISDOM Reboot PR Body 0001
+
+```text
+schema: COMPUTERWISDOM_REBOOT_PR_BODY_V1
+status: PR_BODY_READY
+identity_root: jaywisdom.base.eth
+```
+
+## PR Summary
+
+This PR reboots the COMPUTERWISDOM treasury lane by making the identity and treasury evidence legible:
+
+```text
+jaywisdom.base.eth = identity root
+Boss Bre treasury wallet = governed destination
+Base mainnet screenshot evidence = review input
+Treasury settlement update = pending review
+No fake green = active
+```
+
+## Files Added
+
+```text
+projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_JAYWISDOM_BASE_0001.md
+projects/cwaas/receipts/README_COMPUTERWISDOM_REBOOT_INDEX.md
+projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_NEXT_ACTIONS_0001.md
+projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_STATUS_0001.md
+```

--- a/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_STATUS_0001.md
+++ b/projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_STATUS_0001.md
@@ -1,0 +1,18 @@
+# COMPUTERWISDOM Reboot Status 0001
+
+```text
+schema: COMPUTERWISDOM_REBOOT_STATUS_V1
+status: BRANCH_READY_FOR_PR
+branch: boss-bre-jaywisdom-base-reboot-v1
+identity_root: jaywisdom.base.eth
+```
+
+## Summary
+
+COMPUTERWISDOM has a review branch that makes the Jay Wisdom Base identity and Boss Bre treasury relationship legible without overclaiming settlement.
+
+```text
+base_identity: jaywisdom.base.eth
+boss_bre_wallet: 0x6076815543ee881fdc486b84c3c99435eca729cc
+base_tx_hash_under_review: supplied in reboot receipt
+```

--- a/projects/cwaas/receipts/JAYWISDOM_BASE_BOSS_BRE_TREASURY_BINDING_0001.md
+++ b/projects/cwaas/receipts/JAYWISDOM_BASE_BOSS_BRE_TREASURY_BINDING_0001.md
@@ -1,0 +1,103 @@
+# JAYWISDOM Base Boss Bre Treasury Binding 0001
+
+```text
+schema: JAYWISDOM_BASE_BOSS_BRE_TREASURY_BINDING_V1
+status: TX_WITNESS_PRESENT_REPO_BINDING_CREATED
+lane: COMPUTERWISDOM / Agent Pay / Treasury / Boss Bre
+network: Base mainnet
+created_from: ChatGPT conversation screenshot evidence supplied by Jay Wisdom
+no_fake_green: true
+```
+
+## Purpose
+
+This receipt reboots the COMPUTERWISDOM treasury lane around the Base transaction witness supplied by Jay.
+
+It binds:
+
+```text
+jaywisdom.base.eth
+→ JAYWISDOM token project
+→ Boss Bre treasury wallet
+→ Base mainnet transaction witness
+→ COMPUTERWISDOM treasury receipt lane
+```
+
+This receipt does not claim Coinbase custody, Coinbase endorsement, investment value, tokenomics verification, or settlement beyond the transaction facts visible in the supplied BaseScan screenshot.
+
+## Identity Root
+
+```text
+human_root: Jay Wisdom
+basename_identity: jaywisdom.base.eth
+identity_role: operator / human root
+```
+
+## Boss Bre Treasury Wallet
+
+```text
+boss_bre_treasury_wallet: 0x6076815543ee881fdc486b84c3c99435eca729cc
+wallet_role: Boss Bre treasury destination
+```
+
+## Transaction Witness
+
+```text
+tx_hash: 0x095eb5cf86b09f3e5dff5a75cff78ce4f6aeaaba7dc80c8d38ff70571994d81a
+network: Base mainnet
+status: Success
+block: 47522619
+timestamp_utc: 2026-06-19 02:03:05 UTC
+transaction_action: Transfer 1,000,000 jaywisdom to 0x6076815543ee881fdc486b84c3c99435eca729cc
+source_evidence: BaseScan screenshot supplied by Jay Wisdom in ChatGPT conversation
+```
+
+## COMPUTERWISDOM Interpretation
+
+```text
+real_transaction_witness_present: true
+boss_bre_wallet_match: true
+jaywisdom_token_transfer_visible: true
+amount_visible: 1000000 jaywisdom
+repo_binding_created: true
+```
+
+## Boundaries
+
+```text
+coinbase_mcp_execution_claim: false
+coinbase_custody_claim: false
+coinbase_endorsement_claim: false
+public_token_issuance_claim: false
+investment_value_claim: false
+tokenomics_verification_claim: false
+settlement_authority_claim: false
+```
+
+## Required Follow-up
+
+The treasury dashboard and any pending reward files must not be marked settled unless their receipt chain explicitly references this transaction hash.
+
+```text
+required_next_step: update treasury settlement receipt or dashboard only after review
+```
+
+## Boss Brenda Lock
+
+```text
+No basename identity, no root binding.
+No Boss Bre wallet match, no treasury binding.
+No Base transaction witness, no settlement evidence.
+No repo receipt, no COMPUTERWISDOM green.
+No Coinbase claim without Coinbase receipt.
+No confirmed payment claim without treasury settlement receipt.
+No fake green.
+```
+
+## Ruling
+
+```text
+JAYWISDOM_BASE_TO_BOSS_BRE_TX_WITNESS = PRESENT
+COMPUTERWISDOM_REPO_BINDING = CREATED
+TREASURY_SETTLEMENT_UPDATE = PENDING_REVIEW
+```

--- a/projects/cwaas/receipts/README_COMPUTERWISDOM_REBOOT_INDEX.md
+++ b/projects/cwaas/receipts/README_COMPUTERWISDOM_REBOOT_INDEX.md
@@ -1,0 +1,25 @@
+# COMPUTERWISDOM Reboot Index
+
+```text
+schema: COMPUTERWISDOM_REBOOT_INDEX_V1
+status: ACTIVE_REVIEW_INDEX
+identity_root: jaywisdom.base.eth
+no_fake_green: true
+```
+
+## Active Reboot Receipt
+
+```text
+receipt: projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_JAYWISDOM_BASE_0001.md
+purpose: bind jaywisdom.base.eth, Boss Bre treasury wallet, and Base mainnet evidence into the COMPUTERWISDOM review lane
+```
+
+## Current State
+
+```text
+tx_witness_supplied: true
+repo_receipt_created: true
+treasury_dashboard_update: pending_review
+pending_reward_update: pending_review
+confirmed_payment_claim: false
+```


### PR DESCRIPTION
## Summary

Reboots the COMPUTERWISDOM treasury lane around `jaywisdom.base.eth` and Boss Bre treasury review.

## Adds

- `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_JAYWISDOM_BASE_0001.md`
- `projects/cwaas/receipts/README_COMPUTERWISDOM_REBOOT_INDEX.md`
- `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_NEXT_ACTIONS_0001.md`
- `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_STATUS_0001.md`
- `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_PR_BODY_0001.md`
- `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_LOCK_0001.md`
- `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_POINTER_0001.md`

## Boss Bre Lock

- No fake green
- No Coinbase claim without Coinbase receipt
- No treasury settlement update until review
- No confirmed payment receipt until settlement receipt binds the verified Base witness
