### PR TITLE
Add ICC Controlled Activation Doctrine

### DIFF
--- a/docs/doctrine/README.md
+++ b/docs/doctrine/README.md
@@ -1,0 +1,5 @@
+# Doctrine Index
+
+## Active Canonical Doctrine
+
+- [ICC Controlled Activation Doctrine](../icc-controlled-activation-doctrine.md) — Status: `ACTIVE`; domestic primacy, functional complementarity, narrow backstop activation, and signed exception receipts.

--- a/docs/icc-controlled-activation-doctrine.md
+++ b/docs/icc-controlled-activation-doctrine.md
@@ -1,0 +1,88 @@
+# ICC Controlled Activation Doctrine
+
+**Status:** ACTIVE  
+**Repository:** `jsonwisdom/COMPUTERWISDOM`  
+**Canonical path:** `docs/icc-controlled-activation-doctrine.md`  
+**Effective date:** 2026-07-14  
+**Authority type:** Policy architecture; not law and not legal advice
+
+## Canonical Invariant
+
+> Jurisdiction proven. Deference earned. Failure demonstrated. Cooperation constrained. Exceptions receipted.
+
+## Three-Layer Decision Matrix
+
+| Stage | Input | Logic gate | Default output |
+|---|---|---|---|
+| 1. Sovereignty filter | Jurisdictional basis | Is valid consent, delegation, or another lawful treaty basis established? | `RESIST` if false |
+| 2. Complementarity gate | Domestic proceedings | Are proceedings independent, transparent, timely, and directed at substantially the same person and conduct? | `DEFER` if true |
+| 3. Backstop trigger | Failure evidence | Are exceptional gravity, proven domestic failure, individualized evidence, and a plausible enforcement path established? | `COOPERATE` if true |
+
+## Functional Complementarity Test
+
+Domestic proceedings earn deference only when the record demonstrates:
+
+1. institutional independence;
+2. procedural transparency;
+3. reasonable timeliness;
+4. substantially the same person-and-conduct scope;
+5. no shielding, blanket immunity, sham process, or unjustified delay.
+
+A functioning judiciary creates no categorical immunity. Performance controls.
+
+## Proven-Failure Standard
+
+International activation requires documented evidence of institutional collapse, shielding, sham proceedings, unjustified delay, compromised independence, or inability to secure evidence, custody, or adjudication. Assertions alone do not satisfy the gate.
+
+## Cooperation Constraints
+
+Any cooperation must be case-specific, proportionate, evidence-bound, limited to the verified failure, reviewed on a fixed schedule, and terminated when activation conditions no longer exist.
+
+## Documented-Exception Rule
+
+Any departure from the default matrix must create a signed, reviewable receipt containing:
+
+```text
+CASE_ID
+JURISDICTION_BASIS
+DOMESTIC_PROCESS_STATUS
+SAME_CONDUCT_FINDING
+FAILURE_EVIDENCE
+GRAVITY_FINDING
+ENFORCEMENT_PATH
+OUTPUT: RESIST | DEFER | COOPERATE
+EXCEPTION_USED: TRUE | FALSE
+LEGAL_AUTHORITY
+AUTHORIZING_OFFICIAL
+SCOPE
+EXPECTED_CONSEQUENCES
+REVIEW_DATE
+EXPIRATION_OR_TERMINATION_CONDITION
+SUPPORTING_EVIDENCE_REFERENCES
+SIGNATURE_OR_APPROVAL_RECORD
+```
+
+No undocumented exception is valid under this doctrine.
+
+## Symmetry Rule
+
+The same tests apply to allies, adversaries, democratic governments, non-state actors, and failed states. Political alignment does not alter the evidentiary threshold.
+
+## Institutional Hierarchy
+
+1. Domestic justice systems
+2. Hybrid or regional mechanisms with enforceable sponsorship
+3. ICC as a narrow last-resort backstop
+4. Lawful diplomatic, legal, and political resistance when boundaries are exceeded
+
+## Audit Requirements
+
+Every decision must preserve source provenance, evidentiary citations, responsible decision-maker, applied standard, output, exception status, and review or expiration dates.
+
+Periodic audits should examine geographic balance, referral source, party/non-party status, cooperation rates, arrest outcomes, case duration, and departures from the default matrix.
+
+## Operating Metaphor
+
+> Preserve the extinguisher. Restrict the cabinet. Audit the key holders. Fund the firehouse first.
+
+The ICC is a limited emergency backstop, not a substitute for state power, domestic justice, or enforceable hybrid mechanisms.


### PR DESCRIPTION
## Deployment

Adds the canonical ICC Controlled Activation Doctrine and indexes it for doctrine visibility.

### Included
- Three-layer `RESIST | DEFER | COOPERATE` decision matrix
- Functional complementarity and proven-failure gates
- Symmetry rule for allies and adversaries
- Signed documented-exception receipt schema
- Audit requirements and institutional hierarchy

### Boundary
This is a policy architecture artifact, not enacted law or legal advice.

Direct writes to `master` are protected; this PR is the required deployment path.