### PR TITLE
eas: record base schema registration

### DIFF
--- a/signal-core/eas/README_EAS_V0_4.md
+++ b/signal-core/eas/README_EAS_V0_4.md
@@ -18,6 +18,16 @@ The EAS schema is a public coordination point, not an authority grant.
 string receiptId,string artifactHash,string claimGraphHash,uint256 claimsCount,string receiptCoreHash,bool authorityNone,string policyHash,string bundleRoot,string version
 ```
 
+## Registration
+
+```text
+network: Base
+schema_number: 1618
+schema_uid: 0xa5b0d2dd5470542a119d50eba19898f50e1f77591f01d4fec4c6f3075054aa11
+creator: 0xC345B26094c63C69222Ee775189a3d3eaead5a84
+transaction_hash: 0x60f9ac0a4d23b112743cc902f4d3f8f06f239664f9b9cc0c3c2909ef682ea7bf
+```
+
 ## Registration intent
 
 - Resolver: none
@@ -29,19 +39,6 @@ string receiptId,string artifactHash,string claimGraphHash,uint256 claimsCount,s
 
 Admission Controller status is determined by the most granular failure. A Policy Fail (1) prevents pipeline completion just as effectively as a Schema/Receipt Fail (2). Always check exit codes before automated downstream deployments.
 
-## Registration command placeholder
-
-Use EAS SDK or EAS CLI against the target chain and register the schema string above with no resolver and revocable=false.
-
-After registration, record:
-
-```text
-network:
-schema_uid:
-transaction_hash:
-explorer_url:
-```
-
 ## Next rail
 
-After schema registration, v0.4 can add optional attestation checks to `verify_chain.py` without changing receipt semantics.
+After schema registration, v0.4 can add optional attestation checks to verify_chain.py without changing receipt semantics.

--- a/signal-core/eas/receipt-core-v0.4.eas.json
+++ b/signal-core/eas/receipt-core-v0.4.eas.json
@@ -3,6 +3,12 @@
   "authority": "NONE",
   "resolver": "none",
   "revocable": false,
+  "network": "Base",
+  "schema_number": 1618,
+  "schema_uid": "0xa5b0d2dd5470542a119d50eba19898f50e1f77591f01d4fec4c6f3075054aa11",
+  "creator": "0xC345B26094c63C69222Ee775189a3d3eaead5a84",
+  "transaction_hash": "0x60f9ac0a4d23b112743cc902f4d3f8f06f239664f9b9cc0c3c2909ef682ea7bf",
+  "explorer_url": "https://base.easscan.org/schema/view/0xa5b0d2dd5470542a119d50eba19898f50e1f77591f01d4fec4c6f3075054aa11",
   "schema": "string receiptId,string artifactHash,string claimGraphHash,uint256 claimsCount,string receiptCoreHash,bool authorityNone,string policyHash,string bundleRoot,string version",
   "fields": [
     "receiptId",

--- a/signal-core/tests/test_eas_manifest.py
+++ b/signal-core/tests/test_eas_manifest.py
@@ -4,15 +4,28 @@ import json
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def load_manifest():
+    return json.loads((ROOT / 'eas' / 'receipt-core-v0.4.eas.json').read_text(encoding='utf-8'))
+
+
 def test_eas_manifest_authority_none():
-    manifest = json.loads((ROOT / 'eas' / 'receipt-core-v0.4.eas.json').read_text(encoding='utf-8'))
+    manifest = load_manifest()
     assert manifest['authority'] == 'NONE'
     assert manifest['revocable'] is False
     assert manifest['resolver'] == 'none'
 
 
 def test_eas_schema_contains_locked_fields():
-    manifest = json.loads((ROOT / 'eas' / 'receipt-core-v0.4.eas.json').read_text(encoding='utf-8'))
+    manifest = load_manifest()
     schema = manifest['schema']
     for field in ['receiptId', 'artifactHash', 'claimGraphHash', 'claimsCount', 'receiptCoreHash', 'authorityNone', 'policyHash', 'bundleRoot', 'version']:
         assert field in schema
+
+
+def test_eas_registration_details_locked():
+    manifest = load_manifest()
+    assert manifest['network'] == 'Base'
+    assert manifest['schema_number'] == 1618
+    assert manifest['schema_uid'] == '0xa5b0d2dd5470542a119d50eba19898f50e1f77591f01d4fec4c6f3075054aa11'
+    assert manifest['creator'] == '0xC345B26094c63C69222Ee775189a3d3eaead5a84'
+    assert manifest['transaction_hash'] == '0x60f9ac0a4d23b112743cc902f4d3f8f06f239664f9b9cc0c3c2909ef682ea7bf'


### PR DESCRIPTION
Records the Base EAS schema registration for Receipt Core v0.4.

Adds registration details to:
- signal-core/eas/receipt-core-v0.4.eas.json
- signal-core/eas/README_EAS_V0_4.md
- signal-core/tests/test_eas_manifest.py

Registration:
- network: Base
- schema number: 1618
- schema UID: 0xa5b0d2dd5470542a119d50eba19898f50e1f77591f01d4fec4c6f3075054aa11
- creator: 0xC345B26094c63C69222Ee775189a3d3eaead5a84
- tx: 0x60f9ac0a4d23b112743cc902f4d3f8f06f239664f9b9cc0c3c2909ef682ea7bf

Invariant:
- authority remains NONE
- local semantics unchanged
- public schema anchor recorded as discoverability, not delegated authority