### PR TITLE
eas: scaffold attestation verification v0.5

### DIFF
--- a/signal-core/eas/verify_attestation.py
+++ b/signal-core/eas/verify_attestation.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Optional EAS attestation verification rail for Receipt Core.
+
+This module keeps EAS lookup optional. Local verification remains the source of
+execution semantics. EAS is used only as a public schema and attestation lookup.
+
+Exit map:
+0 = pass
+1 = policy fail
+2 = schema / attestation / receipt mismatch
+3 = system / missing dependency / input error
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / 'eas' / 'receipt-core-v0.4.eas.json'
+
+
+def load_manifest(path=MANIFEST_PATH):
+    return json.loads(Path(path).read_text(encoding='utf-8'))
+
+
+def load_local_receipt(path):
+    return json.loads(Path(path).read_text(encoding='utf-8'))
+
+
+def require_optional_sdk():
+    try:
+        from EAS import EAS  # type: ignore
+    except Exception as exc:
+        raise RuntimeError('optional EAS SDK missing; install eas-sdk/web3 before live lookup') from exc
+    return EAS
+
+
+def normalize_decoded_data(decoded):
+    if decoded is None:
+        return {}
+    if isinstance(decoded, dict):
+        return decoded
+    if isinstance(decoded, list):
+        out = {}
+        for item in decoded:
+            if isinstance(item, dict) and 'name' in item and 'value' in item:
+                out[item['name']] = item['value']
+        return out
+    return {}
+
+
+def verify_attestation_data(attestation, local_receipt_path=None, manifest_path=MANIFEST_PATH):
+    manifest = load_manifest(manifest_path)
+    expected_schema = manifest['schema_uid']
+    att_schema = getattr(attestation, 'schema', None)
+    if att_schema != expected_schema:
+        print('FAIL EAS schema mismatch', file=sys.stderr)
+        return 2
+
+    data = normalize_decoded_data(getattr(attestation, 'decoded_data', None))
+    if data.get('authorityNone') is not True:
+        print('FAIL EAS authorityNone missing or false', file=sys.stderr)
+        return 2
+
+    if local_receipt_path:
+        receipt = load_local_receipt(local_receipt_path)
+        if data.get('receiptCoreHash') != receipt.get('receipt_core_hash'):
+            print('FAIL EAS receiptCoreHash mismatch', file=sys.stderr)
+            return 2
+        if data.get('receiptId') != receipt.get('receipt_id'):
+            print('FAIL EAS receiptId mismatch', file=sys.stderr)
+            return 2
+
+    print('PASS EAS attestation verified')
+    return 0
+
+
+def verify_onchain_attestation(attestation_uid, local_receipt_path=None):
+    try:
+        EAS = require_optional_sdk()
+        eas = EAS.from_chain(chain='base')
+        attestation = eas.get_attestation(attestation_uid)
+        return verify_attestation_data(attestation, local_receipt_path)
+    except RuntimeError as exc:
+        print(f'FAIL EAS dependency: {exc}', file=sys.stderr)
+        return 3
+    except Exception as exc:
+        print(f'FAIL EAS lookup: {exc}', file=sys.stderr)
+        return 3
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        print('Usage: verify_attestation.py <attestation_uid> [local_receipt.json]', file=sys.stderr)
+        return 3
+    uid = argv[0]
+    local = argv[1] if len(argv) > 1 else None
+    return verify_onchain_attestation(uid, local)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/signal-core/tests/test_eas_attestation.py
+++ b/signal-core/tests/test_eas_attestation.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import json
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from eas.verify_attestation import verify_attestation_data
+
+
+class FakeAttestation:
+    def __init__(self, schema, decoded_data):
+        self.schema = schema
+        self.decoded_data = decoded_data
+
+
+def test_eas_attestation_accepts_matching_local_receipt(tmp_path):
+    receipt = {
+        'receipt_id': 'vr:sha256:' + 'a' * 64,
+        'receipt_core_hash': 'sha256:' + 'b' * 64
+    }
+    receipt_path = tmp_path / 'receipt.json'
+    receipt_path.write_text(json.dumps(receipt), encoding='utf-8')
+    att = FakeAttestation(
+        '0xa5b0d2dd5470542a119d50eba19898f50e1f77591f01d4fec4c6f3075054aa11',
+        {
+            'authorityNone': True,
+            'receiptId': receipt['receipt_id'],
+            'receiptCoreHash': receipt['receipt_core_hash'],
+            'version': 'v0.4'
+        }
+    )
+    assert verify_attestation_data(att, str(receipt_path)) == 0
+
+
+def test_eas_attestation_rejects_schema_mismatch():
+    att = FakeAttestation('0x' + '0' * 64, {'authorityNone': True})
+    assert verify_attestation_data(att) == 2
+
+
+def test_eas_attestation_rejects_authority_escalation():
+    att = FakeAttestation(
+        '0xa5b0d2dd5470542a119d50eba19898f50e1f77591f01d4fec4c6f3075054aa11',
+        {'authorityNone': False}
+    )
+    assert verify_attestation_data(att) == 2
+
+
+def test_eas_attestation_rejects_receipt_hash_mismatch(tmp_path):
+    receipt = {
+        'receipt_id': 'vr:sha256:' + 'a' * 64,
+        'receipt_core_hash': 'sha256:' + 'b' * 64
+    }
+    receipt_path = tmp_path / 'receipt.json'
+    receipt_path.write_text(json.dumps(receipt), encoding='utf-8')
+    att = FakeAttestation(
+        '0xa5b0d2dd5470542a119d50eba19898f50e1f77591f01d4fec4c6f3075054aa11',
+        {
+            'authorityNone': True,
+            'receiptId': receipt['receipt_id'],
+            'receiptCoreHash': 'sha256:' + 'c' * 64,
+            'version': 'v0.4'
+        }
+    )
+    assert verify_attestation_data(att, str(receipt_path)) == 2


### PR DESCRIPTION
Scaffolds optional EAS attestation verification for Receipt Core v0.5.

Adds:
- signal-core/eas/verify_attestation.py
- signal-core/tests/test_eas_attestation.py

Behavior:
- validates attestation schema UID against the registered Base EAS schema
- requires authorityNone true
- optionally cross-checks receiptId and receiptCoreHash against a local receipt
- preserves local verification semantics
- keeps live EAS SDK lookup optional so CI does not require network/dependencies

Exit map:
- 0 pass
- 2 schema/attestation/receipt mismatch
- 3 missing SDK / lookup / input error

Note:
- The larger verify_chain.py --eas CLI hook was intentionally deferred to keep this PR small and CI-safe after the connector filtered the larger patch.