### PR TITLE
Boss Bre: Treasury Attest hash binding receipt anchor

### DIFF
--- a/projects/cwaas/receipts/TREASURY_ATTEST_BINDING_0001.md
+++ b/projects/cwaas/receipts/TREASURY_ATTEST_BINDING_0001.md
@@ -7,5 +7,5 @@ Date: [Symbolic Timestamp 2026-06-19]
 Hash: [SYMBOLIC_EVENT_001_HASH]
 Linked Branch: boss-bre-treasury-attest-binding-v1
 
-Status: Binding Active | Connector Path Cleared
+Status: Symbolic Binding Active | Connector Path Blocked Pending Real Hash
 Verification: Post-push GitHub visibility

--- a/projects/cwaas/receipts/TREASURY_ATTEST_BINDING_0001.md
+++ b/projects/cwaas/receipts/TREASURY_ATTEST_BINDING_0001.md
@@ -1,0 +1,11 @@
+# TREASURY_ATTEST_BINDING_0001
+
+**Binding Receipt for Treasury Attest**
+
+Event: Treasury Attest Binding 0001
+Date: [Symbolic Timestamp 2026-06-19]
+Hash: [SYMBOLIC_EVENT_001_HASH]
+Linked Branch: boss-bre-treasury-attest-binding-v1
+
+Status: Binding Active | Connector Path Cleared
+Verification: Post-push GitHub visibility


### PR DESCRIPTION
## Summary

Adds the Treasury Attest binding receipt anchor for the Agent Pay eligibility lane.

## Adds

- `projects/cwaas/receipts/TREASURY_ATTEST_BINDING_0001.md`

## Boundary

- Symbolic hash only
- No real Treasury Attest Event 001/002 hash bound yet
- No activation review unlocked
- No payment execution
- No external adapter call
- No onchain movement
- No settlement finality claim
- No fake green

## Canon Chain

- PR #363 Agent Pay adapter eligibility preflight
- Merge `aa19f7a025cd47dc3faaa155c08f7901a1d57ffc`
- Branch push head includes receipt anchor commit `57fe2df`

## Next

After merge, follow-up PR may replace symbolic placeholders with real Treasury Attest Event hashes and update eligibility verdict boundaries.