### PR TITLE
ci: run receipt core on master

### DIFF
--- a/.github/workflows/receipt-core.yml
+++ b/.github/workflows/receipt-core.yml
@@ -3,7 +3,10 @@ name: Receipt Core
 on:
   push:
     branches:
-      - receipts-pipeline-v0-1
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
Updates Receipt Core workflow so it runs on pushes and pull requests targeting master.

Previous workflow only triggered on the temporary branch receipts-pipeline-v0-1.