### PR TITLE
Boss Bre: Agent Pay adapter dry-run receipt

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -131,6 +131,7 @@
 | `court_reporter/tweet_2056596286099402905_alignment_report.json` | `ANALYSIS_COMPLETE` | `c79cc42` |
 | `projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md` | `PENDING_REVIEW` | `PR_356` |
 | `projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md` | `PENDING_REVIEW` | `PR_355` |
+| `projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md` | `PENDING_REVIEW` | `PR_362` |
 | `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_JAYWISDOM_BASE_0001.md` | `PENDING_REVIEW` | `PR_359` |
 | `projects/cwaas/receipts/README_COMPUTERWISDOM_REBOOT_INDEX.md` | `PENDING_REVIEW` | `PR_359` |
 | `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_NEXT_ACTIONS_0001.md` | `PENDING_REVIEW` | `PR_359` |
@@ -196,6 +197,7 @@
 | COMPUTERWISDOM reboot receipts indexed | 2026-06-19 | `PENDING_REVIEW` |
 | CWaaS receipt schema v1 indexed | 2026-06-19 | `PENDING_REVIEW` |
 | Agent Pay governance wire indexed | 2026-06-20 | `PENDING_REVIEW` |
+| Agent Pay adapter dry-run receipt indexed | 2026-06-20 | `PENDING_REVIEW` |
 
 ---
 
@@ -218,6 +220,7 @@
   "latest_computerwisdom_reboot_pr": "PR_359",
   "latest_cwaas_receipt_schema": "projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md",
   "latest_agent_pay_governance_wire": "projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md",
+  "latest_agent_pay_dryrun_receipt": "projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md",
   "portal_html_mutated": false,
   "public_badge_granted": false,
   "backend_claimed_live": false,

--- a/projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md
+++ b/projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md
@@ -1,0 +1,41 @@
+# AGENT_PAY_ADAPTER_DRYRUN_0001.md
+
+**CWAAS Agent Pay Adapter Dry-Run Receipt v1**
+
+**Date:** 2026-06-19  
+**Reviewer:** Boss Bre / jaywisdom.base.eth  
+**Status:** DRY_RUN_PROOF_RECORDED
+
+## Bound Elements
+
+- Governance Wire: AGENT_PAY_GOVERNANCE_WIRE_0001.md (PR #355 merge 6eb57cea)
+- Schema: CWAAS_RECEIPT_SCHEMA_v1 (PR #356)
+- Root Identity: jaywisdom.base.eth
+- Treasury Anchor: FINAL_BOUND lane (PR #359)
+- Workflow: AGENT_PAY_GITHUB_WORKFLOW_V0_1.md
+
+## Guardrails Matrix
+
+- external_custody_claim: false
+- external_endorsement_claim: false
+- investment_value_claim: false
+- tokenomics_verification_claim: false
+- settlement_finality_claim: false
+- payment_authority_claim: false
+- no_fake_green: true
+
+## Dry-Run Proof
+
+Adapter eligibility check: Boss Bre green confirmed via governance wire.  
+Payment lane: Simulated dry-run only — no onchain movement.  
+Output: Schema-compliant receipt generated successfully.
+
+## Verification Chain
+
+- PR #355 + #356 + #359 merges
+- Master canon post-6eb57cea
+
+**Recommendation:** Eligible for adapter activation PR upon further review. No execution authorized.
+
+**Signed:** Boss Bre Treasury + Governance Protocol  
+**Canon Reference:** 6eb57ceab7f3572df32158935f7a991e4d1e82de

--- a/projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md
+++ b/projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md
@@ -2,40 +2,85 @@
 
 **CWAAS Agent Pay Adapter Dry-Run Receipt v1**
 
-**Date:** 2026-06-19  
-**Reviewer:** Boss Bre / jaywisdom.base.eth  
-**Status:** DRY_RUN_PROOF_RECORDED
+## Header
 
-## Bound Elements
+```text
+date: 2026-06-19
+reviewer: Boss Bre / jaywisdom.base.eth
+status: DRY_RUN_PROOF_RECORDED
+schema: CWAAS_RECEIPT_SCHEMA_v1
+```
 
-- Governance Wire: AGENT_PAY_GOVERNANCE_WIRE_0001.md (PR #355 merge 6eb57cea)
-- Schema: CWAAS_RECEIPT_SCHEMA_v1 (PR #356)
-- Root Identity: jaywisdom.base.eth
-- Treasury Anchor: FINAL_BOUND lane (PR #359)
-- Workflow: AGENT_PAY_GITHUB_WORKFLOW_V0_1.md
+## Bound References
+
+```text
+related_prs: PR_355, PR_356, PR_359
+related_merges: PR_355=6eb57ceab7f3572df32158935f7a991e4d1e82de, PR_356=6e96f0a31cd71d9bd87ae9b801193b5024ed1fc8, PR_359=0b0ec9d17f78467de145803d99e3e52862cad2f2
+related_files:
+  - projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md
+  - projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md
+  - projects/cwaas/workflows/AGENT_PAY_GITHUB_WORKFLOW_V0_1.md
+manifest_refs:
+  - projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md
+```
 
 ## Guardrails Matrix
 
-- external_custody_claim: false
-- external_endorsement_claim: false
-- investment_value_claim: false
-- tokenomics_verification_claim: false
-- settlement_finality_claim: false
-- payment_authority_claim: false
-- no_fake_green: true
+```text
+external_custody_claim: false
+external_endorsement_claim: false
+investment_value_claim: false
+tokenomics_verification_claim: false
+settlement_finality_claim: false
+payment_authority_claim: false
+no_fake_green: true
+```
 
 ## Dry-Run Proof
 
-Adapter eligibility check: Boss Bre green confirmed via governance wire.  
-Payment lane: Simulated dry-run only — no onchain movement.  
-Output: Schema-compliant receipt generated successfully.
+```text
+adapter_eligibility_check: Boss Bre green confirmed via governance wire
+payment_lane: simulated_dry_run_only
+onchain_movement: false
+external_adapter_call: false
+payment_execution: false
+schema_compliant_receipt_generated: true
+```
 
 ## Verification Chain
 
-- PR #355 + #356 + #359 merges
-- Master canon post-6eb57cea
+```text
+prior_receipts:
+  - projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md
+  - projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md
+  - projects/cwaas/receipts/TREASURY_REVIEW_0001.md
+prior_prs:
+  - PR_355
+  - PR_356
+  - PR_359
+prior_merges:
+  - 6eb57ceab7f3572df32158935f7a991e4d1e82de
+  - 6e96f0a31cd71d9bd87ae9b801193b5024ed1fc8
+  - 0b0ec9d17f78467de145803d99e3e52862cad2f2
+manifest_refs:
+  - projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md
+```
 
-**Recommendation:** Eligible for adapter activation PR upon further review. No execution authorized.
+## Recommendation
 
-**Signed:** Boss Bre Treasury + Governance Protocol  
-**Canon Reference:** 6eb57ceab7f3572df32158935f7a991e4d1e82de
+```text
+next_action: review adapter activation PR separately
+eligibility_note: Dry-run proof confirms schema and governance wire continuity only.
+blockers: no execution authorized by this receipt
+```
+
+## Signature
+
+```text
+signed: Boss Bre Treasury + Governance Protocol
+canon_reference: 6eb57ceab7f3572df32158935f7a991e4d1e82de
+```
+
+## Boundary
+
+This receipt records a simulated dry-run proof only. It does not execute a payment, call an external adapter, move funds, create settlement finality, or imply third-party endorsement.


### PR DESCRIPTION
## Summary

Adds the Agent Pay adapter dry-run proof receipt under the canon CWaaS receipt schema.

## Adds

- `projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md`
- MANIFEST index entry and lock-state pointer

## Boundary

- Dry-run proof only
- No payment execution
- No onchain movement
- No settlement finality claim
- No custody or endorsement claim
- No fake green

## Canon Chain

- PR #359 reboot root
- PR #356 CWAAS receipt schema v1
- PR #355 Agent Pay governance wire
- This PR records dry-run proof only