### PR TITLE
ci: add receipt failure artifact rail

### DIFF
--- a/.github/workflows/receipt-core.yml
+++ b/.github/workflows/receipt-core.yml
@@ -18,3 +18,8 @@ jobs:
           python-version: '3.11'
       - run: python -m pip install pytest
       - run: python -m pytest signal-core/tests/test_receipt_core.py -q -rX
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: receipt-failure-debug
+          path: signal-core/tests/


### PR DESCRIPTION
Adds failure artifact upload to Receipt Core CI.

Scope:
- zero receipt semantic change
- keeps pytest -q -rX
- uploads signal-core/tests/ only when the workflow fails

This creates the first forensic rail for failed Receipt Core runs.