### PR TITLE
jaytree: add Graphiti memory audit v0.1

### DIFF
--- a/jaytree/memory/graphiti-audit-v0.1.md
+++ b/jaytree/memory/graphiti-audit-v0.1.md
@@ -1,0 +1,169 @@
+# Graphiti Memory Audit v0.1
+
+## Scope
+
+This audit evaluates `getzep/graphiti` as a read-only temporal memory and retrieval layer for COMPUTERWISDOM Receipt Core / Jaytree / EAS.
+
+Graphiti is not evaluated as an authority system, signing system, execution system, merge system, or attestation system.
+
+## Current anchors
+
+```text
+L0 human authority: Jay Wisdom
+ENS: jaywisdom.eth
+Base name: jaywisdom.base.eth
+Address: 0xA380552a27b0a5a2874Ea7AA52CAC09f542002E8
+
+AL Base MCP root tag:
+v0.1-al-base-mcp-root -> 261f7588a3955ec0f26b08eb609c888b7f12cbcc
+
+AL Base MCP EAS receipt tag:
+v0.1-al-base-mcp-eas-receipt -> 035802353e2ee622de0690aae4bfd6dd773b7bea
+
+EAS UID:
+0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb
+
+TX:
+0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c
+
+Authority: NONE
+Runtime: NOT_PERMITTED
+```
+
+## Finding
+
+Graphiti may be useful as a temporal memory layer for Receipt Core / Jaytree if it is used as a rebuildable index over sealed artifacts.
+
+It should ingest public local artifacts as episodes:
+
+- Receipt Core JSON
+- EAS receipt JSON
+- Git tag references
+- Operations Manual receipt logs
+- Jaytree lattice snapshots
+- Markdown manuals
+
+The memory graph may support search and traversal across receipts, tags, attestations, commits, manuals, and authority boundaries.
+
+## Required invariant
+
+```text
+memory is not authority
+```
+
+Graphiti output must never create truth authority. Every result must cite source episodes and defer authority to sealed receipts, Git commits, EAS attestations, and L0 human approval.
+
+## Minimal ontology
+
+- `Receipt`
+- `Commit`
+- `Tag`
+- `EASAttestation`
+- `Manual`
+- `AuthorityBoundary`
+- `AgentRole`
+- `RuntimeSurface`
+
+## Relationship map
+
+```text
+Tag --PointsTo--> Commit
+Receipt --ReferencesAttestation--> EASAttestation
+Manual --IndexesReceipt--> Receipt
+AuthorityBoundary --ConstrainsRuntime--> RuntimeSurface
+AgentRole --Maintains--> Manual
+```
+
+## COMPUTERWISDOM mappings
+
+```text
+v0.1-al-base-mcp-root
+  --PointsTo-->
+261f7588a3955ec0f26b08eb609c888b7f12cbcc
+
+v0.1-al-base-mcp-eas-receipt
+  --PointsTo-->
+035802353e2ee622de0690aae4bfd6dd773b7bea
+
+vr:sha256:cc438cbc26e0139d0b581f0ca3ae4434e0ee82cf5d3740e446ca0ad45d9b2166
+  --ReferencesAttestation-->
+0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb
+
+Base Builder Operations Manual v0.1
+  --IndexesReceipt-->
+AL Base MCP root + AL Base MCP EAS receipt
+
+Boss Bre
+  --Maintains-->
+Base Builder Operations Manual v0.1
+```
+
+## Hard safety invariants
+
+1. Graphiti cannot create truth authority.
+2. Graphiti cannot sign.
+3. Graphiti cannot execute transactions.
+4. Graphiti cannot merge PRs.
+5. Graphiti cannot attest to EAS.
+6. Graphiti cannot hold wallet keys.
+7. Graphiti cannot hold GitHub write tokens.
+8. Graphiti cannot hold Base/EVM write RPC credentials.
+9. Graphiti output must cite source episodes.
+10. LLM extraction must not be trusted as canonical truth.
+11. Prescribed ontology is required for v0.1 ingestion.
+12. Graphiti is a rebuildable cache over sealed artifacts.
+13. Boss Bre manual-maintainer restrictions apply equally to Graphiti memory.
+
+## Recommended v0.1 architecture
+
+```text
+Receipt Core JSON / EAS / Git tags
+  -> local read-only file ingest
+  -> prescribed ontology mapper
+  -> Graphiti temporal graph
+  -> read-only query API
+  -> UI / agent memory
+```
+
+Truth flows one way only:
+
+```text
+sealed artifact -> memory index
+```
+
+Never:
+
+```text
+memory index -> authority / execution / signing / attestation
+```
+
+## Go / No-Go
+
+### GO
+
+Graphiti is acceptable for a read-only temporal memory prototype if:
+
+- prescribed ontology is used
+- local receipt episodes are the only source
+- read-only wrapper strips write tools
+- every response cites a source episode
+- no authority-bearing credentials are mounted
+- memory is explicitly labeled as non-authoritative
+
+### NO-GO
+
+Graphiti must not be used for:
+
+- truth creation
+- signing
+- wallet operations
+- Base writes
+- GitHub merges
+- EAS attestations
+- autonomous runtime enablement
+
+## Verdict
+
+Graphiti is a good candidate for `jaytree-memory-v0.1` as a read-only temporal retrieval layer.
+
+It should be treated as memory, not authority.

--- a/jaytree/memory/graphiti-memory-v0.1.json
+++ b/jaytree/memory/graphiti-memory-v0.1.json
@@ -1,0 +1,66 @@
+{
+  "version": "graphiti-memory-v0.1",
+  "status": "AUDIT_ONLY",
+  "authority": "NONE",
+  "runtime": "NOT_PERMITTED",
+  "project": "COMPUTERWISDOM / Jaytree temporal memory",
+  "candidate": {
+    "name": "Graphiti",
+    "repository": "getzep/graphiti",
+    "role": "read-only temporal memory and retrieval layer"
+  },
+  "l0_human_authority": {
+    "name": "Jay Wisdom",
+    "ens": "jaywisdom.eth",
+    "basename": "jaywisdom.base.eth",
+    "address": "0xA380552a27b0a5a2874Ea7AA52CAC09f542002E8"
+  },
+  "anchors": {
+    "root_tag": "v0.1-al-base-mcp-root",
+    "root_commit": "261f7588a3955ec0f26b08eb609c888b7f12cbcc",
+    "eas_receipt_tag": "v0.1-al-base-mcp-eas-receipt",
+    "eas_receipt_commit": "035802353e2ee622de0690aae4bfd6dd773b7bea",
+    "eas_uid": "0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb",
+    "eas_tx": "0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c",
+    "receipt_id": "vr:sha256:cc438cbc26e0139d0b581f0ca3ae4434e0ee82cf5d3740e446ca0ad45d9b2166"
+  },
+  "ontology": [
+    "Receipt",
+    "Commit",
+    "Tag",
+    "EASAttestation",
+    "Manual",
+    "AuthorityBoundary",
+    "AgentRole",
+    "RuntimeSurface"
+  ],
+  "allowed_inputs": [
+    "local Receipt Core JSON",
+    "local EAS receipt JSON",
+    "local Git tag references",
+    "local Operations Manual receipt logs",
+    "local Jaytree lattice snapshots",
+    "local Markdown manuals"
+  ],
+  "required_invariant": "memory is not authority",
+  "closed_surfaces": {
+    "wallet_authority": false,
+    "signing_authority": false,
+    "execution_authority": false,
+    "merge_authority": false,
+    "eas_attestation_authority": false,
+    "evm_write_rpc": false,
+    "github_write_token": false,
+    "x402_enabled": false,
+    "runtime_enabled": false
+  },
+  "prototype_constraints": [
+    "read-only wrapper required",
+    "source episodes required for every result",
+    "prescribed ontology required for v0.1",
+    "LLM extraction must not be trusted as canonical truth",
+    "Graphiti is rebuildable cache only",
+    "truth flows from sealed artifacts to memory index only"
+  ],
+  "verdict": "GO for read-only prototype; NO-GO for authority role"
+}

--- a/jaytree/tests/test_graphiti_memory_manifest.py
+++ b/jaytree/tests/test_graphiti_memory_manifest.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / 'memory' / 'graphiti-memory-v0.1.json'
+
+
+def load_manifest():
+    return json.loads(MANIFEST.read_text(encoding='utf-8'))
+
+
+def test_graphiti_memory_is_not_authority():
+    manifest = load_manifest()
+    assert manifest['authority'] == 'NONE'
+    assert manifest['runtime'] == 'NOT_PERMITTED'
+    assert manifest['required_invariant'] == 'memory is not authority'
+    assert manifest['verdict'] == 'GO for read-only prototype; NO-GO for authority role'
+
+
+def test_graphiti_closed_surfaces():
+    manifest = load_manifest()
+    closed = manifest['closed_surfaces']
+    assert closed['wallet_authority'] is False
+    assert closed['signing_authority'] is False
+    assert closed['execution_authority'] is False
+    assert closed['merge_authority'] is False
+    assert closed['eas_attestation_authority'] is False
+    assert closed['evm_write_rpc'] is False
+    assert closed['github_write_token'] is False
+    assert closed['x402_enabled'] is False
+    assert closed['runtime_enabled'] is False
+
+
+def test_graphiti_anchors_locked():
+    manifest = load_manifest()
+    anchors = manifest['anchors']
+    assert anchors['root_tag'] == 'v0.1-al-base-mcp-root'
+    assert anchors['root_commit'] == '261f7588a3955ec0f26b08eb609c888b7f12cbcc'
+    assert anchors['eas_receipt_tag'] == 'v0.1-al-base-mcp-eas-receipt'
+    assert anchors['eas_receipt_commit'] == '035802353e2ee622de0690aae4bfd6dd773b7bea'
+    assert anchors['eas_uid'] == '0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb'
+    assert anchors['eas_tx'] == '0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c'
+    assert anchors['receipt_id'] == 'vr:sha256:cc438cbc26e0139d0b581f0ca3ae4434e0ee82cf5d3740e446ca0ad45d9b2166'


### PR DESCRIPTION
Adds a read-only Graphiti temporal memory audit for COMPUTERWISDOM / Jaytree.

Adds:
- jaytree/memory/graphiti-audit-v0.1.md
- jaytree/memory/graphiti-memory-v0.1.json
- jaytree/tests/test_graphiti_memory_manifest.py

Boundary locked:
- authority NONE
- runtime NOT_PERMITTED
- memory is not authority
- no wallet/signing/execution/merge/EAS authority
- Graphiti is evaluated only as a rebuildable read-only memory/retrieval layer over sealed artifacts

Anchors preserved:
- v0.1-al-base-mcp-root -> 261f7588a3955ec0f26b08eb609c888b7f12cbcc
- v0.1-al-base-mcp-eas-receipt -> 035802353e2ee622de0690aae4bfd6dd773b7bea
- EAS UID 0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb
- TX 0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c