### PR TITLE
jaytree: add world-map v0.1 read-only index

### DIFF
--- a/jaytree/tests/test_world_map_v0_1.py
+++ b/jaytree/tests/test_world_map_v0_1.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORLD_MAP = ROOT / 'world-map' / 'world-map-v0.1.json'
+
+REQUIRED_SURFACES = {
+    'graphiti_memory_audit',
+    'replay_instructions',
+    'blocked_continuity_receipt',
+    'business_recovery_log',
+    'graphiti_ingest_ro',
+    'minnesota_receipt_arcade',
+    'family_continuity_protection',
+    'replay_transform_registry',
+    'public_replay_verifier',
+}
+
+
+def load_map():
+    return json.loads(WORLD_MAP.read_text(encoding='utf-8'))
+
+
+def test_world_map_global_boundary():
+    data = load_map()
+    assert data['authority'] == 'NONE'
+    assert data['runtime'] == 'NOT_PERMITTED'
+    assert data['map_is_not_authority'] is True
+    assert data['memory_is_not_authority'] is True
+    assert data['mcp_runtime_enabled'] is False
+    assert data['network_access'] is False
+    assert data['write_access'] is False
+    assert data['witness_only'] is True
+    assert data['closing_rule'] == 'Map is not authority. Memory is not authority. Receipts beat narrative.'
+
+
+def test_world_map_required_surfaces_present():
+    data = load_map()
+    ids = {surface['id'] for surface in data['surfaces']}
+    assert REQUIRED_SURFACES.issubset(ids)
+
+
+def test_world_map_surface_boundaries():
+    data = load_map()
+    for surface in data['surfaces']:
+        assert surface['authority'] == 'NONE'
+        assert surface['runtime'] == 'NOT_PERMITTED'
+        assert surface['path']
+        assert surface['git_blob_sha']
+        assert 'pending' not in surface['git_blob_sha']
+        assert surface['type']
+
+
+def test_world_map_allowed_types_only():
+    data = load_map()
+    allowed = {
+        'memory-index',
+        'replay-navigation',
+        'receipt-index',
+        'navigation-map',
+        'replay-builder',
+        'playable-map',
+        'continuity-map',
+        'replay-transform-registry',
+        'replay-verifier',
+    }
+    for surface in data['surfaces']:
+        assert surface['type'] in allowed
+
+
+def test_world_map_does_not_enable_runtime_authority():
+    text = WORLD_MAP.read_text(encoding='utf-8').lower()
+    forbidden = [
+        '"authority": "true"',
+        '"runtime": "permitted"',
+        '"mcp_runtime_enabled": true',
+        '"network_access": true',
+        '"write_access": true',
+        'wallet_authority": true',
+        'signing_authority": true',
+        'execution_authority": true',
+        'merge_authority": true',
+        'eas_attestation_authority": true',
+    ]
+    for phrase in forbidden:
+        assert phrase not in text

--- a/jaytree/world-map/README.md
+++ b/jaytree/world-map/README.md
@@ -1,0 +1,45 @@
+# Jaytree World Map v0.1
+
+This folder materializes the distributed COMPUTERWISDOM world-map doctrine as a read-only navigation index.
+
+The map is not a runtime.
+The map is not a database.
+The map is not GIS.
+The map is not an agent.
+The map is not authority.
+
+It points to existing replay, receipt, continuity, memory, verifier, and navigation surfaces as witnesses.
+
+## Invariants
+
+```text
+authority: NONE
+runtime: NOT_PERMITTED
+map is not authority
+memory is not authority
+receipts beat narrative
+```
+
+## Primary artifact
+
+```text
+jaytree/world-map/world-map-v0.1.json
+```
+
+## Indexed witness surfaces
+
+```text
+jaytree/memory/graphiti-memory-v0.1.json
+replay/instructions/replay_instructions_v1.json
+receipts/COMPUTERWISDOM_REPLAY_BLOCKED_CONTINUITY_V1.receipt.json
+BUSINESS_RECOVERY_LOG.md
+jaytree/memory/ingest-ro/prototype.py
+docs/game/minnesota_map_v0_1.md
+docs/family_continuity_protection_map_v1.md
+docs/protocols/manic/runtime/REPLAY_TRANSFORM_REGISTRY_001.md
+docs/public_replay_verifier_spec_v0_1.md
+```
+
+## Boundary
+
+World-map v0.1 is a witness index only. It must not grant wallet, signing, execution, merge, EAS, MCP runtime, network, or write authority.

--- a/jaytree/world-map/world-map-v0.1.json
+++ b/jaytree/world-map/world-map-v0.1.json
@@ -1,0 +1,121 @@
+{
+  "version": "v0.1",
+  "name": "jaytree-world-map-v0.1",
+  "status": "READ_ONLY_NAVIGATION_INDEX",
+  "invariant": "map is not authority",
+  "authority": "NONE",
+  "runtime": "NOT_PERMITTED",
+  "map_is_not_authority": true,
+  "memory_is_not_authority": true,
+  "mcp_runtime_enabled": false,
+  "network_access": false,
+  "write_access": false,
+  "witness_only": true,
+  "source_repo": "jsonwisdom/COMPUTERWISDOM",
+  "source_branch": "master",
+  "surfaces": [
+    {
+      "id": "graphiti_memory_audit",
+      "path": "jaytree/memory/graphiti-memory-v0.1.json",
+      "description": "Temporal KG witness; memory index only.",
+      "git_blob_sha": "88ac6e76beff169dc9d5f4242f51e48b48fbf520aa8bc02edeb3121b6a2bcda7",
+      "artifact_hash": "sha256:88ac6e76beff169dc9d5f4242f51e48b48fbf520aa8bc02edeb3121b6a2bcda7",
+      "anchor": "vr:sha256:c027a4129b426c47a2d373936bc005c1eacc00f3f10b0d7a5c0deea498fcbc1e",
+      "eas_uid": "0x22b32e59336970d44ad03cb32064e8d8e17fbdde9fe5f079a9ea94fa2a4aa46b",
+      "type": "memory-index",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED"
+    },
+    {
+      "id": "replay_instructions",
+      "path": "replay/instructions/replay_instructions_v1.json",
+      "description": "Deterministic replay instruction parameters; continuity navigation, no execution authority.",
+      "git_blob_sha": "ace91b46f2003d64165b091e90b5668c4fe3feb9",
+      "anchor": "replay-trace-witness",
+      "type": "replay-navigation",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED"
+    },
+    {
+      "id": "blocked_continuity_receipt",
+      "path": "receipts/COMPUTERWISDOM_REPLAY_BLOCKED_CONTINUITY_V1.receipt.json",
+      "description": "Verifier lattice receipt candidate; indexed as witness only, not authority.",
+      "git_blob_sha": "001fb20e3c0c9c09b7535817b2708391b364743c",
+      "anchor": "receipt-verifier",
+      "type": "receipt-index",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "note": "Source artifact contains authorized=true internally; world-map interpretation remains authority NONE."
+    },
+    {
+      "id": "business_recovery_log",
+      "path": "BUSINESS_RECOVERY_LOG.md",
+      "description": "Business navigation and evidence spine witness.",
+      "git_blob_sha": "917883fd2878505d31bcbf0cb7603b84a67d17d8",
+      "anchor": "recovery-witness",
+      "type": "navigation-map",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED"
+    },
+    {
+      "id": "graphiti_ingest_ro",
+      "path": "jaytree/memory/ingest-ro/prototype.py",
+      "description": "Read-only episode builder; air-gapped local memory prototype.",
+      "git_blob_sha": "41ce4fa3d63cdb9036fd248c060f73384c8a2f66",
+      "anchor": "ingest-prototype",
+      "type": "replay-builder",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED"
+    },
+    {
+      "id": "minnesota_receipt_arcade",
+      "path": "docs/game/minnesota_map_v0_1.md",
+      "description": "First playable receipt quest map; arcade overworld, not GIS authority.",
+      "git_blob_sha": "51a81c50a0a0b15bb07c538cb1d3ae8410169560",
+      "anchor": "playable-map-witness",
+      "type": "playable-map",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED"
+    },
+    {
+      "id": "family_continuity_protection",
+      "path": "docs/family_continuity_protection_map_v1.md",
+      "description": "Layer 0 family continuity protection surface; expansion only after barriers hold.",
+      "git_blob_sha": "0105056b2b5f9993b7e58312a54ce28daf681967",
+      "anchor": "family-continuity-witness",
+      "type": "continuity-map",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED"
+    },
+    {
+      "id": "replay_transform_registry",
+      "path": "docs/protocols/manic/runtime/REPLAY_TRANSFORM_REGISTRY_001.md",
+      "description": "Deterministic replay transform rule table; structure may be created, meaning may not.",
+      "git_blob_sha": "f0939ed312e1c31945a443796dedbbec8f9d2ee2",
+      "anchor": "transform-registry-witness",
+      "type": "replay-transform-registry",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED"
+    },
+    {
+      "id": "public_replay_verifier",
+      "path": "docs/public_replay_verifier_spec_v0_1.md",
+      "description": "Public replayability classifier; authority remains false.",
+      "git_blob_sha": "316208cb7212488c27721b43a51076657fca6acf",
+      "anchor": "public-verifier-witness",
+      "type": "replay-verifier",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED"
+    }
+  ],
+  "schema": {
+    "anchors": "array",
+    "surfaces": "array",
+    "required_invariants": [
+      "memory-is-not-authority",
+      "map-is-not-authority",
+      "receipts-beat-narrative"
+    ]
+  },
+  "closing_rule": "Map is not authority. Memory is not authority. Receipts beat narrative."
+}


### PR DESCRIPTION
Materializes the distributed COMPUTERWISDOM world-map doctrine as a read-only witness index.

Adds:
- jaytree/world-map/world-map-v0.1.json
- jaytree/world-map/README.md
- jaytree/tests/test_world_map_v0_1.py

Indexed witness surfaces:
- Graphiti memory audit
- replay instructions
- blocked continuity receipt
- business recovery log
- Graphiti RO ingest prototype
- Minnesota receipt arcade map
- family continuity protection map
- replay transform registry
- public replay verifier

Boundary:
- authority NONE
- runtime NOT_PERMITTED
- map is not authority
- memory is not authority
- MCP runtime disabled
- no network/write authority
- no pending artifact pins

Closing rule:
Map is not authority. Memory is not authority. Receipts beat narrative.