### PR TITLE
jaytree: record AL Base MCP EAS receipt

### DIFF
--- a/jaytree/external-roots/receipts/README.md
+++ b/jaytree/external-roots/receipts/README.md
@@ -1,0 +1,13 @@
+# Jaytree External Root Receipts
+
+This folder records EAS receipts for Jaytree external roots.
+
+## AL Base MCP v0.1
+
+```text
+source_root: jaytree/external-roots/al-base-mcp-v0.1.json
+attestation_uid: 0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb
+transaction_hash: 0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c
+receipt_id: vr:sha256:cc438cbc26e0139d0b581f0ca3ae4434e0ee82cf5d3740e446ca0ad45d9b2166
+authority: NONE
+```

--- a/jaytree/external-roots/receipts/al-base-mcp-v0.1.eas-receipt.json
+++ b/jaytree/external-roots/receipts/al-base-mcp-v0.1.eas-receipt.json
@@ -1,0 +1,17 @@
+{
+  "version": "al-base-mcp-eas-receipt-v0.1",
+  "authority": "NONE",
+  "source_root": "jaytree/external-roots/al-base-mcp-v0.1.json",
+  "schema_uid": "0xa5b0d2dd5470542a119d50eba19898f50e1f77591f01d4fec4c6f3075054aa11",
+  "attestation_uid": "0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb",
+  "transaction_hash": "0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c",
+  "receipt_id": "vr:sha256:cc438cbc26e0139d0b581f0ca3ae4434e0ee82cf5d3740e446ca0ad45d9b2166",
+  "artifact_hash": "sha256:ea7e811fa72d674d983697b2332166893a8aaae11867568f99463daeb801cba1",
+  "claim_graph_hash": "sha256:ef34e06e590dd4443863975fbc648389560494dc12f615a7d7081bfca484682f",
+  "claims_count": 1,
+  "receipt_core_hash": "sha256:8a71d51008ab2d522202d3cfd0668eb8f33f0f97eb72c71ccf80f1d4b045f914",
+  "authority_none": true,
+  "policy_hash": "sha256:09b05a9f300be49131fe95e279f295cf6eb4e8e3f817f5c31ec2831e16ebe973",
+  "bundle_root": "sha256:ac814f77d98b991ae983b7a11e9b229eb909eb5e24f061fc91b0211b7272f2e6",
+  "receipt_version": "v0.1"
+}

--- a/jaytree/tests/test_al_base_mcp_eas_receipt.py
+++ b/jaytree/tests/test_al_base_mcp_eas_receipt.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT = ROOT / 'external-roots' / 'receipts' / 'al-base-mcp-v0.1.eas-receipt.json'
+
+
+def load_receipt():
+    return json.loads(RECEIPT.read_text(encoding='utf-8'))
+
+
+def test_al_base_mcp_eas_receipt_authority_none():
+    receipt = load_receipt()
+    assert receipt['authority'] == 'NONE'
+    assert receipt['authority_none'] is True
+
+
+def test_al_base_mcp_eas_receipt_locked_ids():
+    receipt = load_receipt()
+    assert receipt['source_root'] == 'jaytree/external-roots/al-base-mcp-v0.1.json'
+    assert receipt['schema_uid'] == '0xa5b0d2dd5470542a119d50eba19898f50e1f77591f01d4fec4c6f3075054aa11'
+    assert receipt['attestation_uid'] == '0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb'
+    assert receipt['transaction_hash'] == '0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c'
+    assert receipt['receipt_id'] == 'vr:sha256:cc438cbc26e0139d0b581f0ca3ae4434e0ee82cf5d3740e446ca0ad45d9b2166'
+    assert receipt['receipt_core_hash'] == 'sha256:8a71d51008ab2d522202d3cfd0668eb8f33f0f97eb72c71ccf80f1d4b045f914'


### PR DESCRIPTION
Records the AL Base MCP external root EAS receipt as an append-only Jaytree receipt.

Adds:
- jaytree/external-roots/receipts/al-base-mcp-v0.1.eas-receipt.json
- jaytree/external-roots/receipts/README.md
- jaytree/tests/test_al_base_mcp_eas_receipt.py

Receipt:
- UID: 0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb
- TX: 0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c
- Authority: NONE

Note: original external root stays stable; attestation is recorded separately.