### PR TITLE
jaytree: index operations manual receipt log

### DIFF
--- a/jaytree/operations-manual/README.md
+++ b/jaytree/operations-manual/README.md
@@ -1,0 +1,30 @@
+# Jaytree Operations Manual Receipt Log
+
+This folder indexes the Base Builder Operations Manual v0.1 receipt lattice.
+
+## Current entries
+
+```text
+v0.1-al-base-mcp-root -> 261f7588a3955ec0f26b08eb609c888b7f12cbcc
+v0.1-al-base-mcp-eas-receipt -> 035802353e2ee622de0690aae4bfd6dd773b7bea
+```
+
+## Authority boundary
+
+```text
+Jay Wisdom = L0 human authority
+Boss Bre = manual maintainer / operator-context reviewer
+Authority: NONE at receipt layer
+Runtime: NOT_PERMITTED
+```
+
+## Closed surfaces
+
+```text
+wallet_authority: false
+execution_authority: false
+signing_authority: false
+merge_authority: false
+x402_enabled: false
+runtime_enabled: false
+```

--- a/jaytree/operations-manual/lattice-snapshot-v0.1.json
+++ b/jaytree/operations-manual/lattice-snapshot-v0.1.json
@@ -1,0 +1,43 @@
+{
+  "version": "operations-manual-lattice-snapshot-v0.1",
+  "status": "LOCKED",
+  "authority": "NONE",
+  "l0_human_authority": {
+    "name": "Jay Wisdom",
+    "ens": "jaywisdom.eth",
+    "basename": "jaywisdom.base.eth",
+    "address": "0xA380552a27b0a5a2874Ea7AA52CAC09f542002E8"
+  },
+  "manual_layer": {
+    "manual": "Base Builder Operations Manual v0.1",
+    "maintainer": "Boss Bre",
+    "maintainer_role": "manual maintainer and operator-context reviewer",
+    "wallet_authority": false,
+    "signing_authority": false,
+    "execution_authority": false,
+    "merge_authority": false
+  },
+  "root_layer": {
+    "external_root": "jaytree/external-roots/al-base-mcp-v0.1.json",
+    "tag": "v0.1-al-base-mcp-root",
+    "target_commit": "261f7588a3955ec0f26b08eb609c888b7f12cbcc",
+    "runtime": "NOT_PERMITTED",
+    "human_approval_required": true
+  },
+  "receipt_layer": {
+    "receipt": "jaytree/external-roots/receipts/al-base-mcp-v0.1.eas-receipt.json",
+    "tag": "v0.1-al-base-mcp-eas-receipt",
+    "target_commit": "035802353e2ee622de0690aae4bfd6dd773b7bea",
+    "eas_attestation_uid": "0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb",
+    "eas_transaction_hash": "0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c",
+    "receipt_id": "vr:sha256:cc438cbc26e0139d0b581f0ca3ae4434e0ee82cf5d3740e446ca0ad45d9b2166"
+  },
+  "closed_surfaces": {
+    "wallet_authority": false,
+    "execution_authority": false,
+    "signing_authority": false,
+    "merge_authority": false,
+    "x402_enabled": false,
+    "runtime_enabled": false
+  }
+}

--- a/jaytree/operations-manual/receipt-log-v0.1.json
+++ b/jaytree/operations-manual/receipt-log-v0.1.json
@@ -1,0 +1,43 @@
+{
+  "version": "operations-manual-receipt-log-v0.1",
+  "authority": "NONE",
+  "manual": "Base Builder Operations Manual v0.1",
+  "operator_authority": {
+    "human": "Jay Wisdom",
+    "ens": "jaywisdom.eth",
+    "basename": "jaywisdom.base.eth",
+    "address": "0xA380552a27b0a5a2874Ea7AA52CAC09f542002E8"
+  },
+  "entries": [
+    {
+      "entry_id": "al-base-mcp-root-v0.1",
+      "tag": "v0.1-al-base-mcp-root",
+      "tag_object_sha": "c11050b8cb0d084d40fb94f5711fda7e83fcf08d",
+      "target_commit": "261f7588a3955ec0f26b08eb609c888b7f12cbcc",
+      "artifact": "jaytree/external-roots/al-base-mcp-v0.1.json",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "human_approval_required": true
+    },
+    {
+      "entry_id": "al-base-mcp-eas-receipt-v0.1",
+      "tag": "v0.1-al-base-mcp-eas-receipt",
+      "tag_object_sha": "df193d6bebbff7edd5820d7e2bb24e6506e14574",
+      "target_commit": "035802353e2ee622de0690aae4bfd6dd773b7bea",
+      "artifact": "jaytree/external-roots/receipts/al-base-mcp-v0.1.eas-receipt.json",
+      "eas_attestation_uid": "0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb",
+      "eas_transaction_hash": "0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c",
+      "receipt_id": "vr:sha256:cc438cbc26e0139d0b581f0ca3ae4434e0ee82cf5d3740e446ca0ad45d9b2166",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "human_approval_required": true
+    }
+  ],
+  "invariants": [
+    "Jay Wisdom is L0 human authority.",
+    "GitHub tags pin merge artifacts.",
+    "EAS witnesses receipt payloads but does not create truth authority.",
+    "Boss Bre may maintain manuals but does not receive wallet, signing, execution, or merge authority by default.",
+    "Base MCP remains closed until a separate authority receipt enables runtime."
+  ]
+}

--- a/jaytree/tests/test_operations_manual_lattice.py
+++ b/jaytree/tests/test_operations_manual_lattice.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOG = ROOT / 'operations-manual' / 'receipt-log-v0.1.json'
+SNAPSHOT = ROOT / 'operations-manual' / 'lattice-snapshot-v0.1.json'
+
+
+def load(path):
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def test_receipt_log_tag_pair_locked():
+    log = load(LOG)
+    entries = {entry['entry_id']: entry for entry in log['entries']}
+    assert entries['al-base-mcp-root-v0.1']['tag'] == 'v0.1-al-base-mcp-root'
+    assert entries['al-base-mcp-root-v0.1']['target_commit'] == '261f7588a3955ec0f26b08eb609c888b7f12cbcc'
+    assert entries['al-base-mcp-eas-receipt-v0.1']['tag'] == 'v0.1-al-base-mcp-eas-receipt'
+    assert entries['al-base-mcp-eas-receipt-v0.1']['target_commit'] == '035802353e2ee622de0690aae4bfd6dd773b7bea'
+
+
+def test_receipt_log_eas_receipt_locked():
+    log = load(LOG)
+    receipt = {entry['entry_id']: entry for entry in log['entries']}['al-base-mcp-eas-receipt-v0.1']
+    assert receipt['eas_attestation_uid'] == '0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb'
+    assert receipt['eas_transaction_hash'] == '0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c'
+    assert receipt['receipt_id'] == 'vr:sha256:cc438cbc26e0139d0b581f0ca3ae4434e0ee82cf5d3740e446ca0ad45d9b2166'
+
+
+def test_lattice_closed_surfaces():
+    snapshot = load(SNAPSHOT)
+    closed = snapshot['closed_surfaces']
+    assert closed['wallet_authority'] is False
+    assert closed['execution_authority'] is False
+    assert closed['signing_authority'] is False
+    assert closed['merge_authority'] is False
+    assert closed['x402_enabled'] is False
+    assert closed['runtime_enabled'] is False
+
+
+def test_l0_and_boss_bre_boundary():
+    snapshot = load(SNAPSHOT)
+    assert snapshot['l0_human_authority']['name'] == 'Jay Wisdom'
+    assert snapshot['l0_human_authority']['ens'] == 'jaywisdom.eth'
+    assert snapshot['l0_human_authority']['basename'] == 'jaywisdom.base.eth'
+    assert snapshot['manual_layer']['maintainer'] == 'Boss Bre'
+    assert snapshot['manual_layer']['wallet_authority'] is False
+    assert snapshot['manual_layer']['signing_authority'] is False
+    assert snapshot['manual_layer']['execution_authority'] is False


### PR DESCRIPTION
Indexes the AL Base MCP tag pair into the Base Builder Operations Manual receipt log.

Adds:
- jaytree/operations-manual/README.md
- jaytree/operations-manual/receipt-log-v0.1.json
- jaytree/operations-manual/lattice-snapshot-v0.1.json
- jaytree/tests/test_operations_manual_lattice.py

Locks:
- v0.1-al-base-mcp-root -> 261f7588a3955ec0f26b08eb609c888b7f12cbcc
- v0.1-al-base-mcp-eas-receipt -> 035802353e2ee622de0690aae4bfd6dd773b7bea
- EAS UID 0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb
- TX 0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c

Boundary:
- Jay Wisdom = L0 human authority
- Boss Bre = manual maintainer / reviewer
- wallet/signing/execution/merge/x402/runtime remain false