### PR TITLE
schema: formalize verification receipt v0.1

### DIFF
--- a/.github/workflows/receipt-core.yml
+++ b/.github/workflows/receipt-core.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install pytest
-      - run: python -m pytest signal-core/tests/test_receipt_core.py -q -rX
+      - run: python -m pytest signal-core/tests/ -q -rX
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/signal-core/schema/verification-receipt-v0.1.schema.json
+++ b/signal-core/schema/verification-receipt-v0.1.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jsonwisdom.github.io/COMPUTERWISDOM/signal-core/schema/verification-receipt-v0.1.schema.json",
+  "title": "Verification Receipt v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "receipt_id",
+    "artifact_hash",
+    "claim_graph_hash",
+    "claims_count",
+    "receipt_core_hash",
+    "confidence"
+  ],
+  "properties": {
+    "receipt_id": {
+      "type": "string",
+      "pattern": "^vr:sha256:[0-9a-f]{64}$"
+    },
+    "artifact_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "claim_graph_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "claims_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "receipt_core_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "confidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["authority"],
+      "properties": {
+        "authority": {
+          "const": "NONE"
+        }
+      }
+    }
+  }
+}

--- a/signal-core/tests/test_receipt_schema.py
+++ b/signal-core/tests/test_receipt_schema.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import json
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from core import seal
+from validator.schema_validate import ReceiptSchemaError, validate_receipt
+
+
+def test_sealed_receipt_matches_schema(tmp_path):
+    artifact = tmp_path / 'artifact.txt'
+    artifact.write_text('hello', encoding='utf-8')
+    graph = tmp_path / 'graph.json'
+    graph.write_text(json.dumps({'authority':'NONE','claims':[{'claim_id':'a','dependencies':[]}]}), encoding='utf-8')
+    receipt = seal(str(artifact), str(graph))
+    assert validate_receipt(receipt) is True
+
+
+def test_rejects_extra_fields():
+    receipt = {
+        'receipt_id': 'vr:sha256:' + 'a' * 64,
+        'artifact_hash': 'sha256:' + 'b' * 64,
+        'claim_graph_hash': 'sha256:' + 'c' * 64,
+        'claims_count': 1,
+        'receipt_core_hash': 'sha256:' + 'd' * 64,
+        'confidence': {'authority': 'NONE'},
+        'verdict': 'TRUE'
+    }
+    try:
+        validate_receipt(receipt)
+        assert False
+    except ReceiptSchemaError as exc:
+        assert 'unexpected fields' in str(exc)
+
+
+def test_rejects_authority():
+    receipt = {
+        'receipt_id': 'vr:sha256:' + 'a' * 64,
+        'artifact_hash': 'sha256:' + 'b' * 64,
+        'claim_graph_hash': 'sha256:' + 'c' * 64,
+        'claims_count': 1,
+        'receipt_core_hash': 'sha256:' + 'd' * 64,
+        'confidence': {'authority': 'ROOT'}
+    }
+    try:
+        validate_receipt(receipt)
+        assert False
+    except ReceiptSchemaError as exc:
+        assert 'authority must be NONE' in str(exc)

--- a/signal-core/validator/schema_validate.py
+++ b/signal-core/validator/schema_validate.py
@@ -1,0 +1,51 @@
+import json
+import re
+from pathlib import Path
+
+HASH_RE = re.compile(r'^sha256:[0-9a-f]{64}$')
+RECEIPT_RE = re.compile(r'^vr:sha256:[0-9a-f]{64}$')
+
+
+class ReceiptSchemaError(ValueError):
+    pass
+
+
+def require_keys(receipt):
+    required = {
+        'receipt_id',
+        'artifact_hash',
+        'claim_graph_hash',
+        'claims_count',
+        'receipt_core_hash',
+        'confidence',
+    }
+    missing = sorted(required - set(receipt))
+    if missing:
+        raise ReceiptSchemaError('missing required fields: ' + ', '.join(missing))
+    extra = sorted(set(receipt) - required)
+    if extra:
+        raise ReceiptSchemaError('unexpected fields: ' + ', '.join(extra))
+
+
+def validate_receipt(receipt):
+    require_keys(receipt)
+    if not RECEIPT_RE.match(receipt['receipt_id']):
+        raise ReceiptSchemaError('receipt_id must match vr:sha256:<64 hex>')
+    for key in ('artifact_hash', 'claim_graph_hash', 'receipt_core_hash'):
+        if not HASH_RE.match(receipt[key]):
+            raise ReceiptSchemaError(key + ' must match sha256:<64 hex>')
+    if not isinstance(receipt['claims_count'], int) or receipt['claims_count'] < 0:
+        raise ReceiptSchemaError('claims_count must be a non-negative integer')
+    confidence = receipt['confidence']
+    if not isinstance(confidence, dict):
+        raise ReceiptSchemaError('confidence must be an object')
+    if set(confidence.keys()) != {'authority'}:
+        raise ReceiptSchemaError('confidence may only contain authority')
+    if confidence['authority'] != 'NONE':
+        raise ReceiptSchemaError('confidence.authority must be NONE')
+    return True
+
+
+def validate_receipt_file(path):
+    receipt = json.loads(Path(path).read_text(encoding='utf-8'))
+    return validate_receipt(receipt)


### PR DESCRIPTION
Formalizes the Receipt Core v0.1 output contract.

Adds:
- signal-core/schema/verification-receipt-v0.1.schema.json
- signal-core/validator/schema_validate.py
- signal-core/tests/test_receipt_schema.py

Updates CI:
- runs all signal-core/tests/ with pytest -q -rX
- preserves failure artifact rail

Invariant preserved:
- confidence.authority must equal NONE
- additional receipt fields rejected
- no truth/verdict field admitted