### PR TITLE
Add COMPUTERWISDOM nonlocal 2026 frame

### DIFF
--- a/projects/cwaas/COMPUTERWISDOM_NONLOCAL_2026_V0_1.md
+++ b/projects/cwaas/COMPUTERWISDOM_NONLOCAL_2026_V0_1.md
@@ -1,0 +1,150 @@
+# COMPUTERWISDOM_NONLOCAL_2026_V0_1
+
+## Status
+
+```text
+LOCAL_DRAFT
+NONLOCAL_2026_CORRECTION
+MATH_PHYSICS_QUANTUM_FRAME
+NO_FAKE_GREEN_ACTIVE
+```
+
+## Signal Core
+
+COMPUTERWISDOM is non-local in 2026.
+
+It is not primarily a storefront, address, phone number, or local service listing.
+
+It is a replay architecture moving through:
+
+```text
+Math
+Physics
+Quantum
+Receipts
+Non-local coordination
+```
+
+## Core Correction
+
+```text
+COMPUTERWISDOM_2011_2016 = LOCAL_FIELD_MEMORY
+COMPUTERWISDOM_2026 = NONLOCAL_REPLAY_ARCHITECTURE
+CWAAS_2026 = COMPUTER_WISDOM_AS_A_SERVICE
+LOCAL_ADDRESS != SYSTEM_BOUNDARY
+PHONE_NUMBER != PROTOCOL_IDENTITY
+REPLAY_GRAPH > BUSINESS_LISTING
+```
+
+## Math Layer
+
+Math gives COMPUTERWISDOM structure.
+
+```text
+state
+transition
+invariant
+proof
+hash
+graph
+coordinate
+constraint
+```
+
+A claim does not move because it sounds good.
+
+It moves because the transition is valid.
+
+## Physics Layer
+
+Physics gives COMPUTERWISDOM discipline.
+
+```text
+observer
+measurement
+signal
+noise
+energy
+constraint
+causality
+field
+```
+
+A replay is a measurement event.
+
+A receipt is an observed trace.
+
+A dashboard is only an instrument.
+
+## Quantum Layer
+
+Quantum here means non-local graph behavior and multi-perspective replay.
+
+It does not claim quantum hardware, quantum supremacy, or a physics breakthrough.
+
+```text
+same artifact
+multiple observers
+separate locations
+shared receipt state
+entangled interpretation
+replay resolves the frame
+```
+
+## Non-local 2026 Rule
+
+```text
+The system may touch Alabama.
+The system may remember Prattville.
+The system may serve local citizens.
+But COMPUTERWISDOM 2026 is not confined to a local address.
+```
+
+## CWaaS 2026 Frame
+
+```json
+{
+  "system": "COMPUTERWISDOM",
+  "year": 2026,
+  "mode": "NONLOCAL",
+  "service_model": "CWaaS",
+  "layers": ["math", "physics", "quantum", "receipts", "replay"],
+  "local_memory": "2011-2016",
+  "locality_constraint": false,
+  "authority": false,
+  "no_fake_green": true
+}
+```
+
+## Guardrails
+
+1. Do not reduce COMPUTERWISDOM 2026 to a business listing.
+2. Do not claim quantum hardware or scientific breakthrough without proof.
+3. Do not erase the 2011-2016 local memory.
+4. Do not promote local address, number, or service claims without source packet.
+5. Do not let dashboards outrank receipts.
+6. Family Layer 0 still outranks the graph.
+7. No fake green.
+
+## Coach Wisdom Call
+
+```text
+Old field was local.
+New field is non-local.
+Math sets the formation.
+Physics checks the measurement.
+Quantum opens the replay graph.
+Receipts keep the scoreboard honest.
+```
+
+## Closing Receipt
+
+COMPUTERWISDOM non-local 2026 correction opened.
+
+Math, physics, and quantum frame indexed.
+
+Local service claims remain source-packet gated.
+
+No fake green.
+
+JAYWISDOM.eth ⚙️


### PR DESCRIPTION
## Signal Core

Adds `COMPUTERWISDOM_NONLOCAL_2026_V0_1`.

Correction:

```text
COMPUTERWISDOM_2011_2016 = LOCAL_FIELD_MEMORY
COMPUTERWISDOM_2026 = NONLOCAL_REPLAY_ARCHITECTURE
CWAAS_2026 = COMPUTER_WISDOM_AS_A_SERVICE
LOCAL_ADDRESS != SYSTEM_BOUNDARY
PHONE_NUMBER != PROTOCOL_IDENTITY
REPLAY_GRAPH > BUSINESS_LISTING
```

## Layers

- Math
- Physics
- Quantum
- Receipts
- Non-local coordination

## Guardrails

No quantum-hardware claim. No local-service promotion without source packet. No fake green.