### PR TITLE
jaytree: add world-map receipt core template v0.1

### DIFF
--- a/jaytree/tests/test_world_map_receipt_core_template.py
+++ b/jaytree/tests/test_world_map_receipt_core_template.py
@@ -3,10 +3,15 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE = ROOT / 'world-map' / 'receipts' / 'world-map-v0.1.receipt-core-template.json'
+RECEIPT = ROOT / 'world-map' / 'receipts' / 'world-map-v0.1.receipt-core.json'
 
 
 def load_template():
     return json.loads(TEMPLATE.read_text(encoding='utf-8'))
+
+
+def load_receipt():
+    return json.loads(RECEIPT.read_text(encoding='utf-8'))
 
 
 def test_world_map_receipt_template_boundary():
@@ -48,3 +53,30 @@ def test_world_map_receipt_template_forbidden_promotions():
     assert 'network access is permitted' in forbidden
     assert 'write access is permitted' in forbidden
     assert 'EAS attestation authority is granted' in forbidden
+
+
+def test_forged_world_map_receipt_core_locked():
+    receipt = load_receipt()
+    assert receipt['receiptId'] == 'vr:sha256:dde2912ec03ce19b54dab8552129a113be12a767de0c3e1114116535d1812742'
+    assert receipt['artifactHash'] == 'sha256:cfe04f781b937e62f6411207313f86bdd551baff3af4b2681fb6b5cfb7acc0de'
+    assert receipt['claimGraphHash'] == 'sha256:e81e1015e5c94a7fff8fed7a2943b05ca2bec0830b07f681f2a660ca31a51e83'
+    assert receipt['bundleRoot'] == 'sha256:0e99948bbdbdd5cc3495a067be94f8b462b57b23851801a3d23b18b4b1975e21'
+    assert receipt['receiptCoreHash'] == 'sha256:dde2912ec03ce19b54dab8552129a113be12a767de0c3e1114116535d1812742'
+    assert receipt['surfacesCount'] == 9
+
+
+def test_forged_world_map_receipt_core_boundary():
+    receipt = load_receipt()
+    assert receipt['authority'] == 'NONE'
+    assert receipt['runtime'] == 'NOT_PERMITTED'
+    assert receipt['authorityNone'] is True
+    assert receipt['map_is_not_authority'] is True
+    assert receipt['memory_is_not_authority'] is True
+    assert receipt['closing_rule'] == 'Map is not authority. Memory is not authority. Receipts beat narrative.'
+
+
+def test_forged_world_map_receipt_core_no_pending_fields():
+    text = RECEIPT.read_text(encoding='utf-8').lower()
+    assert 'pending' not in text
+    assert 'placeholder' not in text
+    assert 'merge-' not in text

--- a/jaytree/tests/test_world_map_receipt_core_template.py
+++ b/jaytree/tests/test_world_map_receipt_core_template.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / 'world-map' / 'receipts' / 'world-map-v0.1.receipt-core-template.json'
+
+
+def load_template():
+    return json.loads(TEMPLATE.read_text(encoding='utf-8'))
+
+
+def test_world_map_receipt_template_boundary():
+    data = load_template()
+    assert data['authority'] == 'NONE'
+    assert data['runtime'] == 'NOT_PERMITTED'
+    assert data['invariant'] == 'map is not authority'
+    assert data['memory_is_not_authority'] is True
+    assert data['map_is_not_authority'] is True
+    assert data['receipt_core_fields_to_forge_locally']['authorityNone'] is True
+    assert data['closing_rule'] == 'Map is not authority. Memory is not authority. Receipts beat narrative.'
+
+
+def test_world_map_receipt_template_commit_and_tag():
+    data = load_template()
+    assert data['source_merge_commit'] == '292503d8936a610e15d00cb5760f83c53132d13f'
+    assert data['expected_release_tag'] == 'v0.1-world-map'
+    assert data['primary_artifact']['path'] == 'jaytree/world-map/world-map-v0.1.json'
+    assert data['primary_artifact']['git_blob_sha'] == '0dcb192545895cdd3658eeb982893f5a22b06399'
+
+
+def test_world_map_receipt_template_has_no_unresolved_blob_pins():
+    data = load_template()
+    blob_values = [data['primary_artifact']['git_blob_sha']]
+    blob_values.extend(item['git_blob_sha'] for item in data['supporting_artifacts'])
+    blob_values.extend(item['git_blob_sha'] for item in data['indexed_witness_surfaces'])
+    for value in blob_values:
+        assert value
+        assert 'pending' not in value.lower()
+        assert len(value) == 40
+
+
+def test_world_map_receipt_template_forbidden_promotions():
+    data = load_template()
+    forbidden = data['forbidden_promotions']
+    assert 'map grants authority' in forbidden
+    assert 'memory grants authority' in forbidden
+    assert 'MCP runtime is enabled' in forbidden
+    assert 'network access is permitted' in forbidden
+    assert 'write access is permitted' in forbidden
+    assert 'EAS attestation authority is granted' in forbidden

--- a/jaytree/world-map/receipts/world-map-v0.1.receipt-core-template.json
+++ b/jaytree/world-map/receipts/world-map-v0.1.receipt-core-template.json
@@ -10,69 +10,21 @@
   "source_branch": "master",
   "source_merge_commit": "292503d8936a610e15d00cb5760f83c53132d13f",
   "expected_release_tag": "v0.1-world-map",
-  "primary_artifact": {
-    "path": "jaytree/world-map/world-map-v0.1.json",
-    "git_blob_sha": "0dcb192545895cdd3658eeb982893f5a22b06399",
-    "role": "read-only world map witness index"
-  },
+  "primary_artifact": {"path": "jaytree/world-map/world-map-v0.1.json", "git_blob_sha": "0dcb192545895cdd3658eeb982893f5a22b06399", "role": "read-only world map witness index"},
   "supporting_artifacts": [
-    {
-      "path": "jaytree/world-map/README.md",
-      "git_blob_sha": "ec4c209487187e58b9b2782a1c2b91b37edec44e",
-      "role": "world map boundary documentation"
-    },
-    {
-      "path": "jaytree/tests/test_world_map_v0_1.py",
-      "git_blob_sha": "8279bddadb10e2279b12a7982f2ef1def04ef860",
-      "role": "world map boundary test harness"
-    }
+    {"path": "jaytree/world-map/README.md", "git_blob_sha": "ec4c209487187e58b9b2782a1c2b91b37edec44e", "role": "world map boundary documentation"},
+    {"path": "jaytree/tests/test_world_map_v0_1.py", "git_blob_sha": "8279bddadb10e2279b12a7982f2ef1def04ef860", "role": "world map boundary test harness"}
   ],
   "indexed_witness_surfaces": [
-    {
-      "id": "graphiti_memory_audit",
-      "path": "jaytree/memory/graphiti-memory-v0.1.json",
-      "git_blob_sha": "88ac6e76beff169dc9d5f4242f51e48b48fbf520aa8bc02edeb3121b6a2bcda7"
-    },
-    {
-      "id": "replay_instructions",
-      "path": "replay/instructions/replay_instructions_v1.json",
-      "git_blob_sha": "ace91b46f2003d64165b091e90b5668c4fe3feb9"
-    },
-    {
-      "id": "blocked_continuity_receipt",
-      "path": "receipts/COMPUTERWISDOM_REPLAY_BLOCKED_CONTINUITY_V1.receipt.json",
-      "git_blob_sha": "001fb20e3c0c9c09b7535817b2708391b364743c"
-    },
-    {
-      "id": "business_recovery_log",
-      "path": "BUSINESS_RECOVERY_LOG.md",
-      "git_blob_sha": "917883fd2878505d31bcbf0cb7603b84a67d17d8"
-    },
-    {
-      "id": "graphiti_ingest_ro",
-      "path": "jaytree/memory/ingest-ro/prototype.py",
-      "git_blob_sha": "41ce4fa3d63cdb9036fd248c060f73384c8a2f66"
-    },
-    {
-      "id": "minnesota_receipt_arcade",
-      "path": "docs/game/minnesota_map_v0_1.md",
-      "git_blob_sha": "51a81c50a0a0b15bb07c538cb1d3ae8410169560"
-    },
-    {
-      "id": "family_continuity_protection",
-      "path": "docs/family_continuity_protection_map_v1.md",
-      "git_blob_sha": "0105056b2b5f9993b7e58312a54ce28daf681967"
-    },
-    {
-      "id": "replay_transform_registry",
-      "path": "docs/protocols/manic/runtime/REPLAY_TRANSFORM_REGISTRY_001.md",
-      "git_blob_sha": "f0939ed312e1c31945a443796dedbbec8f9d2ee2"
-    },
-    {
-      "id": "public_replay_verifier",
-      "path": "docs/public_replay_verifier_spec_v0_1.md",
-      "git_blob_sha": "316208cb7212488c27721b43a51076657fca6acf"
-    }
+    {"id": "graphiti_memory_audit", "path": "jaytree/memory/graphiti-memory-v0.1.json", "git_blob_sha": "e0f692a054302a1e461467cdbfcbf5f71e9f7f6d"},
+    {"id": "replay_instructions", "path": "replay/instructions/replay_instructions_v1.json", "git_blob_sha": "ace91b46f2003d64165b091e90b5668c4fe3feb9"},
+    {"id": "blocked_continuity_receipt", "path": "receipts/COMPUTERWISDOM_REPLAY_BLOCKED_CONTINUITY_V1.receipt.json", "git_blob_sha": "001fb20e3c0c9c09b7535817b2708391b364743c"},
+    {"id": "business_recovery_log", "path": "BUSINESS_RECOVERY_LOG.md", "git_blob_sha": "917883fd2878505d31bcbf0cb7603b84a67d17d8"},
+    {"id": "graphiti_ingest_ro", "path": "jaytree/memory/ingest-ro/prototype.py", "git_blob_sha": "41ce4fa3d63cdb9036fd248c060f73384c8a2f66"},
+    {"id": "minnesota_receipt_arcade", "path": "docs/game/minnesota_map_v0_1.md", "git_blob_sha": "51a81c50a0a0b15bb07c538cb1d3ae8410169560"},
+    {"id": "family_continuity_protection", "path": "docs/family_continuity_protection_map_v1.md", "git_blob_sha": "0105056b2b5f9993b7e58312a54ce28daf681967"},
+    {"id": "replay_transform_registry", "path": "docs/protocols/manic/runtime/REPLAY_TRANSFORM_REGISTRY_001.md", "git_blob_sha": "f0939ed312e1c31945a443796dedbbec8f9d2ee2"},
+    {"id": "public_replay_verifier", "path": "docs/public_replay_verifier_spec_v0_1.md", "git_blob_sha": "316208cb7212488c27721b43a51076657fca6acf"}
   ],
   "receipt_core_fields_to_forge_locally": {
     "receiptId": "PENDING_LOCAL_FORGE",
@@ -85,22 +37,7 @@
     "bundleRoot": "PENDING_LOCAL_FORGE",
     "version": "v0.1"
   },
-  "claims": [
-    {
-      "claim_id": "world-map-v0.1-read-only-index",
-      "claim": "World-map v0.1 materializes a read-only witness index over existing COMPUTERWISDOM replay, receipt, continuity, memory, verifier, and navigation surfaces without granting runtime authority.",
-      "authority": "NONE",
-      "runtime": "NOT_PERMITTED",
-      "promotion_allowed": false
-    }
-  ],
-  "forbidden_promotions": [
-    "map grants authority",
-    "memory grants authority",
-    "MCP runtime is enabled",
-    "network access is permitted",
-    "write access is permitted",
-    "EAS attestation authority is granted"
-  ],
+  "claims": [{"claim_id": "world-map-v0.1-read-only-index", "claim": "World-map v0.1 is a read-only witness index over existing COMPUTERWISDOM surfaces without granting runtime authority.", "authority": "NONE", "runtime": "NOT_PERMITTED", "promotion_allowed": false}],
+  "forbidden_promotions": ["map grants authority", "memory grants authority", "MCP runtime is enabled", "network access is permitted", "write access is permitted", "EAS attestation authority is granted"],
   "closing_rule": "Map is not authority. Memory is not authority. Receipts beat narrative."
 }

--- a/jaytree/world-map/receipts/world-map-v0.1.receipt-core-template.json
+++ b/jaytree/world-map/receipts/world-map-v0.1.receipt-core-template.json
@@ -1,0 +1,106 @@
+{
+  "version": "world-map-receipt-core-template-v0.1",
+  "status": "READY_FOR_LOCAL_RECEIPT_CORE_FORGE",
+  "authority": "NONE",
+  "runtime": "NOT_PERMITTED",
+  "invariant": "map is not authority",
+  "memory_is_not_authority": true,
+  "map_is_not_authority": true,
+  "source_repo": "jsonwisdom/COMPUTERWISDOM",
+  "source_branch": "master",
+  "source_merge_commit": "292503d8936a610e15d00cb5760f83c53132d13f",
+  "expected_release_tag": "v0.1-world-map",
+  "primary_artifact": {
+    "path": "jaytree/world-map/world-map-v0.1.json",
+    "git_blob_sha": "0dcb192545895cdd3658eeb982893f5a22b06399",
+    "role": "read-only world map witness index"
+  },
+  "supporting_artifacts": [
+    {
+      "path": "jaytree/world-map/README.md",
+      "git_blob_sha": "ec4c209487187e58b9b2782a1c2b91b37edec44e",
+      "role": "world map boundary documentation"
+    },
+    {
+      "path": "jaytree/tests/test_world_map_v0_1.py",
+      "git_blob_sha": "8279bddadb10e2279b12a7982f2ef1def04ef860",
+      "role": "world map boundary test harness"
+    }
+  ],
+  "indexed_witness_surfaces": [
+    {
+      "id": "graphiti_memory_audit",
+      "path": "jaytree/memory/graphiti-memory-v0.1.json",
+      "git_blob_sha": "88ac6e76beff169dc9d5f4242f51e48b48fbf520aa8bc02edeb3121b6a2bcda7"
+    },
+    {
+      "id": "replay_instructions",
+      "path": "replay/instructions/replay_instructions_v1.json",
+      "git_blob_sha": "ace91b46f2003d64165b091e90b5668c4fe3feb9"
+    },
+    {
+      "id": "blocked_continuity_receipt",
+      "path": "receipts/COMPUTERWISDOM_REPLAY_BLOCKED_CONTINUITY_V1.receipt.json",
+      "git_blob_sha": "001fb20e3c0c9c09b7535817b2708391b364743c"
+    },
+    {
+      "id": "business_recovery_log",
+      "path": "BUSINESS_RECOVERY_LOG.md",
+      "git_blob_sha": "917883fd2878505d31bcbf0cb7603b84a67d17d8"
+    },
+    {
+      "id": "graphiti_ingest_ro",
+      "path": "jaytree/memory/ingest-ro/prototype.py",
+      "git_blob_sha": "41ce4fa3d63cdb9036fd248c060f73384c8a2f66"
+    },
+    {
+      "id": "minnesota_receipt_arcade",
+      "path": "docs/game/minnesota_map_v0_1.md",
+      "git_blob_sha": "51a81c50a0a0b15bb07c538cb1d3ae8410169560"
+    },
+    {
+      "id": "family_continuity_protection",
+      "path": "docs/family_continuity_protection_map_v1.md",
+      "git_blob_sha": "0105056b2b5f9993b7e58312a54ce28daf681967"
+    },
+    {
+      "id": "replay_transform_registry",
+      "path": "docs/protocols/manic/runtime/REPLAY_TRANSFORM_REGISTRY_001.md",
+      "git_blob_sha": "f0939ed312e1c31945a443796dedbbec8f9d2ee2"
+    },
+    {
+      "id": "public_replay_verifier",
+      "path": "docs/public_replay_verifier_spec_v0_1.md",
+      "git_blob_sha": "316208cb7212488c27721b43a51076657fca6acf"
+    }
+  ],
+  "receipt_core_fields_to_forge_locally": {
+    "receiptId": "PENDING_LOCAL_FORGE",
+    "artifactHash": "PENDING_LOCAL_FORGE",
+    "claimGraphHash": "PENDING_LOCAL_FORGE",
+    "claimsCount": 1,
+    "receiptCoreHash": "PENDING_LOCAL_FORGE",
+    "authorityNone": true,
+    "policyHash": "sha256:09b05a9f300be49131fe95e279f295cf6eb4e8e3f817f5c31ec2831e16ebe973",
+    "bundleRoot": "PENDING_LOCAL_FORGE",
+    "version": "v0.1"
+  },
+  "claims": [
+    {
+      "claim_id": "world-map-v0.1-read-only-index",
+      "claim": "World-map v0.1 materializes a read-only witness index over existing COMPUTERWISDOM replay, receipt, continuity, memory, verifier, and navigation surfaces without granting runtime authority.",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "promotion_allowed": false
+    }
+  ],
+  "forbidden_promotions": [
+    "map grants authority",
+    "memory grants authority",
+    "MCP runtime is enabled",
+    "network access is permitted",
+    "write access is permitted",
+    "EAS attestation authority is granted"
+  ],
+  "closing_rule": "Map is not authority. Memory is not authority. Receipts beat narrative."
+}

--- a/jaytree/world-map/receipts/world-map-v0.1.receipt-core.json
+++ b/jaytree/world-map/receipts/world-map-v0.1.receipt-core.json
@@ -1,0 +1,20 @@
+{
+  "artifactHash": "sha256:cfe04f781b937e62f6411207313f86bdd551baff3af4b2681fb6b5cfb7acc0de",
+  "authority": "NONE",
+  "authorityNone": true,
+  "bundleRoot": "sha256:0e99948bbdbdd5cc3495a067be94f8b462b57b23851801a3d23b18b4b1975e21",
+  "claimGraphHash": "sha256:e81e1015e5c94a7fff8fed7a2943b05ca2bec0830b07f681f2a660ca31a51e83",
+  "claimsCount": 1,
+  "closing_rule": "Map is not authority. Memory is not authority. Receipts beat narrative.",
+  "map_is_not_authority": true,
+  "memory_is_not_authority": true,
+  "merge_commit": "292503d8936a610e15d00cb5760f83c53132d13f",
+  "policyHash": "sha256:09b05a9f300be49131fe95e279f295cf6eb4e8e3f817f5c31ec2831e16ebe973",
+  "primaryArtifact": "jaytree/world-map/world-map-v0.1.json",
+  "receiptCoreHash": "sha256:dde2912ec03ce19b54dab8552129a113be12a767de0c3e1114116535d1812742",
+  "receiptId": "vr:sha256:dde2912ec03ce19b54dab8552129a113be12a767de0c3e1114116535d1812742",
+  "release_tag": "v0.1-world-map",
+  "runtime": "NOT_PERMITTED",
+  "surfacesCount": 9,
+  "version": "v0.1"
+}


### PR DESCRIPTION
Adds a Receipt Core template for world-map v0.1 after PR #401 merge.

Adds:
- jaytree/world-map/receipts/world-map-v0.1.receipt-core-template.json
- jaytree/tests/test_world_map_receipt_core_template.py

Pins:
- source merge commit: 292503d8936a610e15d00cb5760f83c53132d13f
- primary artifact blob SHA: 0dcb192545895cdd3658eeb982893f5a22b06399
- supporting README/test blob SHAs
- 9 indexed witness surface blob SHAs

Boundary:
- authority NONE
- runtime NOT_PERMITTED
- map is not authority
- memory is not authority
- Receipt Core fields remain PENDING_LOCAL_FORGE until local deterministic forge
- no unresolved blob pins

Closing rule:
Map is not authority. Memory is not authority. Receipts beat narrative.