### PR TITLE
Add receipts-first public proof membrane

### DIFF
--- a/jaywisdom/projects/index.json
+++ b/jaywisdom/projects/index.json
@@ -1,0 +1,60 @@
+{
+  "schema": "https://jsonwisdom.github.io/COMPUTERWISDOM/schemas/public-project-index-v0.1.json",
+  "index_id": "jaywisdom:public-projects:v0.1",
+  "updated_at": "2026-07-29T20:17:00Z",
+  "authority": false,
+  "publication_rule": "Repository activity is not public publication unless an explicit release record says so.",
+  "statuses": ["PUBLIC", "IN REVIEW", "STABLE HOLD", "RESEARCH", "PRIVATE", "PERSONAL"],
+  "projects": [
+    {
+      "id": "jaywisdom-public-face",
+      "title": "JAYWISDOM Public Face",
+      "classification": "PUBLIC",
+      "verification_state": "DEPLOYMENT_UNVERIFIED",
+      "source_url": "https://github.com/jsonwisdom/COMPUTERWISDOM/tree/master/jaywisdom",
+      "release_record_url": "https://github.com/jsonwisdom/COMPUTERWISDOM/pull/419",
+      "public_url": "https://jsonwisdom.github.io/COMPUTERWISDOM/jaywisdom/",
+      "what_is_not_claimed": ["No authority is established.", "A merged pull request does not independently prove GitHub Pages deployment."]
+    },
+    {
+      "id": "minnesota-law-monitor",
+      "title": "Minnesota Law Monitor",
+      "classification": "PUBLIC",
+      "verification_state": "MANUAL_INTAKE",
+      "source_url": "https://github.com/jsonwisdom/COMPUTERWISDOM",
+      "what_is_not_claimed": ["No automated completeness claim.", "No legal authority or legal advice claim."]
+    },
+    {
+      "id": "atomic-dockets",
+      "title": "Atomic Dockets",
+      "classification": "STABLE HOLD",
+      "verification_state": "OFFICIAL_SOURCE_PENDING",
+      "source_url": "https://github.com/jsonwisdom/COMPUTERWISDOM",
+      "what_is_not_claimed": ["No final publication claim.", "No unresolved record is converted into fact."]
+    },
+    {
+      "id": "meme-court",
+      "title": "Meme Court",
+      "classification": "IN REVIEW",
+      "verification_state": "HUMAN_REVIEW_REQUIRED",
+      "source_url": "https://github.com/jsonwisdom/COMPUTERWISDOM",
+      "what_is_not_claimed": ["Satire is not evidence.", "No institutional authority is implied."]
+    },
+    {
+      "id": "public-proof-tools",
+      "title": "Public Proof Tools",
+      "classification": "RESEARCH",
+      "verification_state": "EXPLORATORY",
+      "source_url": "https://github.com/jsonwisdom/COMPUTERWISDOM",
+      "what_is_not_claimed": ["Research artifacts are not production proof.", "Unknown and conflict states remain valid outcomes."]
+    },
+    {
+      "id": "computerwisdom-control-plane",
+      "title": "COMPUTERWISDOM Control Plane",
+      "classification": "RESEARCH",
+      "verification_state": "ACTIVE_DEVELOPMENT",
+      "source_url": "https://github.com/jsonwisdom/COMPUTERWISDOM",
+      "what_is_not_claimed": ["Repository access does not grant operational authority.", "Private, personal, treasury, and family lanes are not auto-promoted."]
+    }
+  ]
+}

--- a/jaywisdom/receipts/PROOF-MEMBRANE-v0.1.md
+++ b/jaywisdom/receipts/PROOF-MEMBRANE-v0.1.md
@@ -1,0 +1,42 @@
+# JAYWISDOM PUBLIC PROOF MEMBRANE — v0.1
+
+Status: IN REVIEW
+Date: 2026-07-29
+Authority: false
+Human release gate: required
+
+## Purpose
+
+Establish a receipts-first public identity and proof membrane connecting the JayWisdom public surface, project directory, source repository, release records, and durable naming pointers without converting publication, minting, repository access, or wallet references into authority.
+
+## Added artifacts
+
+- `jaywisdom/projects/index.json` — machine-readable public project index
+- `jaywisdom/verify/index.html` — zero-dependency verifier interface
+
+## Required fields
+
+Each indexed public project records:
+
+- stable project ID
+- explicit classification
+- verification state
+- source pointer
+- release-record pointer when available
+- public URL when declared
+- explicit statements of what is not claimed
+
+## Invariants
+
+1. Authority is false by default.
+2. Repository activity is not automatically public publication.
+3. A merged pull request does not independently prove deployment.
+4. Unknown, hold, conflict, and deployment-unverified are valid states.
+5. Private, personal, treasury, family, credential, and operational-control lanes are excluded.
+6. Zora artifacts are distribution signals, not proof of authority.
+7. Token references carry no promise of price, profit, liquidity, utility, or future value.
+8. Publication remains human-gated.
+
+## Verification boundary
+
+This version does not validate cryptographic signatures, ENS ownership, wallet control, GitHub Pages deployment, Zora mint provenance, or third-party availability. Those checks require independent observations and separate receipts.

--- a/jaywisdom/verify/index.html
+++ b/jaywisdom/verify/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Receipts-first verifier for the JayWisdom public proof membrane.">
+  <title>JayWisdom — Receipt Verifier</title>
+  <style>
+    :root{--bg:#07111f;--panel:#0d1b2d;--text:#f4f7fb;--muted:#9fb0c6;--line:#2b3d57;--gold:#f5c65a;--green:#69d79f;--blue:#73b8ff;--red:#ff8d8d}*{box-sizing:border-box}body{margin:0;background:linear-gradient(180deg,#07111f,#0a1728);color:var(--text);font:16px/1.55 system-ui,-apple-system,sans-serif}.wrap{width:min(980px,92vw);margin:auto;padding:56px 0}h1{font-size:clamp(2.4rem,7vw,5rem);line-height:.98;margin:.4rem 0 1rem}.eyebrow{color:var(--gold);font-size:.78rem;letter-spacing:.16em;text-transform:uppercase;font-weight:900}.lede{color:var(--muted);max-width:760px}.boundary{padding:18px;border:1px solid var(--line);border-radius:16px;background:var(--panel);margin:28px 0}.boundary strong{color:var(--red)}.controls{display:flex;gap:10px;flex-wrap:wrap;margin:22px 0}input{flex:1;min-width:240px;padding:13px;border-radius:12px;border:1px solid var(--line);background:#06101d;color:var(--text);font:inherit}button,a.btn{padding:13px 16px;border-radius:12px;border:1px solid var(--line);background:#173b61;color:var(--text);font-weight:800;text-decoration:none;cursor:pointer}.status{color:var(--muted);min-height:1.4em}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(270px,1fr));gap:14px}.card{padding:20px;border:1px solid var(--line);border-radius:16px;background:var(--panel)}.card h2{margin:.3rem 0}.tag{color:var(--blue);font-size:.75rem;font-weight:900;letter-spacing:.1em}.state{color:var(--green);font-family:ui-monospace,monospace;font-size:.86rem}.card p,.card li{color:var(--muted)}.card a{color:var(--gold)}code{overflow-wrap:anywhere}footer{margin-top:34px;color:var(--muted);border-top:1px solid var(--line);padding-top:22px}
+  </style>
+</head>
+<body><main class="wrap">
+  <div class="eyebrow">Receipts-first identity membrane</div>
+  <h1>Verify the record.<br>Do not infer authority.</h1>
+  <p class="lede">This page reads the public project index. It displays declared status, source pointers, release records, and explicit non-claims. It does not validate signatures, control wallets, certify identity, or create institutional authority.</p>
+  <div class="boundary"><strong>AUTHORITY = FALSE BY DEFAULT.</strong><br>Unknown, hold, conflict, and deployment-unverified states are valid outcomes—not failures to be hidden.</div>
+  <div class="controls"><input id="query" placeholder="Project ID or title" aria-label="Project ID or title"><button id="find" type="button">Find receipt</button><a class="btn" href="../projects/index.json">Raw JSON</a><a class="btn" href="../projects/">Human-readable map</a></div>
+  <div id="status" class="status" aria-live="polite">Loading public receipt index…</div>
+  <section id="results" class="grid" aria-label="Verification results"></section>
+  <footer>Verification over narrative · Receipts &gt; claims · No fake green · Human release gate remains required.</footer>
+</main>
+<script>
+const results=document.getElementById('results');const statusEl=document.getElementById('status');const query=document.getElementById('query');let index=null;
+function esc(v){return String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
+function render(items){results.innerHTML='';if(!items.length){statusEl.textContent='No matching public receipt. Absence is not proof of nonexistence.';return}statusEl.textContent=`${items.length} public receipt${items.length===1?'':'s'} displayed.`;for(const p of items){const card=document.createElement('article');card.className='card';const claims=(p.what_is_not_claimed||[]).map(x=>`<li>${esc(x)}</li>`).join('');card.innerHTML=`<div class="tag">${esc(p.classification)}</div><h2>${esc(p.title)}</h2><div class="state">${esc(p.verification_state)}</div><p><code>${esc(p.id)}</code></p><p><a href="${esc(p.source_url)}">Source record</a>${p.release_record_url?` · <a href="${esc(p.release_record_url)}">Release record</a>`:''}${p.public_url?` · <a href="${esc(p.public_url)}">Public surface</a>`:''}</p><strong>What is not claimed</strong><ul>${claims}</ul>`;results.appendChild(card)}}
+async function load(){try{const r=await fetch('../projects/index.json',{cache:'no-store'});if(!r.ok)throw new Error(`HTTP ${r.status}`);index=await r.json();render(index.projects||[])}catch(e){statusEl.textContent=`Index unavailable: ${e.message}. Verification state remains UNKNOWN.`}}
+document.getElementById('find').addEventListener('click',()=>{if(!index)return;const q=query.value.trim().toLowerCase();render(!q?index.projects:(index.projects||[]).filter(p=>p.id.toLowerCase().includes(q)||p.title.toLowerCase().includes(q)))});query.addEventListener('keydown',e=>{if(e.key==='Enter')document.getElementById('find').click()});load();
+</script></body></html>


### PR DESCRIPTION
## What changed
- Adds `jaywisdom/projects/index.json` as the machine-readable public project registry
- Adds `jaywisdom/verify/index.html` as a zero-dependency verification surface
- Adds `jaywisdom/receipts/PROOF-MEMBRANE-v0.1.md` as the implementation receipt and boundary record

## Doctrine preserved
- Authority is false by default
- Repository activity is not automatic publication
- Deployment-unverified, unknown, hold, and conflict remain valid states
- Every indexed project states what is not claimed
- Private, personal, treasury, family, credential, and operational-control lanes are excluded
- Human release gate remains required

## Current verification posture
PR #419 is merged, but the GitHub Pages paths were not independently retrievable during this implementation pass. This PR therefore records `DEPLOYMENT_UNVERIFIED`; it does not synthesize a green deployment claim.

## Validation
- Static HTML and JSON only
- No dependencies
- No automatic minting or authority claims
- Existing public files are not overwritten
