### PR TITLE
docs(court): add verified Meme Court deployment pointer

### DIFF
--- a/court/meme-court-frame/INTEGRATION_RECEIPT.md
+++ b/court/meme-court-frame/INTEGRATION_RECEIPT.md
@@ -1,0 +1,24 @@
+# Meme Court Frame Deployment Receipt
+
+**Status:** Verified live  
+**Authority:** `false`
+
+## Provenance chain
+
+- Git commit: `def509c33af5c487ee1a9e56f5390849a1e68f02`
+- Source ZIP SHA-256: `81418a815d6e4c7f83ea400334697f40d7575590e4b240dfab857b6aa5dabbea`
+- Cloud Build: `c08fb32f-80bd-432f-b128-190bff6f4b37` (`SUCCESS`)
+- Container image digest: `sha256:62de20bb221411a73f5a7fe589cb27e21b2713fff9678e131a7d0f2801cc9f88`
+- Cloud Run revision: `meme-court-verifier-00002-csf`
+- Public response SHA-256: `d73c15346e29bd15a8a35dc3556aa247760531cac0f563346baa945636c0ca13`
+- Public endpoint: `https://meme-court-verifier-2y4hej4r2a-uc.a.run.app/api/frame`
+
+## Determination
+
+All nine files uploaded in the Cloud Build source bundle matched their corresponding committed files byte-for-byte. The only committed file absent from the upload bundle was the non-runtime `.gitignore`, which excludes `.next/` and `node_modules/`.
+
+This receipt records a verified runtime-source match. It does not claim that buildpack-generated container layers are byte-for-byte identical to Git source.
+
+## Boundary
+
+This is a pointer and deployment receipt only. No runtime code is duplicated into COMPUTERWISDOM. No execution authority or evidence promotion is created.

--- a/court/meme-court-frame/README.md
+++ b/court/meme-court-frame/README.md
@@ -1,0 +1,15 @@
+# Meme Court Frame Pointer
+
+Governed pointer to the canonical Meme Court Frame runtime and its verified public deployment.
+
+- Repository: `jsonwisdom/receiptos-base`
+- Path: `apps/meme-court-frame`
+- Branch: `feat/meme-court-cloud-run-runtime`
+- Commit: `def509c33af5c487ee1a9e56f5390849a1e68f02`
+- Public endpoint: `https://meme-court-verifier-2y4hej4r2a-uc.a.run.app/api/frame`
+
+## Boundary
+
+This directory contains pointer and receipt material only. Runtime code remains in the canonical source repository. No execution authority, evidence promotion, or runtime duplication is created here.
+
+`authority = false`

--- a/court/meme-court-frame/SOURCE_POINTER.json
+++ b/court/meme-court-frame/SOURCE_POINTER.json
@@ -1,0 +1,23 @@
+{
+  "type": "repository-pointer",
+  "name": "meme-court-frame",
+  "source_repo": "jsonwisdom/receiptos-base",
+  "source_path": "apps/meme-court-frame",
+  "source_branch": "feat/meme-court-cloud-run-runtime",
+  "source_commit": "def509c33af5c487ee1a9e56f5390849a1e68f02",
+  "deployment_target": "Google Cloud Run",
+  "cloud_project": "jaywisdom-boardroom-preview",
+  "service_name": "meme-court-verifier",
+  "region": "us-central1",
+  "public_url": "https://meme-court-verifier-2y4hej4r2a-uc.a.run.app/api/frame",
+  "cloud_build_id": "c08fb32f-80bd-432f-b128-190bff6f4b37",
+  "cloud_run_revision": "meme-court-verifier-00002-csf",
+  "source_zip_sha256": "81418a815d6e4c7f83ea400334697f40d7575590e4b240dfab857b6aa5dabbea",
+  "container_image_digest": "sha256:62de20bb221411a73f5a7fe589cb27e21b2713fff9678e131a7d0f2801cc9f88",
+  "public_response_sha256": "d73c15346e29bd15a8a35dc3556aa247760531cac0f563346baa945636c0ca13",
+  "verification_scope": "All nine uploaded runtime files matched the corresponding committed files byte-for-byte. The non-runtime .gitignore file was excluded from the upload bundle.",
+  "authority": false,
+  "status": "deployed-verified",
+  "last_updated": "2026-07-11",
+  "notes": "COMPUTERWISDOM maintains a governed pointer only. No runtime duplication, execution authority, or evidence promotion is implied."
+}


### PR DESCRIPTION
## Summary

Adds a governed COMPUTERWISDOM pointer and deployment receipt for the canonical Meme Court Frame runtime.

The runtime remains exclusively maintained in:

- Repository: `jsonwisdom/receiptos-base`
- Path: `apps/meme-court-frame`
- Branch: `feat/meme-court-cloud-run-runtime`
- Commit: `def509c33af5c487ee1a9e56f5390849a1e68f02`

No runtime code is duplicated into COMPUTERWISDOM.

## Files added

- `court/meme-court-frame/README.md`
- `court/meme-court-frame/SOURCE_POINTER.json`
- `court/meme-court-frame/INTEGRATION_RECEIPT.md`

## Deployment evidence

- Cloud Build ID: `c08fb32f-80bd-432f-b128-190bff6f4b37`
- Source ZIP SHA-256: `81418a815d6e4c7f83ea400334697f40d7575590e4b240dfab857b6aa5dabbea`
- Container image digest: `sha256:62de20bb221411a73f5a7fe589cb27e21b2713fff9678e131a7d0f2801cc9f88`
- Cloud Run revision: `meme-court-verifier-00002-csf`
- Public endpoint: `https://meme-court-verifier-2y4hej4r2a-uc.a.run.app/api/frame`
- Public GET/POST response SHA-256: `d73c15346e29bd15a8a35dc3556aa247760531cac0f563346baa945636c0ca13`

## Verification determination

All nine files uploaded in the Cloud Build source bundle matched their corresponding committed files byte-for-byte. The only committed file absent from the upload bundle was the non-runtime `.gitignore`.

## Boundaries

- Pointer and receipt only
- No runtime duplication
- No execution authority
- No evidence promotion beyond recorded deployment observations
- `authority = false`
