### PR TITLE
ci: add receipt core pytest extra summary

### DIFF
--- a/.github/workflows/receipt-core.yml
+++ b/.github/workflows/receipt-core.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install pytest
-      - run: python -m pytest signal-core/tests/test_receipt_core.py -q
+      - run: python -m pytest signal-core/tests/test_receipt_core.py -q -rX


### PR DESCRIPTION
Hardens Receipt Core CI by adding pytest -rX output to surface extra test summary details in Actions logs.

Artifact upload was attempted as a larger workflow patch, but the connector blocked that write. This PR lands the safe first hardening boundary: visible pytest extra summary on the real master CI lane.