### PR TITLE
policy: add rql-lite admission controller v0.2

### DIFF
--- a/signal-core/cli/receipts.py
+++ b/signal-core/cli/receipts.py
@@ -33,19 +33,19 @@ def verify_receipt(receipt_path: str, schema_path: str = None, policy_path: str 
         return 0
     except FileNotFoundError as exc:
         print(f'FAIL missing file: {exc}', file=sys.stderr)
-        return 1
+        return 3
     except json.JSONDecodeError as exc:
         print(f'FAIL invalid json: {exc}', file=sys.stderr)
-        return 1
+        return 3
     except ReceiptSchemaError as exc:
         print(f'FAIL receipt schema: {exc}', file=sys.stderr)
-        return 1
+        return 2
     except PolicyError as exc:
         print(f'FAIL receipt policy: {exc}', file=sys.stderr)
         return 1
     except Exception as exc:
         print(f'FAIL error: {exc}', file=sys.stderr)
-        return 1
+        return 3
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -62,7 +62,7 @@ def main(argv=None) -> int:
     args = build_parser().parse_args(argv)
     if args.command == 'verify':
         return verify_receipt(args.receipt_path, args.schema, args.policy)
-    return 1
+    return 3
 
 
 if __name__ == '__main__':

--- a/signal-core/cli/receipts.py
+++ b/signal-core/cli/receipts.py
@@ -6,14 +6,15 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+from policy.rql_lite import PolicyError, evaluate_policy_file
 from validator.schema_validate import ReceiptSchemaError, validate_receipt
 
 
 DEFAULT_SCHEMA = ROOT / 'schema' / 'verification-receipt-v0.1.schema.json'
 
 
-def verify_receipt(receipt_path: str, schema_path: str = None) -> int:
-    """Verify a sealed receipt with the v0.1 structural contract."""
+def verify_receipt(receipt_path: str, schema_path: str = None, policy_path: str = None) -> int:
+    """Verify a sealed receipt with the v0.1 structural contract and optional policy gate."""
     try:
         path = Path(receipt_path)
         receipt = json.loads(path.read_text(encoding='utf-8'))
@@ -23,6 +24,11 @@ def verify_receipt(receipt_path: str, schema_path: str = None) -> int:
             print(f'Schema check: {schema}')
 
         validate_receipt(receipt)
+
+        if policy_path:
+            evaluate_policy_file(receipt, policy_path)
+            print(f'Policy check: {policy_path}')
+
         print('PASS Receipt verified')
         return 0
     except FileNotFoundError as exc:
@@ -33,6 +39,9 @@ def verify_receipt(receipt_path: str, schema_path: str = None) -> int:
         return 1
     except ReceiptSchemaError as exc:
         print(f'FAIL receipt schema: {exc}', file=sys.stderr)
+        return 1
+    except PolicyError as exc:
+        print(f'FAIL receipt policy: {exc}', file=sys.stderr)
         return 1
     except Exception as exc:
         print(f'FAIL error: {exc}', file=sys.stderr)
@@ -45,13 +54,14 @@ def build_parser() -> argparse.ArgumentParser:
     verify = sub.add_parser('verify', help='verify a sealed receipt')
     verify.add_argument('receipt_path')
     verify.add_argument('--schema', default=None)
+    verify.add_argument('--policy', default=None)
     return parser
 
 
 def main(argv=None) -> int:
     args = build_parser().parse_args(argv)
     if args.command == 'verify':
-        return verify_receipt(args.receipt_path, args.schema)
+        return verify_receipt(args.receipt_path, args.schema, args.policy)
     return 1
 
 

--- a/signal-core/policies/strict_research.rql
+++ b/signal-core/policies/strict_research.rql
@@ -1,0 +1,4 @@
+# RQL-lite v0.2 admission policy
+REQUIRE confidence.authority == NONE
+REQUIRE claims_count >= 1
+DENY confidence.authority != NONE

--- a/signal-core/policy/rql_lite.py
+++ b/signal-core/policy/rql_lite.py
@@ -18,6 +18,10 @@ def parse_value(raw):
     try:
         return int(raw)
     except ValueError:
+        pass
+    try:
+        return float(raw)
+    except ValueError:
         return raw
 
 

--- a/signal-core/policy/rql_lite.py
+++ b/signal-core/policy/rql_lite.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+
+class PolicyError(ValueError):
+    pass
+
+
+def parse_value(raw):
+    raw = raw.strip()
+    if raw in ('true', 'True'):
+        return True
+    if raw in ('false', 'False'):
+        return False
+    if raw in ('null', 'None'):
+        return None
+    if len(raw) >= 2 and raw[0] in ('"', "'") and raw[-1] == raw[0]:
+        return raw[1:-1]
+    try:
+        return int(raw)
+    except ValueError:
+        return raw
+
+
+def parse_line(line, idx):
+    parts = line.split()
+    if len(parts) < 4:
+        raise PolicyError(f'invalid policy line {idx}: {line}')
+    action, path, op = parts[0], parts[1], parts[2]
+    expected = parse_value(' '.join(parts[3:]))
+    if action not in ('REQUIRE', 'DENY'):
+        raise PolicyError(f'invalid action line {idx}: {action}')
+    if op not in ('==', '!=', '>=', '<=', '>', '<'):
+        raise PolicyError(f'invalid operator line {idx}: {op}')
+    return (action, path, op, expected, idx)
+
+
+def parse_policy(text):
+    rules = []
+    for idx, line in enumerate(text.splitlines(), start=1):
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        rules.append(parse_line(line, idx))
+    return rules
+
+
+def get_path(obj, dotted):
+    cur = obj
+    for part in dotted.split('.'):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            raise PolicyError(f'missing path: {dotted}')
+    return cur
+
+
+def compare(actual, op, expected):
+    if op == '==':
+        return actual == expected
+    if op == '!=':
+        return actual != expected
+    if not isinstance(actual, (int, float)) or not isinstance(expected, (int, float)):
+        raise PolicyError('ordered comparison requires numbers')
+    if op == '>=':
+        return actual >= expected
+    if op == '<=':
+        return actual <= expected
+    if op == '>':
+        return actual > expected
+    if op == '<':
+        return actual < expected
+    raise PolicyError(f'unsupported operator: {op}')
+
+
+def evaluate_policy(receipt, rules):
+    for action, path, op, expected, idx in rules:
+        actual = get_path(receipt, path)
+        ok = compare(actual, op, expected)
+        if action == 'REQUIRE' and not ok:
+            raise PolicyError(f'REQUIRE failed line {idx}: {path} {op} {expected}; actual={actual}')
+        if action == 'DENY' and ok:
+            raise PolicyError(f'DENY failed line {idx}: {path} {op} {expected}; actual={actual}')
+    return True
+
+
+def evaluate_policy_file(receipt, policy_path):
+    return evaluate_policy(receipt, parse_policy(Path(policy_path).read_text(encoding='utf-8')))

--- a/signal-core/tests/test_admission_controller.py
+++ b/signal-core/tests/test_admission_controller.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import json
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from cli.receipts import verify_receipt
+from core import seal
+from policy.rql_lite import PolicyError, evaluate_policy, parse_policy
+
+
+def sealed_receipt(tmp_path):
+    artifact = tmp_path / 'artifact.txt'
+    artifact.write_text('hello', encoding='utf-8')
+    graph = tmp_path / 'graph.json'
+    graph.write_text(json.dumps({'authority':'NONE','claims':[{'claim_id':'a','dependencies':[]}]}), encoding='utf-8')
+    receipt = seal(str(artifact), str(graph))
+    receipt_path = tmp_path / 'sealed_receipt.json'
+    receipt_path.write_text(json.dumps(receipt), encoding='utf-8')
+    return receipt, receipt_path
+
+
+def test_policy_accepts_strict_research(tmp_path):
+    receipt, receipt_path = sealed_receipt(tmp_path)
+    policy = tmp_path / 'policy.rql'
+    policy.write_text('REQUIRE confidence.authority == NONE\nREQUIRE claims_count >= 1\n', encoding='utf-8')
+    assert verify_receipt(str(receipt_path), policy_path=str(policy)) == 0
+
+
+def test_policy_denies_wrong_claim_count(tmp_path):
+    receipt, _ = sealed_receipt(tmp_path)
+    rules = parse_policy('REQUIRE claims_count > 1\n')
+    try:
+        evaluate_policy(receipt, rules)
+        assert False
+    except PolicyError as exc:
+        assert 'REQUIRE failed' in str(exc)
+
+
+def test_policy_denies_authority_root():
+    receipt = {
+        'confidence': {'authority': 'ROOT'},
+        'claims_count': 1
+    }
+    rules = parse_policy('DENY confidence.authority != NONE\n')
+    try:
+        evaluate_policy(receipt, rules)
+        assert False
+    except PolicyError as exc:
+        assert 'DENY failed' in str(exc)

--- a/signal-core/tests/test_admission_controller.py
+++ b/signal-core/tests/test_admission_controller.py
@@ -28,6 +28,13 @@ def test_policy_accepts_strict_research(tmp_path):
     assert verify_receipt(str(receipt_path), policy_path=str(policy)) == 0
 
 
+def test_policy_failure_exit_code_is_one(tmp_path):
+    receipt, receipt_path = sealed_receipt(tmp_path)
+    policy = tmp_path / 'policy.rql'
+    policy.write_text('REQUIRE claims_count > 1\n', encoding='utf-8')
+    assert verify_receipt(str(receipt_path), policy_path=str(policy)) == 1
+
+
 def test_policy_denies_wrong_claim_count(tmp_path):
     receipt, _ = sealed_receipt(tmp_path)
     rules = parse_policy('REQUIRE claims_count > 1\n')
@@ -49,3 +56,25 @@ def test_policy_denies_authority_root():
         assert False
     except PolicyError as exc:
         assert 'DENY failed' in str(exc)
+
+
+def test_policy_missing_path_fails():
+    rules = parse_policy('REQUIRE confidence.missing == NONE\n')
+    try:
+        evaluate_policy({'confidence': {'authority': 'NONE'}}, rules)
+        assert False
+    except PolicyError as exc:
+        assert 'missing path' in str(exc)
+
+
+def test_policy_float_comparison():
+    rules = parse_policy('REQUIRE score >= 0.75\n')
+    assert evaluate_policy({'score': 0.8}, rules) is True
+
+
+def test_policy_rejects_in_operator():
+    try:
+        parse_policy('REQUIRE confidence.authority in NONE,ROOT\n')
+        assert False
+    except PolicyError as exc:
+        assert 'invalid operator' in str(exc)

--- a/signal-core/tests/test_receipt_cli.py
+++ b/signal-core/tests/test_receipt_cli.py
@@ -32,4 +32,4 @@ def test_receipts_verify_rejects_verdict(tmp_path):
     }
     receipt_path = tmp_path / 'bad_receipt.json'
     receipt_path.write_text(json.dumps(receipt), encoding='utf-8')
-    assert verify_receipt(str(receipt_path)) == 1
+    assert verify_receipt(str(receipt_path)) == 2


### PR DESCRIPTION
Adds the v0.2 admission controller boundary for Receipt Core.

Adds:
- signal-core/policy/rql_lite.py
- signal-core/policy/__init__.py
- signal-core/policies/strict_research.rql
- signal-core/tests/test_admission_controller.py

Updates:
- signal-core/cli/receipts.py now supports --policy on verify

Usage:
python signal-core/cli/receipts.py verify sealed_receipt.json --policy signal-core/policies/strict_research.rql

Semantics:
- REQUIRE rules must evaluate true
- DENY rules must evaluate false
- first policy failure exits 1 with structured reason
- no dependency added
- no receipt semantic mutation
- authority remains NONE