### PR TITLE
docs: add jaytree external root front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@
 >
 > **Security:** See `SECURITY_BOUNDARY.md`. No keys belong in this repo.
 
+## Jaytree External Roots v0.1
+
+- AL Base MCP: `jaytree/external-roots/al-base-mcp-v0.1.json`
+  - Authority: NONE
+  - Runtime: NOT_PERMITTED
+  - Human approval: REQUIRED
+  - Wallet authority: false
+  - Execution authority: false
+  - Signing enabled: false
+  - x402 enabled: false
+  - Connected to future Receipt bundles and EAS attestations
+
 ## Replay Root Map
 
 This repository is an operations lane. It can coordinate replay checks, prepare witness payloads, and preserve operational receipts, but it does not replace the canonical proof root.

--- a/signal-core/README.md
+++ b/signal-core/README.md
@@ -1,3 +1,25 @@
 # Signal Core
 
 Receipt pipeline scaffold for COMPUTERWISDOM.
+
+## jaytree External Roots v0.1
+
+- AL Base MCP: `jaytree/external-roots/al-base-mcp-v0.1.json`
+  - Authority: NONE
+  - Runtime: NOT_PERMITTED
+  - Human approval: REQUIRED
+  - Wallet authority: false
+  - Execution authority: false
+  - Signing enabled: false
+  - x402 enabled: false
+  - Connected to future Receipt bundles and EAS attestations
+
+## Receipt flow
+
+```text
+fetch raw AL files only
+compute deterministic hashes
+verify local manifest
+seal Receipt Core receipt
+attest only after local verify exit 0
+```


### PR DESCRIPTION
Adds README front-door entries for the merged AL Base MCP external root.

Includes:
- main README entry
- signal-core README entry

Boundary:
- Authority: NONE
- Runtime: NOT_PERMITTED
- Human approval: REQUIRED
- Wallet/execution/signing/x402 remain false