### PR TITLE
Boss Bre: Agent Pay adapter eligibility preflight

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -132,6 +132,7 @@
 | `projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md` | `PENDING_REVIEW` | `PR_356` |
 | `projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md` | `PENDING_REVIEW` | `PR_355` |
 | `projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md` | `PENDING_REVIEW` | `PR_362` |
+| `projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md` | `PENDING_REVIEW` | `PR_363` |
 | `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_JAYWISDOM_BASE_0001.md` | `PENDING_REVIEW` | `PR_359` |
 | `projects/cwaas/receipts/README_COMPUTERWISDOM_REBOOT_INDEX.md` | `PENDING_REVIEW` | `PR_359` |
 | `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_NEXT_ACTIONS_0001.md` | `PENDING_REVIEW` | `PR_359` |
@@ -198,6 +199,7 @@
 | CWaaS receipt schema v1 indexed | 2026-06-19 | `PENDING_REVIEW` |
 | Agent Pay governance wire indexed | 2026-06-20 | `PENDING_REVIEW` |
 | Agent Pay adapter dry-run receipt indexed | 2026-06-20 | `PENDING_REVIEW` |
+| Agent Pay adapter eligibility preflight indexed | 2026-06-20 | `PENDING_REVIEW` |
 
 ---
 
@@ -205,7 +207,7 @@
 
 | File | Status |
 |------|--------|
-| `portal.html` | **NOT MUTATED** — protected surface |
+| `portal.html` | **NOT_MUTATED** — protected surface |
 
 ---
 
@@ -221,6 +223,7 @@
   "latest_cwaas_receipt_schema": "projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md",
   "latest_agent_pay_governance_wire": "projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md",
   "latest_agent_pay_dryrun_receipt": "projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md",
+  "latest_agent_pay_eligibility_preflight": "projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md",
   "portal_html_mutated": false,
   "public_badge_granted": false,
   "backend_claimed_live": false,

--- a/projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md
+++ b/projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md
@@ -47,11 +47,11 @@ no_fake_green: true
 ## Eligibility Proof
 
 ```text
-adapter_preflight_eligibility: Boss Bre green gate confirmed for review only
+adapter_preflight_eligibility: blocked_pending_treasury_attest_hashes
 execution_state: cold_review_only
 payment_lane_activated: false
 execution_authorized: false
-verdict: ELIGIBLE_FOR_ACTIVATION_REVIEW_ONLY
+verdict: NOT_ELIGIBLE_FOR_ACTIVATION_REVIEW_UNTIL_TREASURY_ATTEST_HASHES_BOUND
 execution_locked: true
 ```
 
@@ -80,8 +80,8 @@ manifest_refs:
 ## Recommendation
 
 ```text
-next_action: paste Treasury Attest Event 001/002 hashes, then review adapter activation PR separately
-eligibility_note: Eligible for next activation review only after Treasury Attest hashes are bound.
+next_action: paste Treasury Attest Event 001/002 hashes before any activation review
+eligibility_note: Not eligible for activation review until Treasury Attest hashes are bound.
 blockers:
   - treasury_attest_event_001_hash_required
   - treasury_attest_event_002_hash_required
@@ -109,4 +109,4 @@ canon_reference: current master post-01d52792f8a8d464263386ecfc39e44f628aabe4
 
 ## Boundary
 
-This receipt records review-only preflight eligibility. It does not execute a payment, call an external adapter, move funds, create settlement finality, or imply third-party endorsement.
+This receipt records review-only preflight status. It does not make the adapter eligible for activation review while Treasury Attest hashes are pending. It does not execute a payment, call an external adapter, move funds, create settlement finality, or imply third-party endorsement.

--- a/projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md
+++ b/projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md
@@ -1,0 +1,112 @@
+# AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md
+
+**CWAAS Agent Pay Adapter Eligibility Receipt v1**
+
+## Header
+
+```text
+date: 2026-06-19
+reviewer: Boss Bre / jaywisdom.base.eth
+status: ELIGIBILITY_REVIEW_ONLY_RECORDED
+schema: CWAAS_RECEIPT_SCHEMA_v1
+```
+
+## Bound References
+
+```text
+related_prs: PR_355, PR_356, PR_359, PR_362
+related_merges: PR_355=6eb57ceab7f3572df32158935f7a991e4d1e82de, PR_356=6e96f0a31cd71d9bd87ae9b801193b5024ed1fc8, PR_359=0b0ec9d17f78467de145803d99e3e52862cad2f2, PR_362=01d52792f8a8d464263386ecfc39e44f628aabe4
+related_files:
+  - projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md
+  - projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md
+  - projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md
+  - projects/cwaas/workflows/AGENT_PAY_GITHUB_WORKFLOW_V0_1.md
+root_identity: jaywisdom.base.eth
+treasury_anchor: FINAL_BOUND lane
+treasury_attest_event_001: PENDING_TREASURY_ATTEST_HASH
+treasury_attest_event_002: PENDING_TREASURY_ATTEST_HASH
+manifest_refs:
+  - projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md
+```
+
+## Guardrails Matrix
+
+```text
+external_custody_claim: false
+external_endorsement_claim: false
+investment_value_claim: false
+tokenomics_verification_claim: false
+settlement_finality_claim: false
+payment_authority_claim: false
+external_adapter_call: false
+payment_execution: false
+onchain_movement: false
+no_fake_green: true
+```
+
+## Eligibility Proof
+
+```text
+adapter_preflight_eligibility: Boss Bre green gate confirmed for review only
+execution_state: cold_review_only
+payment_lane_activated: false
+execution_authorized: false
+verdict: ELIGIBLE_FOR_ACTIVATION_REVIEW_ONLY
+execution_locked: true
+```
+
+## Verification Chain
+
+```text
+prior_receipts:
+  - projects/cwaas/receipts/agent-pay/AGENT_PAY_GOVERNANCE_WIRE_0001.md
+  - projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md
+  - projects/cwaas/receipts/TREASURY_REVIEW_0001.md
+  - projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_DRYRUN_0001.md
+prior_prs:
+  - PR_355
+  - PR_356
+  - PR_359
+  - PR_362
+prior_merges:
+  - 6eb57ceab7f3572df32158935f7a991e4d1e82de
+  - 6e96f0a31cd71d9bd87ae9b801193b5024ed1fc8
+  - 0b0ec9d17f78467de145803d99e3e52862cad2f2
+  - 01d52792f8a8d464263386ecfc39e44f628aabe4
+manifest_refs:
+  - projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md
+```
+
+## Recommendation
+
+```text
+next_action: paste Treasury Attest Event 001/002 hashes, then review adapter activation PR separately
+eligibility_note: Eligible for next activation review only after Treasury Attest hashes are bound.
+blockers:
+  - treasury_attest_event_001_hash_required
+  - treasury_attest_event_002_hash_required
+  - separate_boss_bre_green_required_for_any_warm_path
+  - no_execution_authorized_by_this_receipt
+```
+
+## Boss Bre Lock
+
+```text
+No Treasury Attest hash, no activation review.
+No human approval, no adapter path.
+No isolated portfolio, no adapter path.
+No receipt hash, no eligibility.
+No execution in v0.
+No fake green.
+```
+
+## Signature
+
+```text
+signed: Boss Bre Treasury + Governance Protocol
+canon_reference: current master post-01d52792f8a8d464263386ecfc39e44f628aabe4
+```
+
+## Boundary
+
+This receipt records review-only preflight eligibility. It does not execute a payment, call an external adapter, move funds, create settlement finality, or imply third-party endorsement.


### PR DESCRIPTION
## Summary

Adds the Agent Pay adapter eligibility preflight receipt under the canon CWaaS receipt schema.

## Adds

- `projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md`
- MANIFEST index entry and lock-state pointer

## Boundary

- Review-only preflight
- No payment execution
- No external adapter call
- No onchain movement
- No settlement finality claim
- Treasury Attest Event hashes remain pending and explicit
- No fake green

## Canon Chain

- PR #359 reboot / treasury anchor
- PR #356 CWAAS receipt schema v1
- PR #355 Agent Pay governance wire
- PR #362 Agent Pay adapter dry-run proof
- This PR records eligibility review only