### PR TITLE
Boss Bre: real Treasury Attest hash binding

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -141,6 +141,7 @@
 | `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_LOCK_0001.md` | `PENDING_REVIEW` | `PR_359` |
 | `projects/cwaas/receipts/COMPUTERWISDOM_REBOOT_POINTER_0001.md` | `PENDING_REVIEW` | `PR_359` |
 
+| `projects/cwaas/receipts/TREASURY_ATTEST_BINDING_0002.md` | `PENDING_REVIEW` | `REAL_HASH_BINDING_PR` |
 ---
 
 ## 9. Service Layers (`/services/`)

--- a/projects/cwaas/receipts/TREASURY_ATTEST_BINDING_0002.md
+++ b/projects/cwaas/receipts/TREASURY_ATTEST_BINDING_0002.md
@@ -1,0 +1,81 @@
+# TREASURY_ATTEST_BINDING_0002.md
+
+**CWAAS Treasury Attest Event Real Hash Binding v1**
+
+## Header
+
+```text
+date: 2026-06-19
+reviewer: Boss Bre / jaywisdom.base.eth
+status: REAL_ATTEST_HASHES_BOUND
+schema: CWAAS_RECEIPT_SCHEMA_v1
+```
+
+## Bound References
+
+```text
+related_prs: PR_355, PR_356, PR_359, PR_362, PR_363, PR_366
+related_merges: PR_363=aa19f7a025cd47dc3faaa155c08f7901a1d57ffc, PR_366=705b1277c5ba55bf228e2571c38d7799212856d7
+related_files:
+  - projects/cwaas/receipts/TREASURY_ATTEST_BINDING_0001.md
+  - projects/cwaas/receipts/TREASURY_ATTEST_BINDING_0002.md
+  - projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md
+  - projects/cwaas/receipts/CWAAS_RECEIPT_SCHEMA_v1.md
+root_identity: jaywisdom.base.eth
+treasury_attest_event_001: 1bcd8cf4d27e23156dd780a6c2ec3e53cd47b307f638f6f0bdbed692aa7602ab
+treasury_attest_event_002: a579ce2ea512727e3cc6569fea4b849f6decc4ba767f55798f5afe513634eeb1
+```
+
+## Guardrails Matrix
+
+```text
+external_custody_claim: false
+external_endorsement_claim: false
+investment_value_claim: false
+tokenomics_verification_claim: false
+settlement_finality_claim: false
+payment_authority_claim: false
+external_adapter_call: false
+payment_execution: false
+onchain_movement: false
+no_fake_green: true
+```
+
+## Binding Proof
+
+```text
+real_attest_hashes_bound: true
+symbolic_placeholders_replaced: true
+activation_review_eligible: true
+execution_state: cold_review_only
+payment_lane_activated: false
+execution_authorized: false
+```
+
+## Recommendation
+
+```text
+next_action: open adapter activation review PR
+eligibility_note: Eligible for activation review only. No execution authorized.
+blockers:
+  - separate_boss_bre_green_required_for_any_warm_path
+  - no_execution_authorized_by_this_receipt
+```
+
+## Boss Bre Lock
+
+```text
+Real Treasury Attest hashes bound.
+Activation review may be opened.
+No human approval, no adapter path.
+No isolated portfolio, no adapter path.
+No execution in v0.
+No fake green.
+```
+
+## Boundary
+
+This receipt binds real Treasury Attest Event hashes for review eligibility only. It does not execute payment, call an external adapter, move funds, create settlement finality, or imply third-party endorsement.
+
+**Signed:** Boss Bre Protocol  
+**Canon Reference:** 705b1277c5ba55bf228e2571c38d7799212856d7

--- a/projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md
+++ b/projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md
@@ -23,8 +23,8 @@ related_files:
   - projects/cwaas/workflows/AGENT_PAY_GITHUB_WORKFLOW_V0_1.md
 root_identity: jaywisdom.base.eth
 treasury_anchor: FINAL_BOUND lane
-treasury_attest_event_001: PENDING_TREASURY_ATTEST_HASH
-treasury_attest_event_002: PENDING_TREASURY_ATTEST_HASH
+treasury_attest_event_001: 1bcd8cf4d27e23156dd780a6c2ec3e53cd47b307f638f6f0bdbed692aa7602ab
+treasury_attest_event_002: a579ce2ea512727e3cc6569fea4b849f6decc4ba767f55798f5afe513634eeb1
 manifest_refs:
   - projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md
 ```
@@ -47,11 +47,11 @@ no_fake_green: true
 ## Eligibility Proof
 
 ```text
-adapter_preflight_eligibility: blocked_pending_treasury_attest_hashes
+adapter_preflight_eligibility: real_treasury_attest_hashes_bound
 execution_state: cold_review_only
 payment_lane_activated: false
 execution_authorized: false
-verdict: NOT_ELIGIBLE_FOR_ACTIVATION_REVIEW_UNTIL_TREASURY_ATTEST_HASHES_BOUND
+verdict: ELIGIBLE_FOR_ACTIVATION_REVIEW_ONLY
 execution_locked: true
 ```
 
@@ -80,8 +80,8 @@ manifest_refs:
 ## Recommendation
 
 ```text
-next_action: paste Treasury Attest Event 001/002 hashes before any activation review
-eligibility_note: Not eligible for activation review until Treasury Attest hashes are bound.
+next_action: open adapter activation review PR
+eligibility_note: Eligible for activation review only. No execution authorized.
 blockers:
   - treasury_attest_event_001_hash_required
   - treasury_attest_event_002_hash_required
@@ -109,4 +109,4 @@ canon_reference: current master post-01d52792f8a8d464263386ecfc39e44f628aabe4
 
 ## Boundary
 
-This receipt records review-only preflight status. It does not make the adapter eligible for activation review while Treasury Attest hashes are pending. It does not execute a payment, call an external adapter, move funds, create settlement finality, or imply third-party endorsement.
+This receipt records review-only preflight status. Real Treasury Attest hashes are now bound; the adapter is eligible for activation review only. It does not execute a payment, call an external adapter, move funds, create settlement finality, or imply third-party endorsement.


### PR DESCRIPTION
## Summary

Binds real repo-native Treasury Attest Event hashes and updates the Agent Pay eligibility receipt to review-eligible only.

## Adds / Updates

- Adds `projects/cwaas/receipts/TREASURY_ATTEST_BINDING_0002.md`
- Updates `projects/cwaas/receipts/agent-pay/AGENT_PAY_ADAPTER_ELIGIBILITY_0002.md`
- Updates `MANIFEST.md`

## Bound Hashes

- Event 001: `1bcd8cf4d27e23156dd780a6c2ec3e53cd47b307f638f6f0bdbed692aa7602ab`
- Event 002: `a579ce2ea512727e3cc6569fea4b849f6decc4ba767f55798f5afe513634eeb1`

## Boundary

- Eligible for activation review only
- No payment execution
- No external adapter call
- No onchain movement
- No settlement finality claim
- No fake green

## Canon Chain

- PR #363 eligibility preflight
- PR #366 symbolic attest binding anchor
- This PR binds real hashes and keeps execution cold