### PR TITLE
Boss Bre: bind Coinbase MCP adapter dry-run receipt

### DIFF
--- a/projects/cwaas/receipts/agent-pay/COINBASE_MCP_ADAPTER_DRYRUN_0001.md
+++ b/projects/cwaas/receipts/agent-pay/COINBASE_MCP_ADAPTER_DRYRUN_0001.md
@@ -1,0 +1,56 @@
+# COINBASE_MCP_ADAPTER_DRYRUN_0001.md
+
+**CWaaS Coinbase MCP Adapter Dry-Run Receipt**
+
+## Header
+
+date: 2026-06-20
+reviewer: Boss Bre / jaywisdom.base.eth
+status: ADAPTER_DRY_RUN_RECEIPT_RECORDED
+schema: CWAAS_RECEIPT_SCHEMA_v1
+
+## Bound References
+
+adapter: projects/cwaas/adapters/coinbase_mcp_adapter_v1.sh
+preview_receipt: projects/cwaas/receipts/agent-pay/coinbase-mcp/coinbase_mcp_preview_20260620-030434.json
+approval_required_receipt: projects/cwaas/receipts/agent-pay/coinbase-mcp/coinbase_mcp_approval_required_20260620-030434.json
+preview_hash: b42dfb20df7a5cffd2cfa352f38ba0c249d573f210e7a096aa91e7346c70b570
+identity_binding: jaywisdom.base.eth
+asset: USDC
+network: base-mainnet
+amount: 0.00
+work_reference: adapter-dry-run-0001
+
+## Guardrails Matrix
+
+external_custody_claim: false
+external_endorsement_claim: false
+investment_value_claim: false
+tokenomics_verification_claim: false
+settlement_finality_claim: false
+payment_authority_claim: false
+external_adapter_call: false
+payment_execution: false
+funds_moved: false
+chain_action: false
+onchain_movement: false
+no_fake_green: true
+
+## Dry-Run Result
+
+adapter_dry_run: PASS
+preview_receipt_created: true
+approval_required_receipt_created: true
+human_approval_required: true
+execution_authorized: false
+
+## Boundary
+
+This receipt records a Coinbase MCP adapter dry-run only. It does not execute payment, move funds, call a live external adapter for settlement, create settlement finality, or imply Coinbase/Base endorsement.
+
+## Boss Bre Lock
+
+No human approval, no adapter execution.
+No real witness, no confirmed payment.
+No funds moved, no chain action.
+No fake green.

--- a/projects/cwaas/receipts/agent-pay/coinbase-mcp/coinbase_mcp_approval_required_20260620-030434.json
+++ b/projects/cwaas/receipts/agent-pay/coinbase-mcp/coinbase_mcp_approval_required_20260620-030434.json
@@ -1,0 +1,10 @@
+{
+  "receipt_type": "COINBASE_MCP_APPROVAL_REQUIRED_V1",
+  "adapter": "coinbase-mcp-v1",
+  "preview_receipt": "receipts/cwaas/agent-pay/coinbase-mcp/coinbase_mcp_preview_20260620-030434.json",
+  "preview_hash": "b42dfb20df7a5cffd2cfa352f38ba0c249d573f210e7a096aa91e7346c70b570",
+  "approved": false,
+  "approval_route": "/approve-agent-pay",
+  "status": "BLOCKED_PENDING_HUMAN_APPROVAL",
+  "created_at": "2026-06-20T03:04:34Z"
+}

--- a/projects/cwaas/receipts/agent-pay/coinbase-mcp/coinbase_mcp_approval_required_20260620-030434.json
+++ b/projects/cwaas/receipts/agent-pay/coinbase-mcp/coinbase_mcp_approval_required_20260620-030434.json
@@ -1,7 +1,7 @@
 {
   "receipt_type": "COINBASE_MCP_APPROVAL_REQUIRED_V1",
   "adapter": "coinbase-mcp-v1",
-  "preview_receipt": "receipts/cwaas/agent-pay/coinbase-mcp/coinbase_mcp_preview_20260620-030434.json",
+  "preview_receipt": "projects/cwaas/receipts/agent-pay/coinbase-mcp/coinbase_mcp_preview_20260620-030434.json",
   "preview_hash": "b42dfb20df7a5cffd2cfa352f38ba0c249d573f210e7a096aa91e7346c70b570",
   "approved": false,
   "approval_route": "/approve-agent-pay",

--- a/projects/cwaas/receipts/agent-pay/coinbase-mcp/coinbase_mcp_preview_20260620-030434.json
+++ b/projects/cwaas/receipts/agent-pay/coinbase-mcp/coinbase_mcp_preview_20260620-030434.json
@@ -1,0 +1,17 @@
+{
+  "receipt_type": "COINBASE_MCP_ADAPTER_PREVIEW_V1",
+  "adapter": "coinbase-mcp-v1",
+  "mode": "dry-run",
+  "dry_run_only": true,
+  "funds_moved": false,
+  "chain_action": false,
+  "identity_binding": "jaywisdom.base.eth",
+  "payment_payload": {
+    "asset": "USDC",
+    "network": "base-mainnet",
+    "amount": "0.00",
+    "work_reference": "adapter-dry-run-0001"
+  },
+  "required_gate": "human_approval",
+  "created_at": "2026-06-20T03:04:34Z"
+}


### PR DESCRIPTION
## Summary

Binds the Coinbase MCP adapter dry-run output into the CWaaS receipt spine.

## Adds

- `projects/cwaas/receipts/agent-pay/COINBASE_MCP_ADAPTER_DRYRUN_0001.md`
- `projects/cwaas/receipts/agent-pay/coinbase-mcp/coinbase_mcp_preview_20260620-030434.json`
- `projects/cwaas/receipts/agent-pay/coinbase-mcp/coinbase_mcp_approval_required_20260620-030434.json`

## Boundary

- dry-run only
- funds moved: false
- chain action: false
- payment execution: false
- adapter execution authority: false
- no fake green

## Canon Chain

Follows the workflow review gate and witness-lane hardening. This PR records adapter dry-run evidence only.