### PR TITLE
Add COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1

### DIFF
--- a/docs/COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1.md
+++ b/docs/COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1.md
@@ -1,0 +1,171 @@
+# COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1
+
+## Status
+
+```text
+STATUS: CORRIDOR_SPEC_DRAFT
+REPO: jsonwisdom/COMPUTERWISDOM
+MODE: GOVERNED_REVIEW
+TRUTH_STATE: YELLOW_PROTECTED
+AUTHORITY: false
+NO_FAKE_GREEN: true
+FAMILY_USERS_REQUIRED: true
+MRS_WISDOM_GATE_REQUIRED: true
+PUBLIC_RENDER_ALLOWED: false
+PRIVATE_DETAILS_ALLOWED: false
+```
+
+## Purpose
+
+The COMPUTERWISDOM Family Secure Corridor defines how `jsonwisdom/COMPUTERWISDOM` operates as the family-safe coordination plane for JSONWisdom without becoming family authority.
+
+COMPUTERWISDOM may coordinate indexes, repo graphs, public-safe ledgers, replay tools, and technical soundness checks.
+
+COMPUTERWISDOM may not grant consent, expose private family details, override Mrs Wisdom, or promote technical green into family green.
+
+## Corridor Role
+
+```text
+COMPUTERWISDOM = coordination_map + operational_control_plane + replay_surface + family_system_index
+```
+
+It serves the family by making the system understandable, replayable, and bounded.
+
+It does not make the family serve the system.
+
+## Source Alignment
+
+This corridor is aligned to the existing COMPUTERWISDOM family surfaces:
+
+```text
+docs/living_family_ledger_v1.md
+docs/family_system_index_v1.md
+docs/family_continuity_protection_map_v1.md
+docs/master_jsonwisdom_repo_graph_v1.md
+```
+
+## Corridor Map
+
+```json
+{
+  "corridor_id": "COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1",
+  "repo": "jsonwisdom/COMPUTERWISDOM",
+  "authority": false,
+  "no_fake_green": true,
+  "truth_state": "YELLOW_PROTECTED",
+  "family_users_required": true,
+  "mrs_wisdom_gate_required": true,
+  "nodes": {
+    "COMPUTERWISDOM": {
+      "role": "coordination_control_plane_and_family_system_index",
+      "allowed": [
+        "coordinate_repo_graphs",
+        "index_public_safe_family_surfaces",
+        "preserve_living_family_ledger",
+        "check_technical_soundness",
+        "route_review_to_mrs_wisdom",
+        "block_fake_green"
+      ],
+      "forbidden": [
+        "grant_family_consent",
+        "authorize_public_render",
+        "expose_private_details",
+        "replace_mrs_wisdom",
+        "promote_technical_green_to_family_green",
+        "claim_authority_over_family_meaning"
+      ]
+    },
+    "JOY": {
+      "role": "family_consent_and_protection_lane",
+      "handoff_rule": "JOY consent state controls family-sensitive publication",
+      "mrs_wisdom_gate_required": true
+    },
+    "AL": {
+      "role": "doctrine_and_receipt_first_replay_lane",
+      "handoff_rule": "AL provides doctrine and replay boundaries but not family consent"
+    },
+    "MR_WISDOM": {
+      "role": "builder_operator_receipt_keeper",
+      "handoff_rule": "Mr Wisdom may structure and verify, but may not approve private family meaning"
+    },
+    "MRS_WISDOM": {
+      "role": "family_meaning_gate_and_review_boundary",
+      "handoff_rule": "Mrs Wisdom review is required before any family-facing public expansion"
+    },
+    "FAMILY_USERS": {
+      "role": "living_ledger_subjects_and_purposeful_users",
+      "handoff_rule": "No family user may be converted into public content without consent boundary"
+    }
+  }
+}
+```
+
+## Boundary Rules
+
+```text
+COMPUTERWISDOM_DOES_NOT_GRANT_FAMILY_CONSENT = ACTIVE
+COMPUTERWISDOM_COORDINATES_BUT_DOES_NOT_AUTHORIZE = ACTIVE
+JOY_CONSENT_STATE_OUTRANKS_REPO_GRAPH = ACTIVE
+AL_DOCTRINE_OUTRANKS_RANDOM_NOISE = ACTIVE
+MRS_WISDOM_GATE_REQUIRED_FOR_PUBLIC_FAMILY_EXPANSION = ACTIVE
+FAMILY_USERS_REQUIRED_OR_DEADTREE = ACTIVE
+NO_FAKE_GREEN = ACTIVE
+AUTHORITY_FALSE = ACTIVE
+```
+
+## Secure Handoff Packet
+
+Any COMPUTERWISDOM handoff involving family continuity must include:
+
+```yaml
+authority: false
+no_fake_green: true
+family_users_present: true
+private_details_exposed: false
+family_consent_claimed: false
+mrs_wisdom_gate_required: true
+joy_consent_reference: required_or_pending
+al_boundary_reference: required_or_pending
+public_render_allowed: false
+human_review_required: true
+```
+
+If any required field is missing:
+
+```text
+COMPUTERWISDOM_HANDOFF_STATE: BLOCKED_PENDING_REVIEW
+```
+
+## Non-Promotion Rules
+
+```text
+REPO_GRAPH_EXISTS != FAMILY_AUTHORITY
+TECHNICAL_GREEN != FAMILY_GREEN
+LEDGER_INDEXED != CONSENT_GRANTED
+PUBLIC_SAFE_LINK != PUBLIC_RELEASE_APPROVAL
+MR_WISDOM_STRUCTURE != MRS_WISDOM_APPROVAL
+FAMILY_USER_FOUND != FAMILY_USER_RENDERABLE
+```
+
+## Family Users Rule
+
+A living ledger requires family users. Without family users, COMPUTERWISDOM becomes a deadtree index.
+
+```text
+NO_FAMILY_USERS = DEADTREE
+FAMILY_USERS_WITHOUT_PURPOSE = DIRECTORY_ONLY
+FAMILY_USERS_WITH_CONSENT_BOUNDARIES = LIVING_LEDGER_CANDIDATE
+```
+
+## Final Ruling
+
+```text
+COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_CREATED
+AUTHORITY_FALSE
+NO_FAKE_GREEN_ACTIVE
+FAMILY_USERS_REQUIRED
+MRS_WISDOM_GATE_REQUIRED
+JOY_CONSENT_OUTRANKS_REPO_GRAPH
+AL_DOCTRINE_BOUNDARY_REFERENCED
+PUBLIC_RENDER_BLOCKED
+```


### PR DESCRIPTION
## Summary

Adds the COMPUTERWISDOM Family Secure Corridor as a governed coordination boundary for the JSONWisdom family system.

## Purpose

Defines how COMPUTERWISDOM can coordinate repo graphs, family-safe indexes, living ledger surfaces, replay tooling, and technical soundness checks without becoming family authority.

## Boundary

- `authority: false`
- `no_fake_green: true`
- Family Users required or deadtree
- Mrs Wisdom gate required for family-facing expansion
- JOY consent state outranks repo graph
- AL doctrine boundary referenced
- Public render blocked
- Private details blocked

## Files added

- `docs/COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1.md`

## Activation posture

This is a corridor specification only. It does not activate public render, create family authority, or grant consent.