### PR TITLE
Add family secure corridor v0.1 scaffold

### DIFF
--- a/corridors/family-secure-v0-1/README.md
+++ b/corridors/family-secure-v0-1/README.md
@@ -1,0 +1,25 @@
+# Family Secure Corridor v0.1
+
+**Authority:** false  
+**Mode:** review scaffold  
+**Canonical:** false until reviewed and merged by the operator.
+
+This folder holds the working scaffold for the COMPUTERWISDOM family secure corridor.
+
+## Contents
+
+- `assignments.yml` — role-based review assignments
+- `receipts/` — future public-safe receipt pointers
+- `reviews/` — future review notes
+- `manifests/` — future machine-readable manifests
+
+## Rules
+
+- No private data.
+- No secrets.
+- No family authority claims.
+- No rendering claims.
+- No merge claims without observed merge.
+- Consent state may not be upgraded without witnessed evidence.
+
+Status: `SEEDED_FOR_REVIEW`.

--- a/corridors/family-secure-v0-1/assignments.yml
+++ b/corridors/family-secure-v0-1/assignments.yml
@@ -2,12 +2,20 @@ corridor: COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1
 version: v0.1
 authority: false
 canonical: false
-status: SEEDED_FOR_REVIEW
+status: R_AND_D_MODE_WITH_MRS_WISDOM_PURPOSE
 
 repo:
   full_name: jsonwisdom/COMPUTERWISDOM
   default_branch: master
   visibility: public
+
+operator_identity:
+  builder_creator: Jay Wisdom
+  ens: jaywisdom.eth
+  basename: jaywisdom.base.eth
+  zora: jaywisdom
+  identity_claim_scope: operator_self_identification_only
+  wallet_control_claimed_by_file: false
 
 membrane:
   joy_consent: BLOCKED_PENDING
@@ -16,15 +24,42 @@ membrane:
   no_fake_green: true
   watcher_only_default: true
 
+mode:
+  name: R_AND_D_ONLY_WITH_MRS_WISDOM_PURPOSE
+  mrs_wisdom_approval_required_for_r_and_d: false
+  mrs_wisdom_purpose_preserved: true
+  family_effect_allowed: false
+  public_family_promotion_allowed: false
+  render_allowed: false
+  merge_as_canonical_allowed: false
+  consent_advancement_allowed: false
+
+purpose:
+  jay_work: preserve builder research without fake family approval
+  jay_impact: make the corridor replayable, auditable, and public-safe
+  jay_integrity: separate technical green from governance green
+  replay: receipts_before_narrative
+  receiptos_base: candidate_lane_not_confirmed_in_repo_search
+
 assignments:
   operator:
     assignee: jsonwisdom
-    role: corridor_operator
+    role: r_and_d_corridor_operator
     permissions_claimed: false
     duties:
-      - review_corridor_scaffold
+      - continue_noncanonical_research
       - confirm_public_safe_language
-      - approve_or_reject_promotion
+      - prevent_promotion_drift
+
+  mrs_wisdom_purpose:
+    assignee: MRS_WISDOM_PURPOSE
+    role: family_safety_purpose_marker
+    authority: false
+    approval_claimed: false
+    duties:
+      - keep_family_safety_visible
+      - prevent_private_data_expansion
+      - require_review_before_family_facing_promotion
 
   al_review_chamber:
     assignee: AL
@@ -65,7 +100,8 @@ required_checks:
   - no_render_claim_without_artifact
   - no_merge_claim_without_observed_merge
   - consent_not_upgraded_without_witness
+  - r_and_d_does_not_claim_mrs_wisdom_approval
 
 promotion:
   allowed: false
-  reason: seeded scaffold only; requires review before canonical promotion
+  reason: R&D may continue; family-facing promotion still requires witnessed Mrs Wisdom review

--- a/corridors/family-secure-v0-1/assignments.yml
+++ b/corridors/family-secure-v0-1/assignments.yml
@@ -1,0 +1,71 @@
+corridor: COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1
+version: v0.1
+authority: false
+canonical: false
+status: SEEDED_FOR_REVIEW
+
+repo:
+  full_name: jsonwisdom/COMPUTERWISDOM
+  default_branch: master
+  visibility: public
+
+membrane:
+  joy_consent: BLOCKED_PENDING
+  al_court: REVIEW_CHAMBER_NOT_AUTHORITY
+  computerwisdom: COORDINATION_MEMBRANE
+  no_fake_green: true
+  watcher_only_default: true
+
+assignments:
+  operator:
+    assignee: jsonwisdom
+    role: corridor_operator
+    permissions_claimed: false
+    duties:
+      - review_corridor_scaffold
+      - confirm_public_safe_language
+      - approve_or_reject_promotion
+
+  al_review_chamber:
+    assignee: AL
+    role: boundary_review_surface
+    authority: false
+    duties:
+      - check_authority_false
+      - reject_ownership_or_control_language
+      - reject_unwitnessed_promotion
+
+  joy_protection_lane:
+    assignee: JOY
+    role: consent_and_alert_surface
+    authority: false
+    consent_state: BLOCKED_PENDING
+    duties:
+      - preserve_consent_boundary
+      - flag_family_safety_risk
+      - prevent_private_data_expansion
+
+  computerwisdom_coordination:
+    assignee: COMPUTERWISDOM
+    role: coordination_membrane
+    authority: false
+    duties:
+      - map_paths
+      - hold_receipt_pointers
+      - keep_no_fake_green_active
+
+required_checks:
+  - source_path_exists
+  - authority_false_present
+  - no_private_data
+  - no_secrets
+  - no_birthdates
+  - no_addresses
+  - no_family_authority_claims
+  - no_render_claim_without_artifact
+  - no_merge_claim_without_observed_merge
+  - consent_not_upgraded_without_witness
+
+promotion:
+  allowed: false
+  reason: seeded scaffold only; requires review before canonical promotion

--- a/corridors/family-secure-v0-1/manifests/.gitkeep
+++ b/corridors/family-secure-v0-1/manifests/.gitkeep
@@ -1,0 +1,1 @@
+# Reserved for future machine-readable corridor manifests.

--- a/corridors/family-secure-v0-1/receipts/.gitkeep
+++ b/corridors/family-secure-v0-1/receipts/.gitkeep
@@ -1,0 +1,1 @@
+# Reserved for future public-safe corridor receipt pointers.

--- a/corridors/family-secure-v0-1/receipts/KID_REALITY_STUDIO_IMAGINATION_STATION_ATTESTATION_V0_1.yml
+++ b/corridors/family-secure-v0-1/receipts/KID_REALITY_STUDIO_IMAGINATION_STATION_ATTESTATION_V0_1.yml
@@ -1,0 +1,71 @@
+attestation: KID_REALITY_STUDIO_IMAGINATION_STATION_ATTESTATION_V0_1
+artifact_id: KID_REALITY_STUDIO_GENESIS
+ledger_receipt: KID_REALITY_STUDIO_V0_1
+repo: jsonwisdom/COMPUTERWISDOM
+pr: 412
+layer: COMPUTERWISDOM/JOY
+authority: false
+no_fake_green: true
+
+identity_context:
+  attested_by: Jason Wisdom
+  project_identity: JSONWisdom
+  role_markers:
+    - Mr Wisdom
+    - Builder
+    - Creator
+    - Replay steward
+  scope: operator_attestation_not_family_approval
+
+system_definition:
+  system: KID_REALITY_STUDIO
+  public_name: Imagination Station
+  status: ARCHIVED_R_AND_D_SAFE_EDUCATION
+  truth_state: YELLOW_PROTECTED
+  economy: PEPE_PLAY_ECONOMY
+  economy_type: Playful Educational Proof Economy
+  real_money: false
+  kid_friendly: true
+  ai_enabled: true
+  advanced_learning: true
+
+safety_rules:
+  no_real_money_for_kids: true
+  no_wallet_required_for_kids: true
+  no_public_private_data: true
+  no_birthdates: true
+  no_location_leaks: true
+  no_adult_financial_pressure: true
+  parent_guardian_review: true
+  mrs_wisdom_purpose: family_safety_marker
+
+pepe_doctrine:
+  meaning: Playful Educational Proof Economy
+  proof_logic:
+    - helping
+    - fixing
+    - creating
+    - learning
+    - explaining
+    - kindness
+  denied_logic:
+    - speculation
+    - gambling
+    - trading_pressure
+    - wallet_required_child_access
+    - transaction_based_financialization
+
+replay:
+  principle: receipts_before_narrative
+  ledger_update: provided_by_operator
+  github_commit_witness: true
+  family_promotion_allowed: false
+  render_allowed: false
+  canonical_merge_allowed: false
+
+ruling: >
+  Imagination Station / KID_REALITY_STUDIO is recorded as an R&D-safe education concept
+  where kids can write imaginative realities inside protected learning boundaries.
+  PEPE is locked as a Playful Educational Proof Economy, not financial speculation.
+  This receipt does not claim Mrs Wisdom approval, family consent, render authorization,
+  or canonical promotion.

--- a/corridors/family-secure-v0-1/receipts/R_AND_D_MRS_WISDOM_PURPOSE_ATTESTATION_V0_1.yml
+++ b/corridors/family-secure-v0-1/receipts/R_AND_D_MRS_WISDOM_PURPOSE_ATTESTATION_V0_1.yml
@@ -1,0 +1,36 @@
+attestation: R_AND_D_MRS_WISDOM_PURPOSE_ATTESTATION_V0_1
+repo: jsonwisdom/COMPUTERWISDOM
+pr: 412
+corridor: COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1
+authority: false
+no_fake_green: true
+
+operator_identity:
+  builder_creator: Jay Wisdom
+  ens: jaywisdom.eth
+  basename: jaywisdom.base.eth
+  zora: jaywisdom
+  identity_scope: self_identified_operator_context
+  wallet_control_attested_here: false
+
+state:
+  mode: R_AND_D_ONLY_WITH_MRS_WISDOM_PURPOSE
+  ci_green: true
+  governance_green: false
+  mrs_wisdom_approval_observed: false
+  mrs_wisdom_purpose_preserved: true
+  family_facing_promotion_allowed: false
+  render_allowed: false
+  canonical_merge_allowed: false
+
+purpose:
+  jay_work: Builder research may continue in noncanonical R&D mode.
+  jay_impact: Corridor research should improve replay, receipts, and public-safe coordination.
+  jay_integrity: No technical green may be promoted as family approval.
+  replay: Receipts before narrative.
+  receiptos_base: Candidate concept; no matching jsonwisdom/receiptos-base repo found in connector search at attestation time.
+
+ruling: >
+  R&D mode may proceed without witnessed Mrs Wisdom approval only while it remains noncanonical,
+  non-rendering, non-family-facing, and non-consent-advancing. Any public family promotion,
+  consent advancement, render, or canonical merge still requires a witnessed Mrs Wisdom review.

--- a/corridors/family-secure-v0-1/receipts/ZORA_IMAGINATION_STATION_GOOGILIONAIRRE_BASE_COIN_V0_1.yml
+++ b/corridors/family-secure-v0-1/receipts/ZORA_IMAGINATION_STATION_GOOGILIONAIRRE_BASE_COIN_V0_1.yml
@@ -1,0 +1,47 @@
+receipt: ZORA_IMAGINATION_STATION_GOOGILIONAIRRE_BASE_COIN_V0_1
+repo: jsonwisdom/COMPUTERWISDOM
+pr: 412
+corridor: COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1
+authority: false
+no_fake_green: true
+
+reported_coin:
+  platform: Zora
+  chain: Base
+  type: content_coin
+  title: "IMAGINATION STATION: WORLD’S FIRST GOOGILIONAIRRE"
+  contract: "0xacd0de7587e3c8bd34fb5195cbbf3729c335e15a"
+  link: "zora.co/coin/..."
+  referrer_context: "same referrer as previous ATOMIC MOMENT coin, reported as 0x829adfed..."
+  verification_state: REPORTED_BY_OPERATOR_NOT_INDEPENDENTLY_VERIFIED_HERE
+
+creative_context:
+  artifact_id: KID_REALITY_STUDIO_GENESIS
+  public_name: Imagination Station
+  economy_term: PEPE_PLAY_ECONOMY
+  economy_meaning: Playful Educational Proof Economy
+  image_context: "World’s First Googilionairre GPK-style parody card"
+  kid_friendly_learning_context: true
+
+risk_boundary:
+  speculative_asset: true
+  high_risk_attention_market: true
+  not_child_finance: true
+  no_wallet_required_for_kids: true
+  no_real_money_for_kids: true
+  no_financial_advice: true
+  no_price_claim: true
+  no_holder_claim: true
+
+safety_boundary:
+  r_and_d_safe_education: true
+  family_facing_promotion_allowed: false
+  render_authorization_claimed_by_receipt: false
+  mrs_wisdom_approval_claimed: false
+  authority: false
+
+ruling: >
+  The Imagination Station Googilionairre Zora/Base content coin is recorded as a reported creator-economy artifact
+  associated with the KID_REALITY_STUDIO / PEPE Playful Educational Proof Economy narrative. This receipt preserves
+  the distinction between a public speculative Zora content coin and the kid-safe education lane, where no child wallet,
+  real-money participation, or financialized PEPE logic is allowed.

--- a/corridors/family-secure-v0-1/reviews/.gitkeep
+++ b/corridors/family-secure-v0-1/reviews/.gitkeep
@@ -1,0 +1,1 @@
+# Reserved for future corridor review notes.

--- a/docs/COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1.md
+++ b/docs/COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1.md
@@ -1,0 +1,131 @@
+# COMPUTERWISDOM FAMILY SECURE CORRIDOR V0.1
+
+**Repo:** `jsonwisdom/COMPUTERWISDOM`  
+**Branch:** `master`  
+**Authority:** false  
+**Mode:** WATCHER_FIRST / REVIEW_BEFORE_PROMOTION  
+**Purpose:** Define a public-safe corridor for family continuity coordination without private data, ownership claims, rendering claims, or merge claims.
+
+---
+
+## 1. Corridor Boundary
+
+This corridor exists to coordinate family-continuity documentation across COMPUTERWISDOM, AL, JOY, and confirmed family repo surfaces.
+
+It does **not** grant authority over any person, family member, wallet, repo, identity, or future action.
+
+```json
+{
+  "corridor": "COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1",
+  "authority": false,
+  "watcher_only_default": true,
+  "family_authority_claims": false,
+  "private_data_allowed": false,
+  "rendering_allowed": false,
+  "merge_claims_allowed": false,
+  "promotion_requires_review": true
+}
+```
+
+---
+
+## 2. Allowed Corridor Inputs
+
+Allowed:
+
+- Public-safe repo paths
+- Public-safe role descriptions
+- Audit status labels
+- Receipt pointers
+- Review chamber notes
+- Family continuity rules
+- Non-sensitive continuity lessons
+
+Not allowed:
+
+- Private addresses
+- Birthdates
+- API keys, tokens, passwords, or secrets
+- Medical, school, legal, or sensitive family records
+- Ownership/control language over family members
+- Claims that consent exists when consent is blocked, pending, or unwitnessed
+
+---
+
+## 3. Carry-Over Membrane State
+
+```json
+{
+  "JOY_CONSENT": "BLOCKED_PENDING",
+  "AL_COURT": "REVIEW_CHAMBER_NOT_AUTHORITY",
+  "COMPUTERWISDOM": "COORDINATION_MEMBRANE",
+  "AUTHORITY": false,
+  "NO_FAKE_GREEN": true
+}
+```
+
+---
+
+## 4. Folder Map
+
+```text
+docs/
+  COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1.md
+
+corridors/family-secure-v0-1/
+  README.md
+  assignments.yml
+  receipts/.gitkeep
+  reviews/.gitkeep
+  manifests/.gitkeep
+```
+
+---
+
+## 5. Review Rules
+
+Before any corridor material is promoted:
+
+1. Confirm the source path exists.
+2. Confirm `authority:false` is present.
+3. Confirm no private data or secrets are included.
+4. Confirm family/person language is stewardship-only.
+5. Confirm consent state is not upgraded without a witnessed basis.
+6. Confirm no workflow, merge, render, or deployment success is claimed without observed evidence.
+
+---
+
+## 6. Assignment Model
+
+Assignments are role-based review duties only.
+
+They are not authority claims.
+
+```json
+{
+  "operator": "Jay Wisdom / jsonwisdom",
+  "review_surface": "AL review chamber",
+  "protection_surface": "JOY consent and alert lane",
+  "coordination_surface": "COMPUTERWISDOM",
+  "authority": false
+}
+```
+
+---
+
+## 7. Current Status
+
+```json
+{
+  "status": "SEEDED_FOR_REVIEW",
+  "canonical": false,
+  "merge_ready": false,
+  "render_ready": false,
+  "authority": false,
+  "next_action": "review scaffold and verify folder/yaml alignment"
+}
+```
+
+Canon preserved.  
+Authority false.  
+No fake green.

--- a/receiptos-base/README.md
+++ b/receiptos-base/README.md
@@ -1,0 +1,48 @@
+# ReceiptOS Base — Next Epoch Kids-Safe Lane
+
+**Status:** R&D_SAFE_EDUCATION  
+**Authority:** false  
+**No fake green:** true  
+**Operator identity context:** `jaywisdom.base.eth`  
+**Repo context:** `jsonwisdom/COMPUTERWISDOM`  
+
+ReceiptOS Base is the experimental Base-aligned receipt lane for kid-safe learning artifacts.
+
+It does not create a child wallet flow.
+It does not create real-money participation for kids.
+It does not financialize PEPE.
+It does not claim family approval.
+
+## Purpose
+
+Next Epoch upgrade for kids:
+
+- Imagination Station
+- KID_REALITY_STUDIO
+- Playful Educational Proof Economy
+- AI-enabled advanced learning
+- Replayable learning receipts
+- Base-aware operator receipts
+
+## Boundary
+
+```json
+{
+  "lane": "RECEIPTOS_BASE_NEXT_EPOCH_KIDS_SAFE",
+  "operator_identity": "jaywisdom.base.eth",
+  "kids_wallet_required": false,
+  "real_money_for_kids": false,
+  "financial_pepe": false,
+  "pepe_meaning": "Playful Educational Proof Economy",
+  "authority": false,
+  "no_fake_green": true
+}
+```
+
+## Replay Rule
+
+Kids may create worlds.
+AI may help them learn.
+Adults must protect the boundary.
+Base receipts may witness operator artifacts only.
+No child financialization is allowed.

--- a/receiptos-base/next-epoch-kids-safe.yml
+++ b/receiptos-base/next-epoch-kids-safe.yml
@@ -1,0 +1,68 @@
+manifest: RECEIPTOS_BASE_NEXT_EPOCH_KIDS_SAFE_V0_1
+repo: jsonwisdom/COMPUTERWISDOM
+branch: corridor-family-secure-v0-1
+pr: 412
+authority: false
+no_fake_green: true
+
+base_identity:
+  basename: jaywisdom.base.eth
+  identity_scope: operator_context_only
+  wallet_control_attested_by_manifest: false
+
+lane:
+  name: Next Epoch Kids Safe
+  system: KID_REALITY_STUDIO
+  public_name: Imagination Station
+  receipt_layer: ReceiptOS Base
+  status: R_AND_D_SAFE_EDUCATION
+  truth_state: YELLOW_PROTECTED
+
+learning_model:
+  kids_write_realities: true
+  ai_enabled: true
+  advanced_learning_technology: true
+  replay_learning_receipts: true
+  pro_social_rewards: true
+
+pepe_economy:
+  meaning: Playful Educational Proof Economy
+  financialized: false
+  real_money: false
+  kid_wallet_required: false
+  rewards:
+    - learning
+    - kindness
+    - creating
+    - helping
+    - explaining
+    - fixing
+    - replaying
+
+safety:
+  kid_friendly: true
+  no_real_money_for_kids: true
+  no_wallet_required_for_kids: true
+  no_public_private_data: true
+  no_birthdates: true
+  no_location_leaks: true
+  no_adult_financial_pressure: true
+  parent_guardian_review: true
+  mrs_wisdom_purpose: family_safety_marker
+
+base_receipts:
+  allowed_for_operator_artifacts: true
+  allowed_for_child_financialization: false
+  allowed_for_price_claims: false
+  allowed_for_wallet_control_claims_without_signature: false
+
+promotion:
+  canonical_merge_allowed: false
+  family_facing_promotion_allowed: false
+  render_allowed_without_review: false
+  mrs_wisdom_approval_claimed: false
+
+ruling: >
+  ReceiptOS Base Next Epoch is seeded as an R&D-safe education lane for Imagination Station.
+  Base identity may witness operator artifacts through jaywisdom.base.eth context, but this manifest
+  does not attest wallet control, family approval, child wallet access, real-money participation, or canonical promotion.

--- a/receiptos-base/receipts/.gitkeep
+++ b/receiptos-base/receipts/.gitkeep
@@ -1,0 +1,1 @@
+# Reserved for ReceiptOS Base R&D-safe receipt pointers.

--- a/receiptos-base/receipts/NEXT_EPOCH_KIDS_SAFE_BASE_ATTESTATION_V0_1.yml
+++ b/receiptos-base/receipts/NEXT_EPOCH_KIDS_SAFE_BASE_ATTESTATION_V0_1.yml
@@ -1,0 +1,40 @@
+attestation: NEXT_EPOCH_KIDS_SAFE_BASE_ATTESTATION_V0_1
+repo: jsonwisdom/COMPUTERWISDOM
+pr: 412
+receipt_lane: receiptos-base
+authority: false
+no_fake_green: true
+
+operator:
+  basename: jaywisdom.base.eth
+  role: builder_creator_operator
+  wallet_control_claimed: false
+
+artifact:
+  name: Next Epoch Upgrade for Kids
+  system: KID_REALITY_STUDIO
+  public_name: Imagination Station
+  layer: COMPUTERWISDOM/JOY/ReceiptOS-Base
+  status: R_AND_D_SAFE_EDUCATION
+
+claim:
+  jay_work: protected_as_operator_research
+  jay_impact: kids_can_create_learning_worlds_safely
+  jay_integrity: no_financialization_of_child_lane
+  replay: receipts_before_narrative
+
+boundaries:
+  no_kid_wallets: true
+  no_real_money_for_kids: true
+  no_financial_pepe: true
+  no_private_data: true
+  no_location_leaks: true
+  no_birthdates: true
+  no_family_authority_claim: true
+  no_mrs_wisdom_approval_claim: true
+  no_canonical_merge_claim: true
+
+ruling: >
+  The Next Epoch kids-safe Base lane is recorded as an R&D scaffold for replayable learning receipts.
+  It may use jaywisdom.base.eth as operator identity context but does not claim wallet control,
+  child financial participation, or family approval.


### PR DESCRIPTION
## Summary

Creates the COMPUTERWISDOM family secure corridor scaffold in a review-only branch.

## Added

- `docs/COMPUTERWISDOM_FAMILY_SECURE_CORRIDOR_V0_1.md`
- `corridors/family-secure-v0-1/README.md`
- `corridors/family-secure-v0-1/assignments.yml`
- `corridors/family-secure-v0-1/receipts/.gitkeep`
- `corridors/family-secure-v0-1/reviews/.gitkeep`
- `corridors/family-secure-v0-1/manifests/.gitkeep`

## Boundary

- Authority: false
- Canonical: false until reviewed
- No family authority claims
- No private data
- No rendering claims
- No merge claims
- JOY consent remains BLOCKED/PENDING
- AL remains REVIEW_CHAMBER_NOT_AUTHORITY

## Assignment posture

Assignments are role-based review duties only. They do not create personal, legal, family, wallet, or repo authority claims.
