### PR TITLE
jaytree: add Graphiti read-only ingest prototype v0.1

### DIFF
--- a/jaytree/memory/ingest-ro/README.md
+++ b/jaytree/memory/ingest-ro/README.md
@@ -1,0 +1,60 @@
+# Graphiti Read-Only Ingest Prototype v0.1
+
+This directory contains a safe COMPUTERWISDOM memory-ingest prototype.
+
+It does **not** connect to Graphiti, Neo4j, FalkorDB, EAS, Base, GitHub write APIs, wallets, or any runtime executor.
+
+It prepares deterministic, Graphiti-shaped memory episodes from sealed local receipt artifacts only.
+
+## Invariant
+
+```text
+memory is not authority
+```
+
+## Boundary
+
+```text
+authority: NONE
+runtime: NOT_PERMITTED
+wallet_authority: false
+signing_authority: false
+execution_authority: false
+merge_authority: false
+eas_attestation_authority: false
+llm_extraction: false
+network_required: false
+```
+
+## Inputs
+
+The prototype reads only local repo files:
+
+```text
+jaytree/memory/graphiti-memory-v0.1.json
+jaytree/memory/receipts/graphiti-memory-v0.1.eas-receipt.json
+jaytree/operations-manual/receipt-log-v0.1.json
+jaytree/operations-manual/lattice-snapshot-v0.1.json
+jaytree/external-roots/receipts/al-base-mcp-v0.1.eas-receipt.json
+```
+
+Missing optional files are reported but do not create authority.
+
+## Output
+
+```text
+jaytree/memory/ingest-ro/out/episodes.jsonl
+jaytree/memory/ingest-ro/out/index.json
+```
+
+These outputs are rebuildable memory artifacts only.
+
+## Run
+
+From repo root:
+
+```bash
+python3 jaytree/memory/ingest-ro/prototype.py
+python3 jaytree/memory/ingest-ro/query.py receipt_id vr:sha256:c027a4129b426c47a2d373936bc005c1eacc00f3f10b0d7a5c0deea498fcbc1e
+python3 jaytree/memory/ingest-ro/query.py invariant "memory is not authority"
+```

--- a/jaytree/memory/ingest-ro/prototype.py
+++ b/jaytree/memory/ingest-ro/prototype.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Graphiti Read-Only Ingest Prototype v0.1
+
+Builds deterministic, Graphiti-shaped memory episodes from sealed local COMPUTERWISDOM artifacts.
+
+No Graphiti server.
+No DB writes.
+No network.
+No LLM extraction.
+No wallet/signing/execution/merge/EAS authority.
+
+Invariant: memory is not authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+OUT_DIR = ROOT / "jaytree" / "memory" / "ingest-ro" / "out"
+EPISODES_JSONL = OUT_DIR / "episodes.jsonl"
+INDEX_JSON = OUT_DIR / "index.json"
+
+REQUIRED_INVARIANT = "memory is not authority"
+AUTHORITY = "NONE"
+RUNTIME = "NOT_PERMITTED"
+GROUP_ID = "computerwisdom_v0.1"
+
+SOURCES = [
+    "jaytree/memory/graphiti-memory-v0.1.json",
+    "jaytree/memory/receipts/graphiti-memory-v0.1.eas-receipt.json",
+    "jaytree/operations-manual/receipt-log-v0.1.json",
+    "jaytree/operations-manual/lattice-snapshot-v0.1.json",
+    "jaytree/external-roots/receipts/al-base-mcp-v0.1.eas-receipt.json",
+]
+
+
+@dataclass(frozen=True)
+class Episode:
+    episode_id: str
+    group_id: str
+    source_path: str
+    source_sha256: str
+    episode_type: str
+    authority: str
+    runtime: str
+    invariant: str
+    body: dict[str, Any]
+
+
+def sha256_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def episode_for_source(rel_path: str) -> Episode | None:
+    path = ROOT / rel_path
+    if not path.exists():
+        return None
+
+    raw = path.read_bytes()
+    source_hash = sha256_bytes(raw)
+    body = load_json(path)
+
+    if body.get("authority") not in (None, AUTHORITY):
+        raise SystemExit(f"authority drift in {rel_path}: {body.get('authority')!r}")
+
+    if body.get("runtime") not in (None, RUNTIME):
+        raise SystemExit(f"runtime drift in {rel_path}: {body.get('runtime')!r}")
+
+    if body.get("required_invariant") not in (None, REQUIRED_INVARIANT):
+        raise SystemExit(f"invariant drift in {rel_path}: {body.get('required_invariant')!r}")
+
+    episode_core = {
+        "source_path": rel_path,
+        "source_sha256": source_hash,
+        "authority": AUTHORITY,
+        "runtime": RUNTIME,
+        "invariant": REQUIRED_INVARIANT,
+    }
+    episode_id = "episode:sha256:" + hashlib.sha256(
+        json.dumps(episode_core, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    return Episode(
+        episode_id=episode_id,
+        group_id=GROUP_ID,
+        source_path=rel_path,
+        source_sha256=source_hash,
+        episode_type="sealed_local_artifact",
+        authority=AUTHORITY,
+        runtime=RUNTIME,
+        invariant=REQUIRED_INVARIANT,
+        body=body,
+    )
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    episodes: list[Episode] = []
+    missing: list[str] = []
+
+    for rel_path in SOURCES:
+        episode = episode_for_source(rel_path)
+        if episode is None:
+            missing.append(rel_path)
+            continue
+        episodes.append(episode)
+
+    index = {
+        "version": "graphiti-ingest-ro-v0.1",
+        "status": "READ_ONLY_INDEX_BUILT",
+        "group_id": GROUP_ID,
+        "authority": AUTHORITY,
+        "runtime": RUNTIME,
+        "required_invariant": REQUIRED_INVARIANT,
+        "episode_count": len(episodes),
+        "missing_optional_sources": missing,
+        "episodes": [
+            {
+                "episode_id": ep.episode_id,
+                "source_path": ep.source_path,
+                "source_sha256": ep.source_sha256,
+            }
+            for ep in episodes
+        ],
+    }
+
+    with EPISODES_JSONL.open("w", encoding="utf-8") as fh:
+        for ep in episodes:
+            fh.write(json.dumps(asdict(ep), sort_keys=True) + "\n")
+
+    INDEX_JSON.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(json.dumps(index, indent=2, sort_keys=True))
+    print(f"WROTE: {EPISODES_JSONL.relative_to(ROOT)}")
+    print(f"WROTE: {INDEX_JSON.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/jaytree/memory/ingest-ro/query.py
+++ b/jaytree/memory/ingest-ro/query.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Read-only query helper for Graphiti-shaped memory episodes."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+EPISODES_JSONL = ROOT / "jaytree" / "memory" / "ingest-ro" / "out" / "episodes.jsonl"
+
+
+def iter_values(obj: Any):
+    if isinstance(obj, dict):
+        for value in obj.values():
+            yield from iter_values(value)
+    elif isinstance(obj, list):
+        for value in obj:
+            yield from iter_values(value)
+    else:
+        yield obj
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: query.py <field> <value>")
+
+    field, needle = sys.argv[1], sys.argv[2]
+
+    if not EPISODES_JSONL.exists():
+        raise SystemExit("missing episodes.jsonl; run prototype.py first")
+
+    matches = []
+    for line in EPISODES_JSONL.read_text(encoding="utf-8").splitlines():
+        episode = json.loads(line)
+        haystack = episode.get("body", {})
+        found = False
+
+        if field in episode and str(episode[field]) == needle:
+            found = True
+        elif isinstance(haystack, dict) and str(haystack.get(field)) == needle:
+            found = True
+        else:
+            found = any(str(value) == needle for value in iter_values(haystack))
+
+        if found:
+            matches.append(
+                {
+                    "episode_id": episode["episode_id"],
+                    "source_path": episode["source_path"],
+                    "source_sha256": episode["source_sha256"],
+                    "authority": episode["authority"],
+                    "runtime": episode["runtime"],
+                    "invariant": episode["invariant"],
+                }
+            )
+
+    print(json.dumps({"matches": matches, "count": len(matches)}, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/jaytree/tests/test_graphiti_ingest_ro.py
+++ b/jaytree/tests/test_graphiti_ingest_ro.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTO = ROOT / 'memory' / 'ingest-ro' / 'prototype.py'
+QUERY = ROOT / 'memory' / 'ingest-ro' / 'query.py'
+
+
+def load_module(path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_prototype_has_no_graphiti_runtime_import():
+    text = PROTO.read_text(encoding='utf-8')
+    assert 'from graphiti_core' not in text
+    assert 'import graphiti_core' not in text
+    assert 'Graphiti(' not in text
+    assert 'add_episode(' not in text
+
+
+def test_prototype_boundary_constants():
+    proto = load_module(PROTO)
+    assert proto.AUTHORITY == 'NONE'
+    assert proto.RUNTIME == 'NOT_PERMITTED'
+    assert proto.REQUIRED_INVARIANT == 'memory is not authority'
+    assert proto.GROUP_ID == 'computerwisdom_v0.1'
+
+
+def test_query_is_read_only_helper():
+    text = QUERY.read_text(encoding='utf-8')
+    assert 'open("w"' not in text
+    assert '.write_text' not in text
+    assert 'git ' not in text
+    assert 'eas' not in text.lower()
+    assert 'wallet' not in text.lower()


### PR DESCRIPTION
Adds a safe read-only memory ingest prototype for the Graphiti/Jaytree lane.

Adds:
- jaytree/memory/ingest-ro/README.md
- jaytree/memory/ingest-ro/prototype.py
- jaytree/memory/ingest-ro/query.py
- jaytree/tests/test_graphiti_ingest_ro.py

Boundary:
- no graphiti_core runtime import
- no DB writes
- no network
- no LLM extraction
- no wallet/signing/execution/merge/EAS authority
- builds rebuildable local memory episodes only

Invariant:
- memory is not authority
- authority NONE
- runtime NOT_PERMITTED