### PR TITLE
jaytree: add AL Base MCP external root v0.1

### DIFF
--- a/jaytree/external-roots/README.md
+++ b/jaytree/external-roots/README.md
@@ -1,0 +1,38 @@
+# Jaytree External Roots
+
+External roots connect existing proof surfaces outside COMPUTERWISDOM into the Jaytree / Receipt Core stack.
+
+## Current external root
+
+```text
+al-base-mcp-v0.1.json
+```
+
+This root points to the existing `jsonwisdom/AL` Base MCP / ALMS scaffold.
+
+## Boundary
+
+```text
+Authority: NONE
+Runtime: NOT_PERMITTED
+Wallet authority: false
+Execution authority: false
+x402 enabled: false
+Signing enabled: false
+```
+
+## Purpose
+
+The AL Base MCP external root is a read-only bridge. It records that the AL scaffold exists and can be referenced by COMPUTERWISDOM receipts later.
+
+It does not grant execution authority, wallet authority, signing authority, payment authority, or runtime authority.
+
+## Future receipt flow
+
+```text
+fetch raw AL files only
+compute deterministic hashes
+verify local manifest
+seal Receipt Core receipt
+attest only after local verify exit 0
+```

--- a/jaytree/external-roots/al-base-mcp-v0.1.json
+++ b/jaytree/external-roots/al-base-mcp-v0.1.json
@@ -1,0 +1,29 @@
+{
+  "version": "al-base-mcp-external-root-v0.1",
+  "source_repo": "jsonwisdom/AL",
+  "identity_anchor": "jaywisdom.base.eth",
+  "base_mcp_plan": "docs/base-mcp-alms-agent-plan.md",
+  "scaffold_audit_receipt": "docs/base-mcp-scaffold-audit-receipt.md",
+  "action_receipt_schema": "agents/base_mcp/schemas/action_receipt.schema.json",
+  "permission_policy_schema": "agents/base_mcp/schemas/permission_policy.schema.json",
+  "session_log_schema": "agents/base_mcp/schemas/session_log.schema.json",
+  "authority": "NONE",
+  "runtime": "NOT_PERMITTED",
+  "wallet_authority": false,
+  "execution_authority": false,
+  "merge_authority": false,
+  "human_approval_required": true,
+  "x402_enabled": false,
+  "signing_enabled": false,
+  "target_stack": "COMPUTERWISDOM Receipt Core / EAS / Jaytree",
+  "timestamp": "2026-06-24T21:58:20Z",
+  "invariants": [
+    "External root is read-only.",
+    "Authority remains NONE.",
+    "Runtime remains NOT_PERMITTED.",
+    "Wallet authority remains false.",
+    "Execution authority remains false.",
+    "Human approval is required before any future live workflow.",
+    "Identity anchor does not prove truth."
+  ]
+}

--- a/jaytree/tests/test_al_base_mcp_external_root.py
+++ b/jaytree/tests/test_al_base_mcp_external_root.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXTERNAL_ROOT = ROOT / 'external-roots' / 'al-base-mcp-v0.1.json'
+
+
+def load_root():
+    return json.loads(EXTERNAL_ROOT.read_text(encoding='utf-8'))
+
+
+def test_external_root_authority_boundaries():
+    root = load_root()
+    assert root['authority'] == 'NONE'
+    assert root['runtime'] == 'NOT_PERMITTED'
+    assert root['wallet_authority'] is False
+    assert root['execution_authority'] is False
+    assert root['merge_authority'] is False
+    assert root['x402_enabled'] is False
+    assert root['signing_enabled'] is False
+    assert root['human_approval_required'] is True
+
+
+def test_external_root_required_paths():
+    root = load_root()
+    assert root['source_repo'] == 'jsonwisdom/AL'
+    assert root['identity_anchor'] == 'jaywisdom.base.eth'
+    assert root['base_mcp_plan'] == 'docs/base-mcp-alms-agent-plan.md'
+    assert root['scaffold_audit_receipt'] == 'docs/base-mcp-scaffold-audit-receipt.md'
+    assert root['action_receipt_schema'] == 'agents/base_mcp/schemas/action_receipt.schema.json'
+    assert root['permission_policy_schema'] == 'agents/base_mcp/schemas/permission_policy.schema.json'
+    assert root['session_log_schema'] == 'agents/base_mcp/schemas/session_log.schema.json'
+
+
+def test_external_root_target_stack():
+    root = load_root()
+    assert 'COMPUTERWISDOM' in root['target_stack']
+    assert 'Receipt Core' in root['target_stack']
+    assert 'EAS' in root['target_stack']
+    assert 'Jaytree' in root['target_stack']


### PR DESCRIPTION
Adds a read-only Jaytree external root for the existing jsonwisdom/AL Base MCP scaffold.

Files:
- jaytree/external-roots/al-base-mcp-v0.1.json
- jaytree/external-roots/README.md
- jaytree/tests/test_al_base_mcp_external_root.py

Boundary:
- authority NONE
- runtime NOT_PERMITTED
- wallet authority false
- execution authority false
- x402 disabled
- signing disabled
- human approval required

Purpose:
Bridge the AL Base MCP scaffold into COMPUTERWISDOM Receipt Core / EAS / Jaytree as a verifiable read-only proof surface.