### PR TITLE
jaytree: update lattice through world-map receipt core v0.1

### DIFF
--- a/jaytree/operations-manual/lattice-snapshot-v0.1.json
+++ b/jaytree/operations-manual/lattice-snapshot-v0.1.json
@@ -32,12 +32,65 @@
     "eas_transaction_hash": "0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c",
     "receipt_id": "vr:sha256:cc438cbc26e0139d0b581f0ca3ae4434e0ee82cf5d3740e446ca0ad45d9b2166"
   },
+  "memory_layer": {
+    "graphiti_memory_audit": {
+      "target_commit": "804f4d61716b199173078cd94bbed8d2b235bd2c",
+      "artifact": "jaytree/memory/graphiti-memory-v0.1.json",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "required_invariant": "memory is not authority"
+    },
+    "graphiti_memory_eas_receipt": {
+      "target_commit": "fee651690e3178dc6401df9b5ac424303d32ea2e",
+      "artifact": "jaytree/memory/receipts/graphiti-memory-v0.1.eas-receipt.json",
+      "eas_attestation_uid": "0x22b32e59336970d44ad03cb32064e8d8e17fbdde9fe5f079a9ea94fa2a4aa46b",
+      "eas_transaction_hash": "0x40b05628f634f7ab9f427234e00a8edf14f79bf72407ddf8558dc03d2d81208c",
+      "receipt_id": "vr:sha256:c027a4129b426c47a2d373936bc005c1eacc00f3f10b0d7a5c0deea498fcbc1e",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "required_invariant": "memory is not authority"
+    },
+    "graphiti_ingest_ro": {
+      "target_commit": "486adec12a3f2bea799b0faf4c925c179a92d81d",
+      "artifact": "jaytree/memory/ingest-ro/",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "required_invariant": "memory is not authority"
+    }
+  },
+  "world_map_layer": {
+    "world_map_v0_1": {
+      "target_commit": "292503d8936a610e15d00cb5760f83c53132d13f",
+      "artifact": "jaytree/world-map/world-map-v0.1.json",
+      "surfaces_count": 9,
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "required_invariant": "map is not authority"
+    },
+    "world_map_receipt_core_v0_1": {
+      "target_commit": "fbc2345c163ab9ab6d81520e753b4cb04ff9df8c",
+      "artifact": "jaytree/world-map/receipts/world-map-v0.1.receipt-core.json",
+      "receipt_id": "vr:sha256:dde2912ec03ce19b54dab8552129a113be12a767de0c3e1114116535d1812742",
+      "artifact_hash": "sha256:cfe04f781b937e62f6411207313f86bdd551baff3af4b2681fb6b5cfb7acc0de",
+      "claim_graph_hash": "sha256:e81e1015e5c94a7fff8fed7a2943b05ca2bec0830b07f681f2a660ca31a51e83",
+      "bundle_root": "sha256:0e99948bbdbdd5cc3495a067be94f8b462b57b23851801a3d23b18b4b1975e21",
+      "receipt_core_hash": "sha256:dde2912ec03ce19b54dab8552129a113be12a767de0c3e1114116535d1812742",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "required_invariant": "map is not authority",
+      "eas_status": "HOLD"
+    }
+  },
   "closed_surfaces": {
     "wallet_authority": false,
     "execution_authority": false,
     "signing_authority": false,
     "merge_authority": false,
     "x402_enabled": false,
-    "runtime_enabled": false
+    "runtime_enabled": false,
+    "mcp_runtime_enabled": false,
+    "network_access": false,
+    "write_access": false,
+    "eas_attestation_authority": false
   }
 }

--- a/jaytree/operations-manual/receipt-log-v0.1.json
+++ b/jaytree/operations-manual/receipt-log-v0.1.json
@@ -31,12 +31,70 @@
       "authority": "NONE",
       "runtime": "NOT_PERMITTED",
       "human_approval_required": true
+    },
+    {
+      "entry_id": "graphiti-memory-audit-v0.1",
+      "target_commit": "804f4d61716b199173078cd94bbed8d2b235bd2c",
+      "artifact": "jaytree/memory/graphiti-memory-v0.1.json",
+      "required_invariant": "memory is not authority",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "human_approval_required": true
+    },
+    {
+      "entry_id": "graphiti-memory-eas-receipt-v0.1",
+      "target_commit": "fee651690e3178dc6401df9b5ac424303d32ea2e",
+      "artifact": "jaytree/memory/receipts/graphiti-memory-v0.1.eas-receipt.json",
+      "eas_attestation_uid": "0x22b32e59336970d44ad03cb32064e8d8e17fbdde9fe5f079a9ea94fa2a4aa46b",
+      "eas_transaction_hash": "0x40b05628f634f7ab9f427234e00a8edf14f79bf72407ddf8558dc03d2d81208c",
+      "receipt_id": "vr:sha256:c027a4129b426c47a2d373936bc005c1eacc00f3f10b0d7a5c0deea498fcbc1e",
+      "required_invariant": "memory is not authority",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "human_approval_required": true
+    },
+    {
+      "entry_id": "graphiti-ingest-ro-v0.1",
+      "target_commit": "486adec12a3f2bea799b0faf4c925c179a92d81d",
+      "artifact": "jaytree/memory/ingest-ro/",
+      "required_invariant": "memory is not authority",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "human_approval_required": true
+    },
+    {
+      "entry_id": "world-map-v0.1",
+      "target_commit": "292503d8936a610e15d00cb5760f83c53132d13f",
+      "artifact": "jaytree/world-map/world-map-v0.1.json",
+      "required_invariant": "map is not authority",
+      "surfaces_count": 9,
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "human_approval_required": true
+    },
+    {
+      "entry_id": "world-map-receipt-core-v0.1",
+      "target_commit": "fbc2345c163ab9ab6d81520e753b4cb04ff9df8c",
+      "artifact": "jaytree/world-map/receipts/world-map-v0.1.receipt-core.json",
+      "receipt_id": "vr:sha256:dde2912ec03ce19b54dab8552129a113be12a767de0c3e1114116535d1812742",
+      "artifact_hash": "sha256:cfe04f781b937e62f6411207313f86bdd551baff3af4b2681fb6b5cfb7acc0de",
+      "claim_graph_hash": "sha256:e81e1015e5c94a7fff8fed7a2943b05ca2bec0830b07f681f2a660ca31a51e83",
+      "bundle_root": "sha256:0e99948bbdbdd5cc3495a067be94f8b462b57b23851801a3d23b18b4b1975e21",
+      "receipt_core_hash": "sha256:dde2912ec03ce19b54dab8552129a113be12a767de0c3e1114116535d1812742",
+      "required_invariant": "map is not authority",
+      "authority": "NONE",
+      "runtime": "NOT_PERMITTED",
+      "human_approval_required": true,
+      "eas_status": "HOLD"
     }
   ],
   "invariants": [
     "Jay Wisdom is L0 human authority.",
     "GitHub tags pin merge artifacts.",
     "EAS witnesses receipt payloads but does not create truth authority.",
+    "Memory is not authority.",
+    "Map is not authority.",
+    "Receipts hold evidence, not authority.",
     "Boss Bre may maintain manuals but does not receive wallet, signing, execution, or merge authority by default.",
     "Base MCP remains closed until a separate authority receipt enables runtime."
   ]

--- a/jaytree/tests/test_operations_manual_lattice.py
+++ b/jaytree/tests/test_operations_manual_lattice.py
@@ -10,9 +10,12 @@ def load(path):
     return json.loads(path.read_text(encoding='utf-8'))
 
 
+def entries_by_id():
+    return {entry['entry_id']: entry for entry in load(LOG)['entries']}
+
+
 def test_receipt_log_tag_pair_locked():
-    log = load(LOG)
-    entries = {entry['entry_id']: entry for entry in log['entries']}
+    entries = entries_by_id()
     assert entries['al-base-mcp-root-v0.1']['tag'] == 'v0.1-al-base-mcp-root'
     assert entries['al-base-mcp-root-v0.1']['target_commit'] == '261f7588a3955ec0f26b08eb609c888b7f12cbcc'
     assert entries['al-base-mcp-eas-receipt-v0.1']['tag'] == 'v0.1-al-base-mcp-eas-receipt'
@@ -20,11 +23,33 @@ def test_receipt_log_tag_pair_locked():
 
 
 def test_receipt_log_eas_receipt_locked():
-    log = load(LOG)
-    receipt = {entry['entry_id']: entry for entry in log['entries']}['al-base-mcp-eas-receipt-v0.1']
+    receipt = entries_by_id()['al-base-mcp-eas-receipt-v0.1']
     assert receipt['eas_attestation_uid'] == '0x0718576a2cdb3eaabaf6bb338a8a4d1bfb09678b05357e7d8c15e237f92a8abb'
     assert receipt['eas_transaction_hash'] == '0x081e969eb9afd5dbef5e604cd903f9666271ef63eceb10af2457e4d1ea04ce3c'
     assert receipt['receipt_id'] == 'vr:sha256:cc438cbc26e0139d0b581f0ca3ae4434e0ee82cf5d3740e446ca0ad45d9b2166'
+
+
+def test_graphiti_world_map_chain_locked():
+    entries = entries_by_id()
+    assert entries['graphiti-memory-audit-v0.1']['target_commit'] == '804f4d61716b199173078cd94bbed8d2b235bd2c'
+    assert entries['graphiti-memory-eas-receipt-v0.1']['target_commit'] == 'fee651690e3178dc6401df9b5ac424303d32ea2e'
+    assert entries['graphiti-ingest-ro-v0.1']['target_commit'] == '486adec12a3f2bea799b0faf4c925c179a92d81d'
+    assert entries['world-map-v0.1']['target_commit'] == '292503d8936a610e15d00cb5760f83c53132d13f'
+    assert entries['world-map-receipt-core-v0.1']['target_commit'] == 'fbc2345c163ab9ab6d81520e753b4cb04ff9df8c'
+
+
+def test_graphiti_world_map_receipts_locked():
+    entries = entries_by_id()
+    graphiti = entries['graphiti-memory-eas-receipt-v0.1']
+    assert graphiti['eas_attestation_uid'] == '0x22b32e59336970d44ad03cb32064e8d8e17fbdde9fe5f079a9ea94fa2a4aa46b'
+    assert graphiti['eas_transaction_hash'] == '0x40b05628f634f7ab9f427234e00a8edf14f79bf72407ddf8558dc03d2d81208c'
+    assert graphiti['receipt_id'] == 'vr:sha256:c027a4129b426c47a2d373936bc005c1eacc00f3f10b0d7a5c0deea498fcbc1e'
+    world = entries['world-map-receipt-core-v0.1']
+    assert world['receipt_id'] == 'vr:sha256:dde2912ec03ce19b54dab8552129a113be12a767de0c3e1114116535d1812742'
+    assert world['artifact_hash'] == 'sha256:cfe04f781b937e62f6411207313f86bdd551baff3af4b2681fb6b5cfb7acc0de'
+    assert world['claim_graph_hash'] == 'sha256:e81e1015e5c94a7fff8fed7a2943b05ca2bec0830b07f681f2a660ca31a51e83'
+    assert world['bundle_root'] == 'sha256:0e99948bbdbdd5cc3495a067be94f8b462b57b23851801a3d23b18b4b1975e21'
+    assert world['eas_status'] == 'HOLD'
 
 
 def test_lattice_closed_surfaces():
@@ -36,6 +61,10 @@ def test_lattice_closed_surfaces():
     assert closed['merge_authority'] is False
     assert closed['x402_enabled'] is False
     assert closed['runtime_enabled'] is False
+    assert closed['mcp_runtime_enabled'] is False
+    assert closed['network_access'] is False
+    assert closed['write_access'] is False
+    assert closed['eas_attestation_authority'] is False
 
 
 def test_l0_and_boss_bre_boundary():
@@ -47,3 +76,12 @@ def test_l0_and_boss_bre_boundary():
     assert snapshot['manual_layer']['wallet_authority'] is False
     assert snapshot['manual_layer']['signing_authority'] is False
     assert snapshot['manual_layer']['execution_authority'] is False
+
+
+def test_memory_and_map_not_authority():
+    snapshot = load(SNAPSHOT)
+    assert snapshot['memory_layer']['graphiti_memory_audit']['required_invariant'] == 'memory is not authority'
+    assert snapshot['memory_layer']['graphiti_ingest_ro']['required_invariant'] == 'memory is not authority'
+    assert snapshot['world_map_layer']['world_map_v0_1']['required_invariant'] == 'map is not authority'
+    assert snapshot['world_map_layer']['world_map_receipt_core_v0_1']['required_invariant'] == 'map is not authority'
+    assert snapshot['world_map_layer']['world_map_receipt_core_v0_1']['eas_status'] == 'HOLD'


### PR DESCRIPTION
Updates the operations-manual receipt log and lattice snapshot through the Graphiti/world-map chain.

Adds/locks entries for:
- Graphiti memory audit
- Graphiti memory EAS receipt
- Graphiti read-only ingest prototype
- World-map v0.1
- World-map receipt core v0.1

Preserves boundaries:
- authority NONE
- runtime NOT_PERMITTED
- memory is not authority
- map is not authority
- receipts hold evidence, not authority
- EAS for world-map remains HOLD
- no wallet/signing/execution/merge/x402/MCP runtime/network/write/EAS authority

Also updates operations-manual tests to lock the Graphiti/world-map chain and closed surfaces.