### PR TITLE
eas: add receipt core schema anchor v0.4

### DIFF
--- a/signal-core/eas/README_EAS_V0_4.md
+++ b/signal-core/eas/README_EAS_V0_4.md
@@ -1,0 +1,47 @@
+# Receipt Core v0.4: EAS Schema Anchor
+
+Receipt Core v0.4 adds an optional public EAS schema anchor for receipts and receipt bundles.
+
+This does not change local verification semantics.
+
+## Invariant
+
+```text
+Authority: NONE
+```
+
+The EAS schema is a public coordination point, not an authority grant.
+
+## Schema string
+
+```text
+string receiptId,string artifactHash,string claimGraphHash,uint256 claimsCount,string receiptCoreHash,bool authorityNone,string policyHash,string bundleRoot,string version
+```
+
+## Registration intent
+
+- Resolver: none
+- Revocable: false
+- Versioned: yes
+- Future versions require new schema UIDs
+
+## Operator warning
+
+Admission Controller status is determined by the most granular failure. A Policy Fail (1) prevents pipeline completion just as effectively as a Schema/Receipt Fail (2). Always check exit codes before automated downstream deployments.
+
+## Registration command placeholder
+
+Use EAS SDK or EAS CLI against the target chain and register the schema string above with no resolver and revocable=false.
+
+After registration, record:
+
+```text
+network:
+schema_uid:
+transaction_hash:
+explorer_url:
+```
+
+## Next rail
+
+After schema registration, v0.4 can add optional attestation checks to `verify_chain.py` without changing receipt semantics.

--- a/signal-core/eas/receipt-core-v0.4.eas.json
+++ b/signal-core/eas/receipt-core-v0.4.eas.json
@@ -1,0 +1,23 @@
+{
+  "version": "v0.4",
+  "authority": "NONE",
+  "resolver": "none",
+  "revocable": false,
+  "schema": "string receiptId,string artifactHash,string claimGraphHash,uint256 claimsCount,string receiptCoreHash,bool authorityNone,string policyHash,string bundleRoot,string version",
+  "fields": [
+    "receiptId",
+    "artifactHash",
+    "claimGraphHash",
+    "claimsCount",
+    "receiptCoreHash",
+    "authorityNone",
+    "policyHash",
+    "bundleRoot",
+    "version"
+  ],
+  "notes": [
+    "EAS anchors receipt structure publicly.",
+    "authorityNone must remain true.",
+    "Future schema versions require new schema UIDs."
+  ]
+}

--- a/signal-core/tests/test_eas_manifest.py
+++ b/signal-core/tests/test_eas_manifest.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_eas_manifest_authority_none():
+    manifest = json.loads((ROOT / 'eas' / 'receipt-core-v0.4.eas.json').read_text(encoding='utf-8'))
+    assert manifest['authority'] == 'NONE'
+    assert manifest['revocable'] is False
+    assert manifest['resolver'] == 'none'
+
+
+def test_eas_schema_contains_locked_fields():
+    manifest = json.loads((ROOT / 'eas' / 'receipt-core-v0.4.eas.json').read_text(encoding='utf-8'))
+    schema = manifest['schema']
+    for field in ['receiptId', 'artifactHash', 'claimGraphHash', 'claimsCount', 'receiptCoreHash', 'authorityNone', 'policyHash', 'bundleRoot', 'version']:
+        assert field in schema


### PR DESCRIPTION
Adds the v0.4 EAS schema anchor boundary for Receipt Core.

Adds:
- signal-core/eas/receipt-core-v0.4.eas.json
- signal-core/eas/README_EAS_V0_4.md
- signal-core/tests/test_eas_manifest.py

Purpose:
- public schema anchor for Receipt Core receipts and bundles
- no resolver / no authority delegation
- revocable=false intent
- future versions require new schema UIDs

Invariant:
- authority remains NONE
- local verification semantics unchanged
- EAS adds public discoverability, not truth authority

Next after merge:
- register schema on target EAS chain
- record network, schema UID, tx hash, explorer URL
- optionally add EAS attestation lookup to verify_chain.py