### PR TITLE
add receipt core pipeline

### DIFF
--- a/.github/workflows/receipt-core.yml
+++ b/.github/workflows/receipt-core.yml
@@ -1,0 +1,17 @@
+name: Receipt Core
+
+on:
+  push:
+    branches:
+      - receipts-pipeline-v0-1
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install pytest
+      - run: python -m pytest signal-core/tests/test_receipt_core.py -q

--- a/signal-core/README.md
+++ b/signal-core/README.md
@@ -1,0 +1,3 @@
+# Signal Core
+
+Receipt pipeline scaffold for COMPUTERWISDOM.

--- a/signal-core/canonicalizer/test.py
+++ b/signal-core/canonicalizer/test.py
@@ -1,0 +1,1 @@
+print('hello')

--- a/signal-core/core.py
+++ b/signal-core/core.py
@@ -1,0 +1,42 @@
+import hashlib
+import json
+from pathlib import Path
+
+
+def canonical_bytes(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
+
+
+def h(data):
+    return 'sha256:' + hashlib.sha256(data).hexdigest()
+
+
+def load_json(path):
+    return json.loads(Path(path).read_text(encoding='utf-8'))
+
+
+def canonicalize_graph(path):
+    graph = load_json(path)
+    if graph.get('authority') != 'NONE':
+        raise ValueError('claim graph authority must be NONE')
+    claims = graph.get('claims', [])
+    graph['claims'] = sorted(claims, key=lambda c: c.get('claim_id', json.dumps(c, sort_keys=True)))
+    for claim in graph['claims']:
+        if isinstance(claim.get('dependencies'), list):
+            claim['dependencies'] = sorted(claim['dependencies'])
+    return graph
+
+
+def seal(artifact_path, graph_path):
+    graph = canonicalize_graph(graph_path)
+    core = {
+        'artifact_hash': h(Path(artifact_path).read_bytes()),
+        'claim_graph_hash': h(canonical_bytes(graph)),
+        'claims_count': len(graph.get('claims', [])),
+        'confidence': {'authority': 'NONE'},
+    }
+    core['receipt_core_hash'] = h(canonical_bytes(core))
+    rid_core = dict(core)
+    rid_core['receipt_id'] = ''
+    core['receipt_id'] = 'vr:' + h(canonical_bytes(rid_core))
+    return core

--- a/signal-core/tests/test_receipt_core.py
+++ b/signal-core/tests/test_receipt_core.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import json
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from core import seal
+
+
+def test_seal_pass(tmp_path):
+    artifact = tmp_path / 'artifact.txt'
+    artifact.write_text('hello', encoding='utf-8')
+    graph = tmp_path / 'graph.json'
+    graph.write_text(json.dumps({'authority':'NONE','claims':[{'claim_id':'b','dependencies':['a']},{'claim_id':'a','dependencies':[]}]}), encoding='utf-8')
+    receipt = seal(str(artifact), str(graph))
+    assert receipt['confidence']['authority'] == 'NONE'
+    assert receipt['receipt_id'].startswith('vr:sha256:')


### PR DESCRIPTION
Adds the visible Signal Core / Receipt Core scaffold directly inside COMPUTERWISDOM.

Included:
- signal-core/README.md
- signal-core/core.py
- signal-core/tests/test_receipt_core.py
- .github/workflows/receipt-core.yml

Actions proof: Receipt Core workflow is visible and green on branch receipts-pipeline-v0-1.

Invariant: Authority remains NONE.