### PR TITLE
add RePlay Wisdom Factory agentic game

### DIFF
--- a/agentic-game/.gitignore
+++ b/agentic-game/.gitignore
@@ -1,0 +1,3 @@
+state/*.json
+!state/fixtures/
+!state/fixtures/*.json

--- a/agentic-game/DESIGN.md
+++ b/agentic-game/DESIGN.md
@@ -1,0 +1,101 @@
+# RePlay Wisdom Factory Game — Design Boundary
+
+## Identity
+
+**RePlay Wisdom Factory Game** is an **agentic pedagogical game** inside `jsonwisdom/COMPUTERWISDOM`.
+
+It teaches the verification rhythm:
+
+`PROPOSE → TEST → RECEIPT → REPLAY → VERIFIED`
+
+It is **not** the JSONWisdom protocol verifier, not a fuzz harness, and not a source of execution authority.
+
+## Boundary
+
+```text
+JSONWisdom / protocol engineering
+        │
+        │ concepts only
+        ▼
+RePlay Wisdom Factory Game
+pedagogical agentic simulation
+```
+
+No in-game score, event, receipt, replay, checkpoint, or Constitution reward amends or verifies `jsonwisdom/AL`.
+
+## Mechanic Classification
+
+### Canonical Analogy
+- Core verification rhythm
+- `PASS != VERIFIED`
+- Independent `REPLAY!`
+- Evidence/receipt thinking
+- Mandatory reflection after each round
+
+### Simplified Analogy
+- Dice/seed resolution
+- Zero Trust ability
+- Bullshit Detector ability
+- Chaos Deck failures
+- Replay anomaly branches
+
+These compress real protocol failure modes into game events. They are not cryptographic verifier outcomes.
+
+### Non-Canonical Gamification
+- Wisdom points
+- Intuition Reward — Non-Canonical
+- In-game Constitution rewards
+- `state/wisdom-graph.json`
+
+These exist only to make learning fun and memorable.
+
+## Game Zero
+
+Game Zero teaches one thing above all:
+
+> A passing test is not the same thing as a verified claim.
+
+Two claims are played. Every resolved round ends with reflection:
+
+1. What did you believe before?
+2. What actually survived?
+
+After both claims resolve, the game asks both players to explain why VERIFIED required more than PASS.
+
+`gameZeroUnderstood` becomes `true` only when the players jointly confirm they can explain the distinction.
+
+The success condition is therefore **understanding**, not obtaining a VERIFIED result.
+
+## Agentic Loop
+
+```text
+MISSION
+  ↓
+PROPOSER — states the claim
+  ↓
+SKEPTIC — attacks assumptions
+  ↓
+TESTER — creates a falsification challenge
+  ↓
+PLAYERS — predict / decide
+  ↓
+REPLAYER — checks consistency
+  ↓
+SCRIBE — records the round
+  ↓
+REFLECTION — records mental-model change
+```
+
+## Runtime State
+
+`state/wisdom-graph.json` is local session state and is ignored by Git.
+
+A future committed fixture may live at:
+
+`state/fixtures/sample-wisdom-graph.json`
+
+## Playtest Question
+
+The prototype succeeds if a new player eventually asks, without prompting:
+
+> “It passed — but did somebody independently replay it?”

--- a/agentic-game/README.md
+++ b/agentic-game/README.md
@@ -1,0 +1,125 @@
+# ⚙️ RePlay Wisdom Factory Game
+
+A cooperative **agentic game** for Jay, David, and friends.
+
+The game teaches one habit:
+
+> **PASS is not VERIFIED.**
+
+Players propose claims, attack assumptions, run tests, demand independent replay, record receipts, and reflect on what survived.
+
+This is a **pedagogical game**. It does not create protocol authority and does not verify or amend `jsonwisdom/AL`.
+
+## Play Game Zero
+
+Requirements: Node.js 18+.
+
+```bash
+cd agentic-game
+npm start
+```
+
+Optional deterministic playtest seed:
+
+```bash
+WISDOM_SEED=42 npm start
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:WISDOM_SEED=42; npm start
+```
+
+## Two-Player Loop
+
+```text
+PLAYER 1 CLAIM
+      ↓
+PLAYER 2 ATTACKS
+      ↓
+TESTER
+      ↓
+PASS / FAIL
+      ↓
+REPLAY!
+      ↓
+RECEIPT
+      ↓
+REFLECTION
+```
+
+Then roles reverse.
+
+After both claims resolve, Game Zero asks both players:
+
+**Why does VERIFIED require more than PASS?**
+
+The game only sets `gameZeroUnderstood: true` after both explanations and shared agreement.
+
+## Agents
+
+- **Proposer** — states the claim.
+- **Skeptic** — attacks an assumption.
+- **Tester** — creates the primary test outcome.
+- **Replayer** — independently checks the result.
+- **Scribe** — records the receipt.
+- **Gatekeeper** — refuses to equate PASS with VERIFIED.
+
+## Reflection
+
+Every round asks:
+
+1. What did you believe before?
+2. What actually survived?
+
+Reflection happens after success **and** failure.
+
+## Wisdom Points
+
+Wisdom points are game feedback only. More points do not create more authority.
+
+The former “David Jackpot” is now the **Intuition Reward — Non-Canonical** concept: fun for the game, meaningless to the protocol.
+
+## Runtime State
+
+Sessions save locally to:
+
+```text
+state/wisdom-graph.json
+```
+
+That file is gitignored. Do not submit personal/private session state in issues.
+
+## David + Friends Playtest
+
+For the first public test, play Game Zero once and report:
+
+- Did you understand why PASS was insufficient?
+- At what moment did you want to demand REPLAY yourself?
+- What confused you?
+- Did the Chaos Card help or distract?
+- Did Reflection change your opinion of the claim?
+- What should tomorrow's build change first?
+
+### Snapchat RePlay feedback lane
+
+Snapchat can be used to share the **experience** of the playtest with friends: reactions, screenshots that contain no private data, and short “what survived?” recaps.
+
+Snapchat sharing is a **feedback/distribution enablement only**. A Snap is not evidence, a game receipt, or protocol authority.
+
+Please move durable feedback into the GitHub feedback issue so tomorrow's work has a replayable record.
+
+## Design Boundary
+
+Read [`DESIGN.md`](./DESIGN.md) before changing game mechanics. It labels mechanics as:
+
+- Canonical Analogy
+- Simplified Analogy
+- Non-Canonical Gamification
+
+## Game Zero Success
+
+You do **not** win because a claim gets VERIFIED.
+
+You win when both players can explain why a passing test alone was not enough.

--- a/agentic-game/package.json
+++ b/agentic-game/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "replay-wisdom-factory-game",
+  "version": "0.1.0",
+  "private": false,
+  "description": "RePlay Wisdom Factory Game — a cooperative agentic game for learning replay, verification, and reflection.",
+  "type": "module",
+  "scripts": {
+    "start": "node src/cli.js"
+  },
+  "license": "MIT"
+}

--- a/agentic-game/src/cli.js
+++ b/agentic-game/src/cli.js
@@ -1,0 +1,208 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import {
+  createRng,
+  drawChaos,
+  runTest,
+  runReplay,
+  wisdomFor,
+  classifyReceipt,
+  NON_CANONICAL_NOTICE
+} from './engine.js';
+
+const rl = readline.createInterface({ input, output });
+const stateDir = path.resolve('state');
+const statePath = path.join(stateDir, 'wisdom-graph.json');
+const seed = process.env.WISDOM_SEED ? Number(process.env.WISDOM_SEED) : Date.now();
+const rng = createRng(seed);
+
+function freshState() {
+  return {
+    version: 1,
+    game: 'RePlay Wisdom Factory Game',
+    wisdom: 0,
+    history: [],
+    gameZeroUnderstood: false,
+    checkpointExplanation: null
+  };
+}
+
+function loadState() {
+  try {
+    return JSON.parse(fs.readFileSync(statePath, 'utf8'));
+  } catch {
+    return freshState();
+  }
+}
+
+function saveState(state) {
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+async function ask(prompt) {
+  return (await rl.question(prompt)).trim();
+}
+
+async function finish(state, round) {
+  console.log('\nREFLECTION — mandatory every round');
+  const believedBefore = await ask('What did you believe before? ');
+  const survived = await ask('What actually survived? ');
+
+  round.reflection = { believedBefore, survived };
+  round.completedAt = new Date().toISOString();
+  state.history.push(round);
+  state.wisdom += wisdomFor(round.status);
+  saveState(state);
+
+  console.log(`\nReceipt: ${round.status}`);
+  console.log(`Wisdom: +${wisdomFor(round.status)} (game score only)`);
+  console.log(NON_CANONICAL_NOTICE);
+  return round;
+}
+
+async function playRound(state, proposer, skeptic, claim, roundNumber) {
+  console.log(`\n========================================`);
+  console.log(`GAME ZERO — ROUND ${roundNumber}`);
+  console.log(`PROPOSER: ${proposer}`);
+  console.log(`CLAIM: ${claim}`);
+  console.log(`SKEPTIC: ${skeptic}`);
+
+  const attack = await ask(`${skeptic}, attack one assumption: `);
+  if (!attack) {
+    return finish(state, {
+      roundNumber, proposer, skeptic, claim, attack,
+      status: 'NO_ATTACK',
+      chaos: null,
+      test: null,
+      replay: null
+    });
+  }
+
+  const prediction = (await ask('Predict the primary test (PASS/FAIL): ')).toUpperCase();
+  if (!['PASS', 'FAIL'].includes(prediction)) {
+    return finish(state, {
+      roundNumber, proposer, skeptic, claim, attack, prediction,
+      status: 'INVALID_PREDICTION',
+      chaos: null,
+      test: null,
+      replay: null
+    });
+  }
+
+  const chaos = drawChaos(rng);
+  console.log(`\nCHAOS CARD: ${chaos.id}`);
+  console.log(chaos.text);
+
+  const test = runTest(rng);
+  console.log(`\nTESTER rolled ${test.roll}: ${test.note}`);
+
+  if (!test.passed) {
+    return finish(state, {
+      roundNumber, proposer, skeptic, claim, attack, prediction,
+      chaos, test, replay: null,
+      status: classifyReceipt({ test, replay: null })
+    });
+  }
+
+  console.log('\nPASS is not VERIFIED. The Factory requires REPLAY!');
+  const replayChoice = (await ask('Run independent REPLAY? (yes/no): ')).toLowerCase();
+  if (!['y', 'yes'].includes(replayChoice)) {
+    return finish(state, {
+      roundNumber, proposer, skeptic, claim, attack, prediction,
+      chaos, test, replay: null,
+      status: classifyReceipt({ test, replay: null })
+    });
+  }
+
+  const replay = runReplay(rng);
+  console.log(`REPLAYER rolled ${replay.roll}: ${replay.note}`);
+
+  if (!replay.matched) {
+    return finish(state, {
+      roundNumber, proposer, skeptic, claim, attack, prediction,
+      chaos, test, replay,
+      status: classifyReceipt({ test, replay })
+    });
+  }
+
+  const evidence = await ask('Name one piece of evidence that should be traceable: ');
+  if (!evidence) {
+    return finish(state, {
+      roundNumber, proposer, skeptic, claim, attack, prediction,
+      chaos, test, replay, evidence,
+      status: 'EVIDENCE_INCOMPLETE'
+    });
+  }
+
+  const receipt = await ask('SCRIBE: give this game receipt a short label: ');
+  if (!receipt) {
+    return finish(state, {
+      roundNumber, proposer, skeptic, claim, attack, prediction,
+      chaos, test, replay, evidence, receipt,
+      status: 'RECEIPT_INCOMPLETE'
+    });
+  }
+
+  return finish(state, {
+    roundNumber, proposer, skeptic, claim, attack, prediction,
+    chaos, test, replay, evidence, receipt,
+    status: classifyReceipt({ test, replay })
+  });
+}
+
+async function gameZeroCheckpoint(state, playerOne, playerTwo) {
+  console.log('\n========================================');
+  console.log('GAME ZERO CHECKPOINT');
+  console.log('Getting VERIFIED is not the win condition. Understanding is.');
+
+  const one = await ask(`${playerOne}: Why does VERIFIED require more than PASS? `);
+  const two = await ask(`${playerTwo}: Why does VERIFIED require more than PASS? `);
+  const shared = (await ask('Do you both agree you can explain the difference? (yes/no): ')).toLowerCase();
+
+  state.checkpointExplanation = {
+    [playerOne]: one,
+    [playerTwo]: two,
+    sharedAgreement: ['y', 'yes'].includes(shared),
+    recordedAt: new Date().toISOString()
+  };
+
+  state.gameZeroUnderstood = Boolean(
+    one && two && state.checkpointExplanation.sharedAgreement
+  );
+  saveState(state);
+
+  console.log(`\nGAME ZERO UNDERSTOOD: ${state.gameZeroUnderstood ? 'YES' : 'NOT YET'}`);
+  console.log(NON_CANONICAL_NOTICE);
+}
+
+async function main() {
+  const state = loadState();
+
+  console.log('\n⚙️  RePlay Wisdom Factory Game');
+  console.log('An agentic game about claims that must survive attack, test, replay, and reflection.');
+  console.log(NON_CANONICAL_NOTICE);
+  console.log(`Seed: ${seed}`);
+
+  const playerOne = (await ask('\nPlayer 1 name [Jay]: ')) || 'Jay';
+  const playerTwo = (await ask('Player 2 name [David]: ')) || 'David';
+
+  const claimOne = await ask(`${playerOne}, enter one claim you believe is true: `);
+  const claimTwo = await ask(`${playerTwo}, enter one claim you believe is true: `);
+
+  await playRound(state, playerOne, playerTwo, claimOne || 'Unspecified claim', 1);
+  await playRound(state, playerTwo, playerOne, claimTwo || 'Unspecified claim', 2);
+  await gameZeroCheckpoint(state, playerOne, playerTwo);
+
+  console.log('\nGame Zero complete.');
+  console.log(`Session state: ${statePath}`);
+}
+
+main()
+  .catch((error) => {
+    console.error('\nFactory error:', error);
+    process.exitCode = 1;
+  })
+  .finally(() => rl.close());

--- a/agentic-game/src/engine.js
+++ b/agentic-game/src/engine.js
@@ -1,0 +1,66 @@
+const CHAOS_DECK = [
+  { id: 'THE_404', text: 'One piece of evidence cannot be resolved.' },
+  { id: 'CONFIDENT_AI', text: 'An agent reports high confidence without evidence.' },
+  { id: 'THE_CLOCK', text: 'A timestamp or elapsed-time field changes the raw output.' },
+  { id: '23_OF_55', text: 'A claimed conformance layer disagrees with its own test matrix.' },
+  { id: 'MOVING_TARGET', text: 'The underlying source changed after the original test.' },
+  { id: 'HUMAN_SAID_SO', text: 'Authority is offered in place of replayable evidence.' },
+  { id: 'BEAUTIFUL_CHART', text: 'The presentation looks convincing but the evidence is weak.' },
+  { id: 'THE_COPY', text: 'Two supposedly independent agents used the same source.' }
+];
+
+export function createRng(seed = Date.now()) {
+  let x = Number(seed) >>> 0;
+  if (!x) x = 0x9e3779b9;
+  return () => {
+    x += 0x6d2b79f5;
+    let t = x;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function drawChaos(rng = Math.random) {
+  return CHAOS_DECK[Math.floor(rng() * CHAOS_DECK.length)];
+}
+
+export function runTest(rng = Math.random) {
+  const roll = 1 + Math.floor(rng() * 6);
+  return {
+    roll,
+    passed: roll >= 3,
+    note: roll >= 3 ? 'Primary test PASS.' : 'Primary test FAIL.'
+  };
+}
+
+export function runReplay(rng = Math.random) {
+  const roll = 1 + Math.floor(rng() * 6);
+  const matched = roll >= 3;
+  return {
+    roll,
+    matched,
+    note: matched
+      ? 'Independent replay matched the primary result.'
+      : 'Independent replay did not match. Replay anomaly recorded.'
+  };
+}
+
+export function wisdomFor(status) {
+  switch (status) {
+    case 'TEST_FAILED': return 2;
+    case 'REPLAY_ANOMALY': return 3;
+    case 'VERIFIED': return 5;
+    default: return 1;
+  }
+}
+
+export function classifyReceipt({ test, replay }) {
+  if (!test.passed) return 'TEST_FAILED';
+  if (!replay) return 'PASS_NOT_REPLAYED';
+  if (!replay.matched) return 'REPLAY_ANOMALY';
+  return 'VERIFIED';
+}
+
+export const NON_CANONICAL_NOTICE =
+  'GAME ONLY — this result creates no authority and does not amend or verify jsonwisdom/AL.';


### PR DESCRIPTION
## What changed

Adds a new public `agentic-game/` surface for **RePlay Wisdom Factory Game**.

- runnable Node CLI for Game Zero
- Proposer / Skeptic / Tester / Replayer / Scribe flow
- `PASS != VERIFIED` enforced in the game loop
- mandatory reflection every round
- Game Zero checkpoint with `gameZeroUnderstood`
- runtime `state/*.json` ignored
- DESIGN.md boundary between canonical analogy, simplified analogy, and non-canonical gamification
- public playtest instructions for David + friends
- Snapchat RePlay described strictly as a feedback/distribution lane, never protocol authority

## Why

The game is a pedagogical agentic simulation that teaches the verification rhythm before users touch protocol engineering. It belongs in `COMPUTERWISDOM` and does **not** modify or verify `jsonwisdom/AL`.

## Tester goal

A successful Game Zero session ends when both players can explain why a passing test alone is insufficient for VERIFIED.

## Validation

This PR is intentionally routed through the repository's protected-branch workflow and required `verify` status check.