### PR TITLE
Scaffold RePlay Global Genesis v0.1

### DIFF
--- a/adapters/courts/README.md
+++ b/adapters/courts/README.md
@@ -1,0 +1,52 @@
+# RePlay Genesis Court Adapter v0.1
+
+Status: MATERIALIZED / NOT_PRODUCTION_READY  
+Authority: false  
+Branch: `replay-global-genesis-v0-1`
+
+## Purpose
+
+Court-source adapter for evidence-bounded retrieval, provenance receipts, deterministic hashing, and EAS dry-run mapping.
+
+## Source routing
+
+```text
+COURT RECORD AUTHORITY -> court-issued filing / order / judgment
+PACER / CM/ECF        -> official court-record distribution and filing surface
+RECAP / CourtListener -> public index / mirror; never promoted to court authority by itself
+UniCourt              -> enrichment only unless independently bound to official source
+```
+
+## Frozen EAS mapping
+
+- Network: Base
+- Chain ID: `8453`
+- Schema UID: `0xc90097ca9f787edcc5fa2ce0920032abe4c4417cc8356198fa12d397c46a453c`
+- Revocable: `false`
+- Resolver: zero address
+
+Schema:
+
+```text
+bytes32 receiptHash,bytes32 lineageHash,bytes32 previousReceiptHash,bytes32 subjectHash,bytes32 sourceRefHash,uint64 createdAt,uint8 evidenceState,uint8 retrievalState
+```
+
+## Current implementation boundary
+
+`replay_court_adapter_v0_1.py` supports public RECAP/CourtListener retrieval, deterministic v0.1 receipt construction, self-hash validation, EAS dry-run mapping, and pending seal-envelope construction.
+
+PACER authentication, persistent token cache, paid retrieval, receipt-store persistence, EAS signing, and transaction broadcast are intentionally NOT implemented in this module.
+
+## Fail-closed rules
+
+- failed retrieval -> `evidence_state=UNRESOLVED`
+- failed retrieval -> `retrieval_state=FAILED`
+- a retrieval-error artifact hash is never labeled as a court-document hash
+- no floats in canonical receipt data
+- no secret-bearing fields
+- no mainnet attestation from a dry-run fixture
+- `authority=false` always
+
+## First fixture
+
+`fixtures/court/RECAP_TEST_RECEIPT_001.json` records a genuine attempted public RECAP/CourtListener fetch for docket `1:26-cv-01417`. The fetch returned HTTP 403 in the execution environment, so the receipt remains `UNRESOLVED / FAILED`. This is intentional negative-control behavior, not a successful court-record retrieval.

--- a/adapters/courts/pacer/README.md
+++ b/adapters/courts/pacer/README.md
@@ -1,19 +1,28 @@
 # PACER Court Adapter
 
-Status: SHELL_ONLY
+Status: PARTIAL_IMPLEMENTATION_V0_1
 Authority: false
 Production ready: false
 
 Purpose: parent namespace for PACER/CM-ECF integration inside RePlay Genesis.
 
-Planned children:
-- auth/ — authentication lifecycle and endpoint-specific session handling
-- cache/ — persistent token/session cache with no secret-derived receipts
-- qa/ — PACER QA validation fixtures and run receipts
+Children:
+- `auth/` — IMPLEMENTED_V0_1 authentication lifecycle and endpoint-specific session handling
+- `cache/` — IMPLEMENTED_V0_1 persistent token/session cache with delegated secret storage
+- `qa/` — SHELL_ONLY PACER QA validation fixtures and run receipts
+
+Current implementation boundary:
+- authentication + persistent cache code exists
+- offline fake-transport/fake-secret-store validation exists
+- real PACER QA authentication has NOT been run
+- real OS-keyring persistence has NOT been independently validated here
+- PACER PCL query adapter is not part of this milestone
+- no successful MATCH / COMPLETE PACER receipt exists yet
 
 Hard boundaries:
 - no credentials in Git
 - no assumed token TTL
 - PACER/CM-ECF is an official record surface, not an authority creator by itself
 - failed retrieval stays UNRESOLVED
-- no EAS transaction is emitted from directory presence
+- negative-control receipt stays off-chain
+- mainnet provenance attestation requires a successful MATCH + COMPLETE receipt and independent hash/JCS replay

--- a/adapters/courts/pacer/README.md
+++ b/adapters/courts/pacer/README.md
@@ -1,0 +1,19 @@
+# PACER Court Adapter
+
+Status: SHELL_ONLY
+Authority: false
+Production ready: false
+
+Purpose: parent namespace for PACER/CM-ECF integration inside RePlay Genesis.
+
+Planned children:
+- auth/ — authentication lifecycle and endpoint-specific session handling
+- cache/ — persistent token/session cache with no secret-derived receipts
+- qa/ — PACER QA validation fixtures and run receipts
+
+Hard boundaries:
+- no credentials in Git
+- no assumed token TTL
+- PACER/CM-ECF is an official record surface, not an authority creator by itself
+- failed retrieval stays UNRESOLVED
+- no EAS transaction is emitted from directory presence

--- a/adapters/courts/pacer/auth/README.md
+++ b/adapters/courts/pacer/auth/README.md
@@ -1,0 +1,16 @@
+# PACER Auth
+
+Status: SHELL_ONLY
+Authority: false
+Implementation: NOT_YET
+
+Reserved for corrected PACER authentication semantics:
+- user-managed 180-day password policy
+- 179-day reminder/alert target only
+- server-controlled token lifetime
+- persistent token reuse while valid
+- endpoint-specific cookies/headers
+- MFA TOTP support
+- redactFlag only when filer-capable
+
+No credentials, tokens, OTP secrets, or secret-derived hashes belong here.

--- a/adapters/courts/pacer/auth/README.md
+++ b/adapters/courts/pacer/auth/README.md
@@ -1,16 +1,32 @@
 # PACER Auth
 
-Status: SHELL_ONLY
+Status: IMPLEMENTED_V0_1
 Authority: false
-Implementation: NOT_YET
+PACER QA validated: false
+Production ready: false
 
-Reserved for corrected PACER authentication semantics:
-- user-managed 180-day password policy
-- 179-day reminder/alert target only
-- server-controlled token lifetime
-- persistent token reuse while valid
-- endpoint-specific cookies/headers
-- MFA TOTP support
-- redactFlag only when filer-capable
+Implementation: `pacer_auth.py`
 
-No credentials, tokens, OTP secrets, or secret-derived hashes belong here.
+Implemented semantics:
+- official QA auth endpoint: `https://qa-login.uscourts.gov/services/cso-auth`
+- official production auth endpoint: `https://pacer.login.uscourts.gov/services/cso-auth`
+- user-managed 180-day password policy with day-179 reminder helper only
+- server-controlled token lifetime; no local TTL is invented
+- persistent token reuse by default; no re-authentication per search
+- runtime MFA `otpCode` support; no OTP secret is stored here
+- `redactFlag=1` only when the caller explicitly marks the account/use as filer-capable
+- optional client code is runtime-only and is not serialized by the cache
+- court-system cookie builder uses `nextGenCSO` and optional `PacerClientCode`
+- no generic bearer-token assumption; PCL-specific header behavior belongs in the PCL adapter
+- explicit logout via `/services/cso-logout`
+- local invalidation hook for downstream authentication failures
+- explicit replacement hook for PACER token re-issuance
+
+Secrets boundary:
+- no credentials, tokens, OTP secrets, client codes, or secret-derived hashes in Git
+- runtime credentials are accepted only as in-memory inputs
+- token persistence is delegated to the cache SecretStore
+
+Validation:
+- offline fake-transport validator exists at `scripts/validation/court/validate_pacer_auth_cache_v0_1.py`
+- real PACER QA login has NOT been run

--- a/adapters/courts/pacer/auth/pacer_auth.py
+++ b/adapters/courts/pacer/auth/pacer_auth.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""PACER Authentication API client with persistent token reuse.
+
+No credentials, tokens, OTP secrets, or client codes are logged or serialized
+by this module. Tokens are delegated to PacerTokenCache's SecretStore.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any, Dict, Optional, Protocol
+
+import requests
+
+from adapters.courts.pacer.cache.pacer_token_cache import PacerTokenCache
+
+AUTH_ENDPOINTS = {
+    "qa": "https://qa-login.uscourts.gov/services/cso-auth",
+    "production": "https://pacer.login.uscourts.gov/services/cso-auth",
+}
+LOGOUT_ENDPOINTS = {
+    "qa": "https://qa-login.uscourts.gov/services/cso-logout",
+    "production": "https://pacer.login.uscourts.gov/services/cso-logout",
+}
+PASSWORD_REMINDER_DAY = 179
+PASSWORD_REQUIRED_DAY = 180
+
+
+class PacerAuthError(RuntimeError):
+    pass
+
+
+class PacerTransport(Protocol):
+    def post(self, url: str, **kwargs: Any): ...
+
+
+@dataclass(frozen=True)
+class PacerCredentials:
+    login_id: str
+    password: str
+    otp_code: Optional[str] = None
+    client_code: Optional[str] = None
+    filer: bool = False
+
+    def request_body(self) -> Dict[str, str]:
+        if not self.login_id or not self.password:
+            raise ValueError("PACER login_id and password are required")
+        body = {"loginId": self.login_id, "password": self.password}
+        if self.client_code:
+            body["clientCode"] = self.client_code
+        if self.otp_code:
+            body["otpCode"] = self.otp_code
+        if self.filer:
+            body["redactFlag"] = "1"
+        return body
+
+
+@dataclass(frozen=True)
+class AuthResult:
+    token: str
+    source: str
+    server_validity: str
+    error_description: str = ""
+
+
+@dataclass(frozen=True)
+class PasswordRotationStatus:
+    age_days: int
+    reminder_due: bool
+    update_required: bool
+
+
+def password_rotation_status(
+    last_changed: date, *, today: Optional[date] = None
+) -> PasswordRotationStatus:
+    """180-day password policy; day 179 is a local reminder only."""
+    current = today or datetime.now(timezone.utc).date()
+    age = (current - last_changed).days
+    if age < 0:
+        raise ValueError("last_changed cannot be in the future")
+    return PasswordRotationStatus(
+        age_days=age,
+        reminder_due=age >= PASSWORD_REMINDER_DAY,
+        update_required=age >= PASSWORD_REQUIRED_DAY,
+    )
+
+
+class PacerAuthClient:
+    def __init__(
+        self,
+        environment: str,
+        cache: PacerTokenCache,
+        *,
+        transport: Optional[PacerTransport] = None,
+        timeout_seconds: int = 30,
+    ) -> None:
+        if environment not in AUTH_ENDPOINTS:
+            raise ValueError("environment must be 'qa' or 'production'")
+        if cache.environment != environment:
+            raise ValueError("cache environment must match auth environment")
+        self.environment = environment
+        self.cache = cache
+        self.transport = transport or requests.Session()
+        self.timeout_seconds = timeout_seconds
+
+    def cached_token(self) -> Optional[AuthResult]:
+        cached = self.cache.get()
+        if cached is None:
+            return None
+        return AuthResult(
+            token=cached.token,
+            source="CACHE",
+            server_validity="UNKNOWN",
+        )
+
+    def get_or_authenticate(
+        self,
+        credentials: Optional[PacerCredentials] = None,
+        *,
+        force_reauthenticate: bool = False,
+    ) -> AuthResult:
+        """Reuse the persisted token by default; do not re-auth per search."""
+        if not force_reauthenticate:
+            cached = self.cached_token()
+            if cached is not None:
+                return cached
+        if credentials is None:
+            raise PacerAuthError(
+                "no cached token available; runtime credentials are required"
+            )
+        return self.authenticate(credentials)
+
+    def authenticate(self, credentials: PacerCredentials) -> AuthResult:
+        response = self.transport.post(
+            AUTH_ENDPOINTS[self.environment],
+            json=credentials.request_body(),
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            timeout=self.timeout_seconds,
+        )
+        if getattr(response, "status_code", None) != 200:
+            raise PacerAuthError(
+                f"PACER authentication HTTP status {getattr(response, 'status_code', 'UNKNOWN')}"
+            )
+        try:
+            data = response.json()
+        except Exception as exc:
+            raise PacerAuthError("PACER authentication returned non-JSON") from exc
+
+        login_result = str(data.get("loginResult", ""))
+        token = data.get("nextGenCSO")
+        error_description = str(data.get("errorDescription") or "")
+        if login_result != "0" or not isinstance(token, str) or not token:
+            raise PacerAuthError(
+                "PACER authentication failed"
+                + (f": {error_description}" if error_description else "")
+            )
+
+        self.cache.put(token, client_code_present=bool(credentials.client_code))
+        return AuthResult(
+            token=token,
+            source="AUTHENTICATION",
+            server_validity="ISSUED_BY_PACER",
+            error_description=error_description,
+        )
+
+    def observe_reissued_token(
+        self, token: str, *, client_code_present: bool = False
+    ) -> None:
+        """Persist a replacement token observed from a PACER response."""
+        self.cache.observe_reissued_token(
+            token, client_code_present=client_code_present
+        )
+
+    def invalidate_on_auth_failure(self) -> None:
+        """Local invalidation after a downstream endpoint rejects the token."""
+        self.cache.invalidate()
+
+    def logout(self) -> bool:
+        cached = self.cache.get()
+        if cached is None:
+            return False
+        response = self.transport.post(
+            LOGOUT_ENDPOINTS[self.environment],
+            json={"nextGenCSO": cached.token},
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            timeout=self.timeout_seconds,
+        )
+        if getattr(response, "status_code", None) != 200:
+            raise PacerAuthError(
+                f"PACER logout HTTP status {getattr(response, 'status_code', 'UNKNOWN')}"
+            )
+        try:
+            data = response.json()
+        except Exception as exc:
+            raise PacerAuthError("PACER logout returned non-JSON") from exc
+        if str(data.get("loginResult", "")) != "0":
+            error_description = str(data.get("errorDescription") or "")
+            raise PacerAuthError(
+                "PACER logout failed"
+                + (f": {error_description}" if error_description else "")
+            )
+        self.cache.invalidate()
+        return True
+
+    @staticmethod
+    def court_cookies(
+        token: str, *, client_code: Optional[str] = None
+    ) -> Dict[str, str]:
+        """Cookie semantics for court systems; not for the PCL API."""
+        if not token:
+            raise ValueError("token must be non-empty")
+        cookies = {"nextGenCSO": token}
+        if client_code:
+            cookies["PacerClientCode"] = client_code
+        return cookies

--- a/adapters/courts/pacer/cache/README.md
+++ b/adapters/courts/pacer/cache/README.md
@@ -1,15 +1,37 @@
 # PACER Token Cache
 
-Status: SHELL_ONLY
+Status: IMPLEMENTED_V0_1
 Authority: false
-Implementation: NOT_YET
+PACER QA validated: false
+Production ready: false
 
-Reserved for persistent PACER session/token state across process and cron restarts.
+Implementation: `pacer_token_cache.py`
 
-Required properties:
-- encrypted-at-rest or delegated secret-store backing
-- no token value in receipts or logs
-- atomic replacement on reissue/invalidation
-- explicit environment partitioning (qa vs production)
-- fail closed on unreadable/corrupt cache
-- cache existence does not imply token validity
+Storage model:
+- metadata is persisted on disk and partitioned by `qa` vs `production`
+- the actual `nextGenCSO` token is delegated to a SecretStore
+- normal persistent backend: operating-system keyring via optional Python `keyring` package
+- metadata contains only account label, opaque secret reference, timestamps, state, and booleans
+- metadata always records server-side validity as `UNKNOWN`
+
+Implemented guarantees:
+- no PACER token, password, OTP secret, client code, or secret-derived hash in metadata
+- token reuse across process/cron restarts when the delegated secret store persists
+- atomic metadata replacement using temporary file + `os.replace`
+- explicit environment partitioning
+- token replacement when PACER re-issues a token
+- logout/auth-failure invalidation removes the delegated token
+- ACTIVE metadata with a missing delegated secret fails closed
+- unreadable, malformed, mismatched, or unsupported metadata fails closed
+- cache existence never claims PACER server validity
+
+Crash boundary:
+- secret replacement occurs before metadata replacement
+- invalidation deletes the secret before writing INVALIDATED metadata
+- if a crash leaves ACTIVE metadata without a secret, the next read hard-fails instead of treating the cache as valid
+
+Do not point `cache_root` into the repository. Runtime cache state belongs in an external application-state directory.
+
+Validation:
+- offline fake-secret-store validator exists at `scripts/validation/court/validate_pacer_auth_cache_v0_1.py`
+- real OS-keyring persistence and PACER QA login remain unvalidated in this milestone

--- a/adapters/courts/pacer/cache/README.md
+++ b/adapters/courts/pacer/cache/README.md
@@ -1,0 +1,15 @@
+# PACER Token Cache
+
+Status: SHELL_ONLY
+Authority: false
+Implementation: NOT_YET
+
+Reserved for persistent PACER session/token state across process and cron restarts.
+
+Required properties:
+- encrypted-at-rest or delegated secret-store backing
+- no token value in receipts or logs
+- atomic replacement on reissue/invalidation
+- explicit environment partitioning (qa vs production)
+- fail closed on unreadable/corrupt cache
+- cache existence does not imply token validity

--- a/adapters/courts/pacer/cache/pacer_token_cache.py
+++ b/adapters/courts/pacer/cache/pacer_token_cache.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Persistent PACER token cache with delegated secret storage.
+
+The metadata cache is content-light and contains no PACER token, password,
+OTP secret, client code, or secret-derived hash. The token itself is stored
+through a SecretStore implementation (KeyringSecretStore in normal use).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Protocol
+
+CACHE_VERSION = "0.1"
+VALID_ENVIRONMENTS = {"qa", "production"}
+_SAFE_LABEL = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
+class CacheError(RuntimeError):
+    pass
+
+
+class CacheCorruptionError(CacheError):
+    pass
+
+
+class SecretStoreUnavailable(CacheError):
+    pass
+
+
+class SecretStore(Protocol):
+    def get(self, ref: str) -> Optional[str]: ...
+    def put(self, ref: str, value: str) -> None: ...
+    def delete(self, ref: str) -> None: ...
+
+
+class KeyringSecretStore:
+    """Delegate token persistence to the operating-system keyring."""
+
+    def __init__(self, service_name: str = "replay-genesis-pacer") -> None:
+        self.service_name = service_name
+
+    @staticmethod
+    def _keyring():
+        try:
+            import keyring  # type: ignore
+        except ImportError as exc:
+            raise SecretStoreUnavailable(
+                "python package 'keyring' is required for persistent PACER secrets"
+            ) from exc
+        return keyring
+
+    def get(self, ref: str) -> Optional[str]:
+        return self._keyring().get_password(self.service_name, ref)
+
+    def put(self, ref: str, value: str) -> None:
+        if not value:
+            raise ValueError("secret value must be non-empty")
+        self._keyring().set_password(self.service_name, ref, value)
+
+    def delete(self, ref: str) -> None:
+        keyring = self._keyring()
+        try:
+            keyring.delete_password(self.service_name, ref)
+        except Exception as exc:
+            # Backends differ in their exact not-found exception type.
+            # A missing secret is already equivalent to deleted here.
+            if "not found" not in str(exc).lower():
+                raise
+
+
+@dataclass(frozen=True)
+class TokenMetadata:
+    cache_version: str
+    environment: str
+    account_label: str
+    secret_ref: str
+    state: str
+    issued_at: str
+    updated_at: str
+    client_code_present: bool
+    server_validity: str = "UNKNOWN"
+
+
+@dataclass(frozen=True)
+class CachedToken:
+    token: str
+    metadata: TokenMetadata
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _validate_environment(environment: str) -> str:
+    if environment not in VALID_ENVIRONMENTS:
+        raise ValueError("environment must be 'qa' or 'production'")
+    return environment
+
+
+def _validate_label(account_label: str) -> str:
+    if not _SAFE_LABEL.fullmatch(account_label):
+        raise ValueError(
+            "account_label must contain only letters, digits, dot, underscore, or hyphen"
+        )
+    return account_label
+
+
+class PacerTokenCache:
+    """Metadata-on-disk + token-in-secret-store persistent cache.
+
+    A cache hit means only that a token was previously issued and has not been
+    locally invalidated. PACER remains the authority on server-side validity.
+    """
+
+    def __init__(
+        self,
+        cache_root: Path,
+        environment: str,
+        account_label: str,
+        secret_store: SecretStore,
+    ) -> None:
+        self.environment = _validate_environment(environment)
+        self.account_label = _validate_label(account_label)
+        self.cache_root = Path(cache_root)
+        self.secret_store = secret_store
+        self.meta_dir = self.cache_root / self.environment
+        self.meta_path = self.meta_dir / f"{self.account_label}.json"
+        self.secret_ref = f"pacer:{self.environment}:{self.account_label}:nextGenCSO"
+
+    def _read_metadata(self) -> Optional[TokenMetadata]:
+        if not self.meta_path.exists():
+            return None
+        try:
+            raw = json.loads(self.meta_path.read_text(encoding="utf-8"))
+            meta = TokenMetadata(**raw)
+        except Exception as exc:
+            raise CacheCorruptionError(
+                f"unreadable or invalid PACER cache metadata: {self.meta_path}"
+            ) from exc
+        if meta.cache_version != CACHE_VERSION:
+            raise CacheCorruptionError("unsupported PACER cache version")
+        if meta.environment != self.environment:
+            raise CacheCorruptionError("PACER cache environment mismatch")
+        if meta.account_label != self.account_label:
+            raise CacheCorruptionError("PACER cache account-label mismatch")
+        if meta.secret_ref != self.secret_ref:
+            raise CacheCorruptionError("PACER cache secret reference mismatch")
+        if meta.state not in {"ACTIVE", "INVALIDATED"}:
+            raise CacheCorruptionError("PACER cache state invalid")
+        if meta.server_validity != "UNKNOWN":
+            raise CacheCorruptionError("cache must not claim server-side token validity")
+        return meta
+
+    def _write_metadata(self, meta: TokenMetadata) -> None:
+        self.meta_dir.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(
+            asdict(meta), sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        ) + "\n"
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self.account_label}.",
+            suffix=".tmp",
+            dir=self.meta_dir,
+            text=True,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(tmp_name, 0o600)
+            os.replace(tmp_name, self.meta_path)
+        finally:
+            try:
+                os.unlink(tmp_name)
+            except FileNotFoundError:
+                pass
+
+    def get(self) -> Optional[CachedToken]:
+        meta = self._read_metadata()
+        if meta is None or meta.state != "ACTIVE":
+            return None
+        token = self.secret_store.get(meta.secret_ref)
+        if not token:
+            raise CacheCorruptionError(
+                "PACER metadata says ACTIVE but delegated secret is missing"
+            )
+        return CachedToken(token=token, metadata=meta)
+
+    def put(self, token: str, *, client_code_present: bool) -> TokenMetadata:
+        if not token:
+            raise ValueError("token must be non-empty")
+        current = self._read_metadata()
+        now = _utc_now()
+        issued_at = (
+            current.issued_at
+            if current is not None
+            and current.state == "ACTIVE"
+            and self.secret_store.get(self.secret_ref) == token
+            else now
+        )
+        self.secret_store.put(self.secret_ref, token)
+        meta = TokenMetadata(
+            cache_version=CACHE_VERSION,
+            environment=self.environment,
+            account_label=self.account_label,
+            secret_ref=self.secret_ref,
+            state="ACTIVE",
+            issued_at=issued_at,
+            updated_at=now,
+            client_code_present=bool(client_code_present),
+            server_validity="UNKNOWN",
+        )
+        self._write_metadata(meta)
+        return meta
+
+    def observe_reissued_token(
+        self, token: str, *, client_code_present: bool
+    ) -> TokenMetadata:
+        """Replace the delegated token when PACER re-issues it."""
+        return self.put(token, client_code_present=client_code_present)
+
+    def invalidate(self) -> TokenMetadata:
+        current = self._read_metadata()
+        now = _utc_now()
+        issued_at = current.issued_at if current is not None else now
+        try:
+            self.secret_store.delete(self.secret_ref)
+        finally:
+            meta = TokenMetadata(
+                cache_version=CACHE_VERSION,
+                environment=self.environment,
+                account_label=self.account_label,
+                secret_ref=self.secret_ref,
+                state="INVALIDATED",
+                issued_at=issued_at,
+                updated_at=now,
+                client_code_present=(
+                    current.client_code_present if current is not None else False
+                ),
+                server_validity="UNKNOWN",
+            )
+            self._write_metadata(meta)
+        return meta
+
+    def metadata(self) -> Optional[TokenMetadata]:
+        return self._read_metadata()

--- a/adapters/courts/pacer/qa/README.md
+++ b/adapters/courts/pacer/qa/README.md
@@ -1,0 +1,16 @@
+# PACER QA
+
+Status: SHELL_ONLY
+Authority: false
+Validation: NOT_RUN
+
+Reserved for PACER QA-only integration checks before any production credential use.
+
+Planned checks:
+- authentication success/failure semantics
+- token reuse and reissue behavior
+- endpoint-specific transport
+- filer redactFlag behavior when applicable
+- cost metadata capture
+- failed retrieval -> UNRESOLVED
+- successful retrieval -> receipt candidate, never automatic MATCH without validation

--- a/adapters/courts/replay_court_adapter_v0_1.py
+++ b/adapters/courts/replay_court_adapter_v0_1.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""RePlay Genesis court adapter v0.1.
+
+Scope:
+- Public RECAP/CourtListener fetches.
+- Deterministic court provenance receipts.
+- RFC 8785-compatible canonicalization for the v0.1 no-float profile.
+- EAS mapping dry-run only.
+
+Non-goals:
+- No PACER credential handling in this module.
+- No EAS transaction signing or broadcasting.
+- No legal/factual authority creation.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import requests
+
+ADAPTER_VERSION = "0.1"
+CHAIN_ID = 8453
+NETWORK = "base"
+EAS_SCHEMA_UID = "0xc90097ca9f787edcc5fa2ce0920032abe4c4417cc8356198fa12d397c46a453c"
+EAS_SCHEMA_STRING = (
+    "bytes32 receiptHash,bytes32 lineageHash,bytes32 previousReceiptHash,"
+    "bytes32 subjectHash,bytes32 sourceRefHash,uint64 createdAt,"
+    "uint8 evidenceState,uint8 retrievalState"
+)
+
+EVIDENCE_STATE = {
+    "UNRESOLVED": 0,
+    "PARTIAL": 1,
+    "MATCH": 2,
+    "NOT_APPLICABLE": 3,
+}
+RETRIEVAL_STATE = {
+    "COMPLETE": 0,
+    "FAILED": 1,
+    "AUTH_BLOCKED": 2,
+    "BUDGET_EXHAUSTED": 3,
+    "NOT_ATTEMPTED": 4,
+}
+ZERO_HASH = "0x" + ("0" * 64)
+ZERO_SHA256 = "sha256:" + ("0" * 64)
+MAX_SAFE_INTEGER = (1 << 53) - 1
+
+
+class CanonicalizationError(ValueError):
+    pass
+
+
+def _validate_jcs_profile(value: Any) -> None:
+    """Fail closed on values outside the v0.1 JCS profile.
+
+    v0.1 intentionally prohibits floating-point numbers. Integers must fit
+    I-JSON's exact IEEE-754 integer range. Lone UTF-16 surrogates are rejected.
+    """
+    if isinstance(value, bool) or value is None:
+        return
+    if isinstance(value, float):
+        raise CanonicalizationError("floating-point values are prohibited")
+    if isinstance(value, int):
+        if abs(value) > MAX_SAFE_INTEGER:
+            raise CanonicalizationError("integer outside exact I-JSON range")
+        return
+    if isinstance(value, str):
+        if any(0xD800 <= ord(ch) <= 0xDFFF for ch in value):
+            raise CanonicalizationError("lone surrogate code point prohibited")
+        return
+    if isinstance(value, list):
+        for item in value:
+            _validate_jcs_profile(item)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise CanonicalizationError("object keys must be strings")
+            _validate_jcs_profile(key)
+            _validate_jcs_profile(item)
+        return
+    raise CanonicalizationError(f"unsupported JSON value: {type(value).__name__}")
+
+
+def _utf16_sort_key(value: str) -> bytes:
+    return value.encode("utf-16-be")
+
+
+def _jcs_render(value: Any) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if isinstance(value, list):
+        return "[" + ",".join(_jcs_render(item) for item in value) + "]"
+    if isinstance(value, dict):
+        parts = []
+        for key in sorted(value.keys(), key=_utf16_sort_key):
+            parts.append(
+                json.dumps(key, ensure_ascii=False, separators=(",", ":"))
+                + ":"
+                + _jcs_render(value[key])
+            )
+        return "{" + ",".join(parts) + "}"
+    raise CanonicalizationError(f"unsupported JSON value: {type(value).__name__}")
+
+
+def jcs_canonical_bytes(value: Any) -> bytes:
+    _validate_jcs_profile(value)
+    return _jcs_render(value).encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def jcs_sha256(value: Any) -> str:
+    return sha256_hex(jcs_canonical_bytes(value))
+
+
+def _parse_utc_seconds(value: str) -> int:
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.utcoffset() is None:
+        raise ValueError("created_at must be timezone-aware")
+    return int(dt.timestamp())
+
+
+@dataclass(frozen=True)
+class FetchObservation:
+    url: str
+    body: bytes
+    status_code: int
+    content_type: str
+    retrieved_at: str
+    cost_billed_microusd: int = 0
+    pacer_pages: Optional[int] = None
+
+
+class RecapTransport:
+    """Public RECAP/CourtListener transport. No authentication."""
+
+    def __init__(self, timeout: int = 30):
+        self.timeout = timeout
+
+    def fetch(self, url: str) -> FetchObservation:
+        now = datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+        try:
+            response = requests.get(
+                url,
+                timeout=self.timeout,
+                headers={"User-Agent": "RePlay-Genesis-Court-Adapter/0.1"},
+            )
+            body = response.content
+            content_type = response.headers.get("Content-Type", "application/octet-stream")
+            return FetchObservation(
+                url=url,
+                body=body,
+                status_code=response.status_code,
+                content_type=content_type,
+                retrieved_at=now,
+            )
+        except requests.RequestException as exc:
+            body = f"{type(exc).__name__}: {exc}\n".encode("utf-8")
+            return FetchObservation(
+                url=url,
+                body=body,
+                status_code=0,
+                content_type="text/plain",
+                retrieved_at=now,
+            )
+
+
+def build_receipt_core(
+    observation: FetchObservation,
+    *,
+    receipt_id: str,
+    lineage_id: str,
+    cell: str,
+    jurisdiction: str,
+    case_ref: str,
+    official_ref: str,
+    prev_receipt_hash: str = ZERO_SHA256,
+    docket_entry: Optional[int] = None,
+    genesis_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    complete = 200 <= observation.status_code < 300
+    retrieval_state = "COMPLETE" if complete else "FAILED"
+    evidence_state = "UNRESOLVED"
+
+    content_scope = "RETRIEVED_SOURCE_BYTES" if complete else "RETRIEVAL_ARTIFACT_NOT_COURT_DOCUMENT"
+
+    core: Dict[str, Any] = {
+        "receipt_version": "0.1",
+        "receipt_id": receipt_id,
+        "schema": "replay.court.provenance.v0.1",
+        "created_at": observation.retrieved_at,
+        "created_by": "replay.court.adapter.recap",
+        "lineage_id": lineage_id,
+        "subject": {
+            "cell": cell,
+            "jurisdiction": jurisdiction,
+            "genesis_key": genesis_key,
+            "case_ref": case_ref,
+            "docket_entry": docket_entry,
+        },
+        "evidence_state": evidence_state,
+        "retrieval_state": retrieval_state,
+        "authority_chain": {
+            "primary": "PACER_CMECF",
+            "index_used": "RECAP_COURTLISTENER",
+            "enrichment_used": None,
+            "secondary_summary": False,
+        },
+        "provenance": {
+            "official_ref": official_ref,
+            "source_url": observation.url,
+            "content_hash": "sha256:" + sha256_hex(observation.body),
+            "content_hash_scope": content_scope,
+            "content_length": len(observation.body),
+            "mime_type": observation.content_type,
+            "retrieval_timestamp": observation.retrieved_at,
+            "cost_billed_microusd": observation.cost_billed_microusd,
+            "currency": "USD",
+            "pacer_pages": observation.pacer_pages,
+        },
+        "auth_context": {
+            "credential_event_receipt": None,
+            "account_type": "public_recap",
+            "mfa_used": False,
+            "environment": "public",
+        },
+        "integrity": {
+            "prev_receipt_hash": prev_receipt_hash,
+            "self_hash": None,
+        },
+        "authority": False,
+    }
+
+    if not complete:
+        core["failure"] = {
+            "http_status": observation.status_code,
+            "category": "SOURCE_FETCH_FAILED" if observation.status_code == 0 else "SOURCE_FETCH_NON_SUCCESS",
+            "retryable": observation.status_code in {0, 408, 425, 429, 500, 502, 503, 504},
+        }
+
+    hash_payload = copy.deepcopy(core)
+    del hash_payload["integrity"]["self_hash"]
+    core["integrity"]["self_hash"] = "sha256:" + jcs_sha256(hash_payload)
+    return core
+
+
+def validate_receipt_core(core: Dict[str, Any]) -> None:
+    if core.get("authority") is not False:
+        raise ValueError("authority must be false")
+    if core.get("evidence_state") not in EVIDENCE_STATE:
+        raise ValueError("unknown evidence_state")
+    if core.get("retrieval_state") not in RETRIEVAL_STATE:
+        raise ValueError("unknown retrieval_state")
+
+    integrity = core.get("integrity") or {}
+    self_hash = integrity.get("self_hash")
+    if not isinstance(self_hash, str) or not self_hash.startswith("sha256:"):
+        raise ValueError("self_hash missing or malformed")
+
+    payload = copy.deepcopy(core)
+    del payload["integrity"]["self_hash"]
+    expected = "sha256:" + jcs_sha256(payload)
+    if self_hash != expected:
+        raise ValueError("self_hash mismatch")
+
+    forbidden_fragments = ("password", "secret", "token", "otp")
+    for key in _walk_keys(core):
+        low = key.lower()
+        if any(fragment in low for fragment in forbidden_fragments):
+            if key != "credential_event_receipt":
+                raise ValueError(f"secret-like field name prohibited: {key}")
+
+
+def _walk_keys(value: Any):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            yield key
+            yield from _walk_keys(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_keys(item)
+
+
+def build_eas_dry_run(core: Dict[str, Any]) -> Dict[str, Any]:
+    validate_receipt_core(core)
+
+    receipt_hash = core["integrity"]["self_hash"].removeprefix("sha256:")
+    prev_hash = core["integrity"]["prev_receipt_hash"].removeprefix("sha256:")
+
+    mapping = {
+        "receiptHash": "0x" + receipt_hash,
+        "lineageHash": "0x" + jcs_sha256({"lineage_id": core["lineage_id"]}),
+        "previousReceiptHash": "0x" + prev_hash,
+        "subjectHash": "0x" + jcs_sha256(core["subject"]),
+        "sourceRefHash": "0x" + jcs_sha256(
+            {
+                "authority_chain": core["authority_chain"],
+                "official_ref": core["provenance"]["official_ref"],
+            }
+        ),
+        "createdAt": _parse_utc_seconds(core["created_at"]),
+        "evidenceState": EVIDENCE_STATE[core["evidence_state"]],
+        "retrievalState": RETRIEVAL_STATE[core["retrieval_state"]],
+    }
+
+    for name in (
+        "receiptHash",
+        "lineageHash",
+        "previousReceiptHash",
+        "subjectHash",
+        "sourceRefHash",
+    ):
+        if not isinstance(mapping[name], str) or not mapping[name].startswith("0x") or len(mapping[name]) != 66:
+            raise ValueError(f"{name} must be bytes32")
+
+    return {
+        "dry_run_version": "0.1",
+        "network": NETWORK,
+        "chain_id": CHAIN_ID,
+        "schema_uid": EAS_SCHEMA_UID,
+        "schema_string": EAS_SCHEMA_STRING,
+        "mapping": mapping,
+        "validation": {
+            "jcs_profile_valid": True,
+            "self_hash_valid": True,
+            "lineage_valid": True,
+            "state_enum_valid": True,
+            "secret_fields_present": False,
+            "pii_onchain": False,
+            "authority": False,
+        },
+        "transaction_submitted": False,
+        "attestation_uid": None,
+        "status": "DRY_RUN_VALIDATED",
+    }
+
+
+def build_pending_seal_envelope(core: Dict[str, Any], dry_run: Dict[str, Any]) -> Dict[str, Any]:
+    if dry_run.get("status") != "DRY_RUN_VALIDATED":
+        raise ValueError("dry run must validate before creating pending envelope")
+    return {
+        "seal_version": "0.1",
+        "receipt_hash": core["integrity"]["self_hash"],
+        "method": "EAS",
+        "network": NETWORK,
+        "chain_id": CHAIN_ID,
+        "schema_uid": EAS_SCHEMA_UID,
+        "attestation_uid": None,
+        "attester": None,
+        "transaction_hash": None,
+        "block_number": None,
+        "sealed_at": None,
+        "status": "PENDING",
+        "dry_run_validated": True,
+        "authority": False,
+    }

--- a/adapters/jurisdictions/README.md
+++ b/adapters/jurisdictions/README.md
@@ -1,0 +1,23 @@
+# Jurisdiction Adapters
+
+Status: `SHELL_ONLY`
+Authority: `false`
+
+Adapters translate authoritative public jurisdiction sources into normalized RePlay observations. They do not create jurisdiction, legal authority, or political conclusions.
+
+Required adapter contract:
+- source identity
+- retrieval method
+- observed timestamp
+- source hash when captured
+- parser/version identifier
+- normalized output
+- unresolved/error state
+
+Planned starter packs:
+- `_template/`
+- `us/`
+- `fr/`
+- `ke/`
+
+No jurisdiction adapter is production-ready merely because its directory exists.

--- a/adapters/jurisdictions/_template/README.md
+++ b/adapters/jurisdictions/_template/README.md
@@ -1,0 +1,18 @@
+# Jurisdiction Adapter Template
+
+Status: `SHELL_ONLY`
+Authority: `false`
+
+Copy this directory only after authoritative source endpoints for the target jurisdiction are identified.
+
+Expected fields:
+- adapter_id
+- jurisdiction_scope
+- authoritative_sources[]
+- retrieval_mode
+- parser_version
+- output_schema
+- source_hash_policy
+- fail_closed_behavior
+
+Default behavior: `UNRESOLVED` on missing, ambiguous, stale, or unauthenticated source material.

--- a/adapters/jurisdictions/fr/README.md
+++ b/adapters/jurisdictions/fr/README.md
@@ -1,0 +1,9 @@
+# France Jurisdiction Adapter Pack
+
+Status: `SHELL_ONLY`
+Authority: `false`
+Sources bound: `0`
+
+Planned source classes: official national, regional, departmental, commune, legal-publication, and public-data sources.
+
+Nothing in this shell establishes a jurisdiction, officeholder, boundary, vote, or legal status. All bindings require authoritative-source receipts.

--- a/adapters/jurisdictions/ke/README.md
+++ b/adapters/jurisdictions/ke/README.md
@@ -1,0 +1,9 @@
+# Kenya Jurisdiction Adapter Pack
+
+Status: `SHELL_ONLY`
+Authority: `false`
+Sources bound: `0`
+
+Planned source classes: official national, county, city/municipal, legislative, gazette, and public-data sources.
+
+Nothing in this shell establishes a jurisdiction, officeholder, boundary, vote, or legal status. All bindings require authoritative-source receipts.

--- a/adapters/jurisdictions/us/README.md
+++ b/adapters/jurisdictions/us/README.md
@@ -1,0 +1,9 @@
+# US Jurisdiction Adapter Pack
+
+Status: `SHELL_ONLY`
+Authority: `false`
+Sources bound: `0`
+
+Planned source classes: federal legislative/public records, Census/geographic identifiers, official state registries, county records, municipal charters and public-data surfaces.
+
+Nothing in this shell establishes a jurisdiction, officeholder, boundary, vote, or legal status. All bindings require authoritative-source receipts.

--- a/fixtures/court/EAS_DRY_RUN_001.json
+++ b/fixtures/court/EAS_DRY_RUN_001.json
@@ -1,0 +1,29 @@
+{
+  "dry_run_version": "0.1",
+  "network": "base",
+  "chain_id": 8453,
+  "schema_uid": "0xc90097ca9f787edcc5fa2ce0920032abe4c4417cc8356198fa12d397c46a453c",
+  "schema_string": "bytes32 receiptHash,bytes32 lineageHash,bytes32 previousReceiptHash,bytes32 subjectHash,bytes32 sourceRefHash,uint64 createdAt,uint8 evidenceState,uint8 retrievalState",
+  "mapping": {
+    "receiptHash": "0xc117f476b50d4c6cbd362cd57799c80387b68a9d972b25e0a597daf5b937e730",
+    "lineageHash": "0x1fc9d89e6f9c004338189eaa0a93047fb10c54d4b8ec76cb89a2fe4ba61e5744",
+    "previousReceiptHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "subjectHash": "0x40bf5cc8faa9668b288f59da1fe8a0c787abe2c6ad6d77620c95129d303fc7bc",
+    "sourceRefHash": "0x8fcfde270b3f0254bf9dfaa8375c8ad06a24ce2cf346d7ed1da64a1abed6c430",
+    "createdAt": 1786146235,
+    "evidenceState": 0,
+    "retrievalState": 1
+  },
+  "validation": {
+    "jcs_profile_valid": true,
+    "self_hash_valid": true,
+    "lineage_valid": true,
+    "state_enum_valid": true,
+    "secret_fields_present": false,
+    "pii_onchain": false,
+    "authority": false
+  },
+  "transaction_submitted": false,
+  "attestation_uid": null,
+  "status": "DRY_RUN_VALIDATED"
+}

--- a/fixtures/court/RECAP_RETRIEVAL_ARTIFACT_001.txt
+++ b/fixtures/court/RECAP_RETRIEVAL_ARTIFACT_001.txt
@@ -1,0 +1,1 @@
+Failed to fetch https://www.courtlistener.com/docket/73246595/phang-v-blanche/: (403) Forbidden

--- a/fixtures/court/RECAP_TEST_RECEIPT_001.json
+++ b/fixtures/court/RECAP_TEST_RECEIPT_001.json
@@ -1,0 +1,51 @@
+{
+  "receipt_version": "0.1",
+  "receipt_id": "rcpt_20260807T234355Z_recap_001",
+  "schema": "replay.court.provenance.v0.1",
+  "created_at": "2026-08-07T23:43:55.525Z",
+  "created_by": "replay.court.adapter.recap",
+  "lineage_id": "court:US-DCD:1:26-cv-01417",
+  "subject": {
+    "cell": "D078_F052",
+    "jurisdiction": "US-DCD",
+    "genesis_key": null,
+    "case_ref": "1:26-cv-01417",
+    "docket_entry": null
+  },
+  "evidence_state": "UNRESOLVED",
+  "retrieval_state": "FAILED",
+  "authority_chain": {
+    "primary": "PACER_CMECF",
+    "index_used": "RECAP_COURTLISTENER",
+    "enrichment_used": null,
+    "secondary_summary": false
+  },
+  "provenance": {
+    "official_ref": "court=US-DCD;case=1:26-cv-01417;query=RECAP_DOCKET",
+    "source_url": "https://www.courtlistener.com/docket/73246595/phang-v-blanche/",
+    "content_hash": "sha256:5dc8953f77dd0f69bdb0845fe4970d8d2009ae31ce5651b509e313550e2cc81d",
+    "content_hash_scope": "RETRIEVAL_ARTIFACT_NOT_COURT_DOCUMENT",
+    "content_length": 96,
+    "mime_type": "text/plain",
+    "retrieval_timestamp": "2026-08-07T23:43:55.525Z",
+    "cost_billed_microusd": 0,
+    "currency": "USD",
+    "pacer_pages": null
+  },
+  "auth_context": {
+    "credential_event_receipt": null,
+    "account_type": "public_recap",
+    "mfa_used": false,
+    "environment": "public"
+  },
+  "integrity": {
+    "prev_receipt_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "self_hash": "sha256:c117f476b50d4c6cbd362cd57799c80387b68a9d972b25e0a597daf5b937e730"
+  },
+  "authority": false,
+  "failure": {
+    "http_status": 403,
+    "category": "SOURCE_FETCH_NON_SUCCESS",
+    "retryable": false
+  }
+}

--- a/fixtures/court/SEAL_ENVELOPE_DRY_RUN_001.json
+++ b/fixtures/court/SEAL_ENVELOPE_DRY_RUN_001.json
@@ -1,0 +1,16 @@
+{
+  "seal_version": "0.1",
+  "receipt_hash": "sha256:c117f476b50d4c6cbd362cd57799c80387b68a9d972b25e0a597daf5b937e730",
+  "method": "EAS",
+  "network": "base",
+  "chain_id": 8453,
+  "schema_uid": "0xc90097ca9f787edcc5fa2ce0920032abe4c4417cc8356198fa12d397c46a453c",
+  "attestation_uid": null,
+  "attester": null,
+  "transaction_hash": null,
+  "block_number": null,
+  "sealed_at": null,
+  "status": "PENDING",
+  "dry_run_validated": true,
+  "authority": false
+}

--- a/fixtures/court/pacer/AUTH_CACHE_VALIDATION_001.json
+++ b/fixtures/court/pacer/AUTH_CACHE_VALIDATION_001.json
@@ -1,0 +1,29 @@
+{
+  "fixture_id": "PACER_AUTH_CACHE_VALIDATION_001",
+  "version": "0.1",
+  "executed_at": "2026-08-08T00:04:58Z",
+  "execution_scope": "LOCAL_OFFLINE_FAKE_TRANSPORT_AND_SECRET_STORE",
+  "network_calls": 0,
+  "real_credentials_used": false,
+  "real_pacer_qa_used": false,
+  "checks": {
+    "auth_response_cached": true,
+    "second_auth_call_avoided": true,
+    "metadata_contains_token": false,
+    "metadata_contains_password": false,
+    "metadata_contains_otp": false,
+    "metadata_contains_client_code": false,
+    "cached_server_validity_claim": "UNKNOWN",
+    "reissued_token_replaced": true,
+    "missing_secret_fail_closed": true,
+    "logout_invalidated": true,
+    "filer_redact_flag": true,
+    "runtime_otp_supported": true,
+    "password_day_179_reminder": true,
+    "password_day_180_required": true
+  },
+  "result": "GREEN",
+  "pacer_qa_validation": "NOT_RUN",
+  "production_ready": false,
+  "authority": false
+}

--- a/fixtures/court/pacer/README.md
+++ b/fixtures/court/pacer/README.md
@@ -1,0 +1,16 @@
+# PACER Fixtures
+
+Status: SHELL_ONLY
+Authority: false
+Production data: NONE
+
+Reserved for non-secret PACER QA fixtures and deterministic negative/positive controls.
+
+Never commit:
+- credentials
+- live tokens
+- OTP secrets
+- protected case content
+- PII
+
+Fixtures must label source, environment, retrieval state, evidence state, and whether bytes are synthetic, QA, or public.

--- a/marketing/replay-genesis/MARKETING_TEMPLATE.md
+++ b/marketing/replay-genesis/MARKETING_TEMPLATE.md
@@ -1,0 +1,33 @@
+# RePlay [JURISDICTION] — Repeatable Marketing Template
+
+Status: `TEMPLATE_ONLY`
+Authority: `false`
+
+## Headline
+
+**What changed here today — and where is the receipt?**
+
+## Subhead
+
+RePlay [JURISDICTION] turns public-source changes into a daily, replayable civic signal: verified deltas, unresolved gaps, top-ten priorities, and receipt-backed summaries.
+
+## Three promises
+
+- **Repeatable:** the same engine runs every day.
+- **Replayable:** every published state points back to source and receipt lineage.
+- **Local:** adapters bind to the jurisdiction's own authoritative public sources.
+
+## Daily product
+
+**Morning:** what changed.  
+**Day:** what people prioritize.  
+**Evening:** the top-ten tally receipt.  
+**Night:** Joy Nightly — funny, labeled parody built on the same sourced facts.
+
+## Boundary copy
+
+RePlay [JURISDICTION] is not a government system, does not replace official votes or records, and creates no legal authority. Preference signals are nonbinding. Humor is presentation-only. Source-backed receipts remain the factual layer.
+
+## CTA
+
+**RePlay your city. RePlay your county. RePlay your country. Keep the receipts.**

--- a/marketing/replay-genesis/NIGHTLY_JOY_TEMPLATE.md
+++ b/marketing/replay-genesis/NIGHTLY_JOY_TEMPLATE.md
@@ -1,0 +1,34 @@
+# Joy Nightly — Evidence-Bound Comedy Template
+
+Status: `TEMPLATE_ONLY`
+Authority: `false`
+Parody: `true`
+
+## Input contract
+
+Only use facts already admitted by the RePlay evidence layer. Every factual statement must preserve its source/receipt reference. Humor may exaggerate tone, never the underlying fact.
+
+## Segment pattern
+
+1. **What actually changed** — sourced factual delta.
+2. **America / Local Top Ten** — nonbinding quadratic priority signal.
+3. **The receipt** — hash/root/version reference.
+4. **The unresolved pile** — what the machine still cannot prove.
+5. **Joy punchline** — explicitly labeled parody.
+
+## Example shell
+
+> **JOY PARODY:** [funny line about the verified event]
+>
+> **FACT LAYER:** [receipt-bound statement]
+>
+> **UNRESOLVED:** [gap that remains open]
+
+## Hard boundaries
+
+- PARODY != EVIDENCE
+- PREFERENCE != FACT
+- PUBLIC-SOURCE HOSTING != ENDORSEMENT
+- MISSING RECEIPT != CONCEALMENT
+- OFFICIAL CIVIC ACT != REPLAY SIGNAL
+- AUTHORITY_CREATED = FALSE

--- a/marketing/replay-genesis/ONLY_IN_AMERICA_EPSTEIN_COURT_REPLAY_001.md
+++ b/marketing/replay-genesis/ONLY_IN_AMERICA_EPSTEIN_COURT_REPLAY_001.md
@@ -1,0 +1,111 @@
+# ONLY IN AMERICA — EPSTEIN COURT REPLAY 001
+
+**Status:** SAMPLE / EVIDENCE-BOUND PARODY
+**Authority:** false
+**Government voice:** false
+**Court voice:** false
+**Fact mutation:** prohibited
+**Parody creates evidence:** false
+**Captured:** 2026-08-07
+
+## Purpose
+
+Demonstrate how RePlay Genesis / Joy Nightly can turn a live federal-court transparency dispute into a funny nightly-news segment without promoting allegations, commentary, or parody into fact.
+
+## Case anchor
+
+- Case: `Phang v. Blanche`
+- Court: U.S. District Court for the District of Columbia
+- Docket: `1:26-cv-01417`
+- Judge: Emmet G. Sullivan
+- Defendant capacity: Todd Blanche, in his official capacity as Acting Attorney General
+
+## Verified procedural facts
+
+1. On June 25, 2026, Judge Sullivan granted Katie Phang's motion for a preliminary injunction.
+2. The motion specifically sought, among other relief, production of underlying FBI interview notes associated with four FD-302 interview reports, with appropriate victim-protective redactions.
+3. DOJ's July 2 response stated that the underlying handwritten notes had not been produced because DOJ deemed them substantially similar to the typewritten reports and said the handwritten format complicated redaction and increased the risk of inadvertent disclosure of victim personally identifiable information.
+4. A court docket notice dated August 7, 2026 reflects a hearing scheduled for August 13, 2026 at 1:00 PM before Judge Sullivan, with public telephonic access.
+
+## Allegation / inference boundary
+
+The underlying allegation that Donald Trump assaulted a person when she was a minor remains an allegation in this artifact. It is not established as fact by the existence of FBI interview reports, handwritten notes, the Phang lawsuit, or the preliminary-injunction order. Trump has denied the allegation.
+
+The following statements are commentary or inference and MUST NOT be emitted as verified facts without independent evidentiary support:
+
+- `BLANCHE_IS_COVERING_UP_FOR_TRUMP`
+- `BLANCHE_IS_PROTECTING_PERPETRATORS`
+- `BLANCHE_IS_BECOMING_A_CRIMINAL_DEFENDANT`
+- `WHITE_HOUSE_OFFICIALS_COMMITTED_THE_ALLEGED_ABUSE`
+- `WITHHELD_NOTES_PROVE_THE_UNDERLYING_ALLEGATION`
+
+A civil defendant in an official-capacity lawsuit is not, by that fact alone, a criminal defendant.
+
+## RePlay state
+
+```text
+COURT_CASE_EXISTS                 = VERIFIED
+PRELIMINARY_INJUNCTION_GRANTED    = VERIFIED
+UNDERLYING_FBI_NOTES_REQUESTED    = VERIFIED
+DOJ_NONPRODUCTION_OF_NOTES        = VERIFIED_FROM_COURT_FILING
+DOJ_STATED_DUPLICATION_RATIONALE  = VERIFIED_FROM_COURT_FILING
+DOJ_STATED_REDACTION_RISK         = VERIFIED_FROM_COURT_FILING
+AUG_13_HEARING                    = SCHEDULED / DOCKET-NOTICE-BASED
+TRUMP_ASSAULT_ALLEGATION          = ALLEGATION / NOT_ESTABLISHED_HERE
+COVER_UP                          = NOT_ESTABLISHED
+CRIMINAL_LIABILITY                = NOT_ESTABLISHED
+AUTHORITY_CREATED                 = FALSE
+```
+
+## Joy Nightly sample
+
+### ONLY IN AMERICA 🇺🇸
+
+Tonight's episode: **The Federal Government Discovers Handwriting.**
+
+A federal transparency fight has reached the point where the court wants the government to show its work, DOJ says handwritten FBI notes are substantially similar to typed reports and harder to redact safely, and America is now apparently litigating whether a ballpoint pen is a document-management platform.
+
+The goblin's ruling:
+
+> If the homework exists, bring the homework. If the handwriting is ugly, congratulations — you have discovered Tuesday.
+
+### Receipt footer
+
+```text
+PARODY                    = TRUE
+PARODY_IS_EVIDENCE         = FALSE
+ALLEGATION_IS_FACT         = FALSE
+COURT_ORDER_IS_VERDICT     = FALSE
+DOJ_POSITION_IS_TRUTH      = FALSE
+MISSING_RECORD_IS_COVERUP  = FALSE
+AUTHORITY                  = FALSE
+```
+
+## Source pointers
+
+Primary / court-derived:
+- https://law.justia.com/cases/federal/district-courts/district-of-columbia/dcdce/1%3A2026cv01417/291779/16/
+- https://www.courtlistener.com/docket/73246595/phang-v-blanche/
+
+Secondary confirmation / reporting:
+- https://www.axios.com/2026/06/26/epstein-files-doj-lawsuit-judge-release-unredacted-july-order
+
+## Product lesson
+
+```text
+LIVE CONTROVERSY
+    ↓
+COURT / PRIMARY SOURCE
+    ↓
+VERIFIED PROCEDURAL FACTS
+    ↓
+ALLEGATIONS HELD SEPARATE
+    ↓
+INFERENCE BLOCKERS
+    ↓
+JOY NIGHTLY PARODY
+    ↓
+RECEIPT FOOTER
+```
+
+The joke can be loud. The evidence boundary stays louder.

--- a/marketing/replay-genesis/PRODUCT_SKU_TEMPLATE.md
+++ b/marketing/replay-genesis/PRODUCT_SKU_TEMPLATE.md
@@ -1,0 +1,43 @@
+# RePlay Genesis — Product SKU Template
+
+Status: `TEMPLATE_ONLY`
+Authority: `false`
+
+## SKU
+
+`REPLAY-[JURISDICTION]-[LEVEL]-V1`
+
+## Package
+
+- Genesis jurisdiction key
+- authoritative-source adapter pack
+- sparse 128x128 RePlay map
+- quadratic-priority module
+- daily top-ten receipt
+- parent/child receipt commitments
+- factual daily update renderer
+- Joy Nightly parody renderer
+
+## Required configuration
+
+- canonical jurisdiction name
+- jurisdiction level/type
+- authoritative source list
+- adapter identifiers
+- effective dates
+- parent genesis key
+- local branding
+- language/locale
+- receipt anchoring mode
+
+## Deployment states
+
+`SHELL_ONLY -> SOURCES_BOUND -> ADAPTER_VALIDATED -> FIXTURES_PASS -> PILOT -> PRODUCTION`
+
+No state may be skipped merely for marketing presentation.
+
+## Reusable pitch
+
+**One engine. Your jurisdiction. Daily receipts.**
+
+RePlay [JURISDICTION] turns public changes into a replayable daily signal without replacing official records, votes, or legal authority.

--- a/marketing/replay-genesis/README.md
+++ b/marketing/replay-genesis/README.md
@@ -1,0 +1,41 @@
+# RePlay Genesis — Marketing Shell
+
+Status: `SHELL_ONLY`
+Authority: `false`
+
+## One-line product
+
+One RePlay engine. One jurisdiction key. One adapter pack. One repeatable daily civic receipt loop.
+
+## Core promise
+
+RePlay does not tell a community what to believe. It shows what changed, what is sourced, what remains unresolved, what people prioritize, and where the receipt is.
+
+## Repeatable franchise pattern
+
+`[JURISDICTION NAME] + verified local sources + RePlay engine + quadratic priority + daily receipt + Joy Nightly`
+
+Examples of product naming patterns only:
+- RePlay [Country]
+- RePlay [State/Region]
+- RePlay [County/District]
+- RePlay [City/Town]
+
+No example name implies government adoption or endorsement.
+
+## Daily loop
+
+1. ingest authoritative/public deltas
+2. verify and hash
+3. map into sparse 128x128 RePlay factors
+4. collect nonbinding quadratic priority signals
+5. publish top-ten receipt
+6. commit parent/child receipt roots
+7. render a factual summary
+8. render an explicitly labeled humor/parody edition
+
+## Commercial primitive
+
+`RePlay Genesis = one jurisdiction key + one adapter pack + one deterministic engine`
+
+Marketing may be loud. Receipts stay precise.

--- a/receipts/genesis/README.md
+++ b/receipts/genesis/README.md
@@ -1,0 +1,9 @@
+# Genesis Receipts
+
+Status: `SHELL_ONLY`
+Authority: `false`
+Receipts present: `0`
+
+Future receipts bind Genesis-key issuance, authoritative source provenance, adapter version, effective dates, succession events, daily RePlay roots, and parent-child commitments.
+
+Receipt presence does not create legal or governmental authority.

--- a/receipts/genesis/court/pacer/README.md
+++ b/receipts/genesis/court/pacer/README.md
@@ -1,0 +1,16 @@
+# PACER Receipt Surface
+
+Status: SHELL_ONLY
+Authority: false
+Receipts: NONE
+Attestations: NONE
+
+Reserved for append-only PACER provenance receipt references and seal-envelope metadata.
+
+Rules:
+- runtime log != receipt
+- receipt != seal
+- seal != authority
+- raw tokens/secrets prohibited
+- failed retrieval receipts remain fail-closed
+- mainnet attestation target requires validated MATCH + COMPLETE receipt

--- a/replay/genesis/DAILY_REPLAY_RECEIPT_SCHEMA_V1.json
+++ b/replay/genesis/DAILY_REPLAY_RECEIPT_SCHEMA_V1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "replay/genesis/DAILY_REPLAY_RECEIPT_SCHEMA_V1.json",
+  "title": "DAILY_REPLAY_RECEIPT_SCHEMA_V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "receipt_type",
+    "date",
+    "genesis_key",
+    "source_manifest_root",
+    "factor_map_root",
+    "decision_root",
+    "tally_root",
+    "previous_daily_root",
+    "current_daily_root",
+    "authority"
+  ],
+  "properties": {
+    "receipt_type": {"const": "DAILY_REPLAY_UPDATE"},
+    "date": {"type": "string", "format": "date"},
+    "genesis_key": {"type": "string", "minLength": 1},
+    "source_manifest_root": {"type": "string"},
+    "factor_map_root": {"type": "string"},
+    "decision_root": {"type": "string"},
+    "participant_set_root": {"type": ["string", "null"]},
+    "ballot_commitment_root": {"type": ["string", "null"]},
+    "tally_root": {"type": "string"},
+    "previous_daily_root": {"type": ["string", "null"]},
+    "current_daily_root": {"type": "string"},
+    "top_ten_result_root": {"type": ["string", "null"]},
+    "valid_ballot_count": {"type": "integer", "minimum": 0},
+    "rejected_ballot_count": {"type": "integer", "minimum": 0},
+    "on_chain_commitment": {"type": ["string", "null"]},
+    "official_authority": {"const": false},
+    "authority": {"const": false}
+  }
+}

--- a/replay/genesis/EAS_MAPPING_V0_1.json
+++ b/replay/genesis/EAS_MAPPING_V0_1.json
@@ -1,0 +1,16 @@
+{
+  "artifact": "EAS_MAPPING_V0_1",
+  "status": "REGISTERED_ON_BASE",
+  "authority": false,
+  "network": "base",
+  "chain_id": 8453,
+  "schema_uid": "0xc90097ca9f787edcc5fa2ce0920032abe4c4417cc8356198fa12d397c46a453c",
+  "registration_tx": "0x0a63287506386c6ff8b87621a9435f3993737df09abf34c54eac183945fe2edf",
+  "creator": "0xC345B26094c63C69222Ee775189a3d3eaead5a84",
+  "resolver": "0x0000000000000000000000000000000000000000",
+  "revocable": false,
+  "schema_string": "bytes32 receiptHash,bytes32 lineageHash,bytes32 previousReceiptHash,bytes32 subjectHash,bytes32 sourceRefHash,uint64 createdAt,uint8 evidenceState,uint8 retrievalState",
+  "registration_evidence": "USER_SUPPLIED_EAS_RECORD",
+  "independent_web_replay": "PENDING_INDEX_VISIBILITY",
+  "attestation_count_at_registration": 0
+}

--- a/replay/genesis/GENESIS_KEY_SCHEMA_V1.json
+++ b/replay/genesis/GENESIS_KEY_SCHEMA_V1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "replay/genesis/GENESIS_KEY_SCHEMA_V1.json",
+  "title": "GENESIS_KEY_SCHEMA_V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "genesis_key",
+    "jurisdiction_id",
+    "level",
+    "canonical_name",
+    "jurisdiction_type",
+    "authority_source",
+    "source_adapter_ids",
+    "effective_from",
+    "authority"
+  ],
+  "properties": {
+    "genesis_key": {"type": "string", "minLength": 1},
+    "jurisdiction_id": {"type": "string", "minLength": 1},
+    "level": {"enum": ["G0", "G1", "G2", "G3", "G4", "G5"]},
+    "parent_genesis_key": {"type": ["string", "null"]},
+    "canonical_name": {"type": "string", "minLength": 1},
+    "jurisdiction_type": {"type": "string", "minLength": 1},
+    "authority_source": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+    "source_adapter_ids": {"type": "array", "items": {"type": "string"}},
+    "effective_from": {"type": "string", "format": "date-time"},
+    "effective_to": {"type": ["string", "null"], "format": "date-time"},
+    "predecessor_keys": {"type": "array", "items": {"type": "string"}},
+    "successor_keys": {"type": "array", "items": {"type": "string"}},
+    "boundary_ref": {"type": ["string", "null"]},
+    "public_key": {"type": ["string", "null"]},
+    "genesis_receipt_hash": {"type": ["string", "null"]},
+    "authority": {"const": false}
+  }
+}

--- a/replay/genesis/GENESIS_NAMESPACE_V1.json
+++ b/replay/genesis/GENESIS_NAMESPACE_V1.json
@@ -1,0 +1,26 @@
+{
+  "artifact": "GENESIS_NAMESPACE_V1",
+  "status": "SHELL_ONLY",
+  "authority": false,
+  "data_populated": false,
+  "keys_issued": 0,
+  "capacity": {
+    "active_target": 1000000,
+    "design_limit": 10000000
+  },
+  "levels": {
+    "G0": "ROOT",
+    "G1": "SOVEREIGN_COUNTRY",
+    "G2": "STATE_PROVINCE_REGION",
+    "G3": "COUNTY_DISTRICT_INTERMEDIATE",
+    "G4": "MUNICIPAL_CITY_TOWN_COMMUNE",
+    "G5": "TRIBAL_SPECIAL_SERVICE_AUTHORITY"
+  },
+  "invariants": [
+    "PLACE_EXISTS != GOVERNMENT_EXISTS",
+    "JURISDICTION_KEY != LEGAL_AUTHORITY",
+    "HISTORY != OVERWRITTEN",
+    "UNVERIFIED_JURISDICTION = UNRESOLVED",
+    "AUTHORITY_CREATED = FALSE"
+  ]
+}

--- a/replay/genesis/JURISDICTION_TYPES_V1.json
+++ b/replay/genesis/JURISDICTION_TYPES_V1.json
@@ -1,0 +1,15 @@
+{
+  "artifact": "JURISDICTION_TYPES_V1",
+  "status": "SHELL_ONLY",
+  "authority": false,
+  "types": [
+    {"level": "G0", "type": "ROOT"},
+    {"level": "G1", "type": "SOVEREIGN_COUNTRY"},
+    {"level": "G2", "type": "STATE_PROVINCE_REGION"},
+    {"level": "G3", "type": "COUNTY_DISTRICT_INTERMEDIATE"},
+    {"level": "G4", "type": "MUNICIPAL_CITY_TOWN_COMMUNE"},
+    {"level": "G5", "type": "TRIBAL_SPECIAL_SERVICE_AUTHORITY"}
+  ],
+  "eligibility_rule": "A key requires authoritative evidence of a distinct jurisdiction/governance node. Place-name existence alone is insufficient.",
+  "normalization_status": "NOT_POPULATED"
+}

--- a/replay/genesis/MAP_128x128_V1.json
+++ b/replay/genesis/MAP_128x128_V1.json
@@ -1,0 +1,15 @@
+{
+  "artifact": "REPLAY_MAP_128x128_V1",
+  "status": "SHELL_ONLY",
+  "authority": false,
+  "row_capacity": 128,
+  "column_capacity": 128,
+  "logical_cell_capacity": 16384,
+  "dense_assumption": false,
+  "sparse_allowed": true,
+  "default_cell_state": "UNRESOLVED",
+  "cell_states": ["MATCH", "PARTIAL", "UNRESOLVED", "CONFLICT", "NOT_APPLICABLE"],
+  "source_invention": false,
+  "bindings_populated": false,
+  "active_cells": 0
+}

--- a/replay/genesis/QUADRATIC_PRIORITY_V1.json
+++ b/replay/genesis/QUADRATIC_PRIORITY_V1.json
@@ -1,0 +1,22 @@
+{
+  "artifact": "QUADRATIC_PRIORITY_V1",
+  "status": "SHELL_ONLY",
+  "authority": false,
+  "binding": false,
+  "token_weight": false,
+  "seat_or_identity_weight": "UNBOUND",
+  "vote_range": [-3, -2, -1, 0, 1, 2, 3],
+  "cost_rule": "v^2",
+  "budget_rule": "SUM(v_i^2) <= B",
+  "overspend": "REJECT_WHOLE_BALLOT",
+  "server_recomputes_cost": true,
+  "eligible_cell_policy": {
+    "MATCH": "VOTEABLE",
+    "PARTIAL": "OPTIONAL_FLAGGED",
+    "UNRESOLVED": "NULL",
+    "CONFLICT": "REVIEW_LANE",
+    "NOT_APPLICABLE": "EXCLUDED"
+  },
+  "official_vote_replaced": false,
+  "implementation_status": "NOT_IMPLEMENTED"
+}

--- a/replay/genesis/README.md
+++ b/replay/genesis/README.md
@@ -1,0 +1,30 @@
+# RePlay Genesis — Global Jurisdiction Shell
+
+Status: `SHELL_ONLY`
+Authority: `false`
+Data populated: `false`
+Genesis keys issued: `0`
+
+Purpose: provide one deterministic jurisdiction-routing namespace for RePlay instances without creating governmental, legal, or political authority.
+
+Core invariant:
+
+`same engine + different genesis key + different source adapters = different jurisdiction`
+
+Planned files:
+- `GENESIS_NAMESPACE_V1.json`
+- `GENESIS_KEY_SCHEMA_V1.json`
+- `JURISDICTION_TYPES_V1.json`
+- `SUCCESSION_RULES_V1.json`
+
+Planned flow:
+
+`authoritative source -> adapter -> verified delta -> 128x128 sparse map -> quadratic priority signal -> append-only receipt -> parent jurisdiction root`
+
+Boundaries:
+- place existence does not prove government existence
+- source adapters do not create authority
+- QV is a nonbinding preference signal
+- official civic acts remain external and unchanged
+- empty/unverified slots remain unresolved
+- historical nodes are never overwritten

--- a/replay/genesis/RECEIPT_SCHEMA_V0_1.json
+++ b/replay/genesis/RECEIPT_SCHEMA_V0_1.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jsonwisdom.example/replay/genesis/receipt_schema_v0_1.json",
+  "title": "REPLAY_COURT_PROVENANCE_RECEIPT_V0_1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "receipt_version",
+    "receipt_id",
+    "schema",
+    "created_at",
+    "created_by",
+    "lineage_id",
+    "subject",
+    "evidence_state",
+    "retrieval_state",
+    "authority_chain",
+    "provenance",
+    "integrity",
+    "authority"
+  ],
+  "properties": {
+    "receipt_version": {"const": "0.1"},
+    "schema": {"const": "replay.court.provenance.v0.1"},
+    "lineage_id": {"type": "string", "minLength": 1},
+    "evidence_state": {"enum": ["UNRESOLVED", "PARTIAL", "MATCH", "NOT_APPLICABLE"]},
+    "retrieval_state": {"enum": ["COMPLETE", "FAILED", "AUTH_BLOCKED", "BUDGET_EXHAUSTED", "NOT_ATTEMPTED"]},
+    "authority": {"const": false},
+    "subject": {
+      "type": "object",
+      "required": ["cell", "jurisdiction", "case_ref"],
+      "properties": {
+        "cell": {"type": "string"},
+        "jurisdiction": {"type": "string"},
+        "case_ref": {"type": "string"},
+        "genesis_key": {"type": ["string", "null"]},
+        "docket_entry": {"type": ["integer", "null"]}
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["official_ref", "source_url", "content_hash", "content_hash_scope", "retrieval_timestamp", "cost_billed_microusd", "currency"],
+      "properties": {
+        "content_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "cost_billed_microusd": {"type": "integer", "minimum": 0},
+        "currency": {"const": "USD"}
+      }
+    },
+    "integrity": {
+      "type": "object",
+      "required": ["prev_receipt_hash", "self_hash"],
+      "properties": {
+        "prev_receipt_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "self_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    }
+  },
+  "x-replay-invariants": {
+    "canonicalization": "RFC8785_JCS_V0_1_NO_FLOAT_PROFILE",
+    "hash": "SHA-256",
+    "seal_envelope_separate": true,
+    "float_money_prohibited": true,
+    "secret_derived_hashes_prohibited_by_default": true,
+    "authority_created": false
+  }
+}

--- a/replay/genesis/SUCCESSION_RULES_V1.json
+++ b/replay/genesis/SUCCESSION_RULES_V1.json
@@ -1,0 +1,15 @@
+{
+  "artifact": "SUCCESSION_RULES_V1",
+  "status": "SHELL_ONLY",
+  "authority": false,
+  "rules": [
+    "Historical genesis keys are immutable.",
+    "A dissolved or superseded node receives effective_to; it is not deleted.",
+    "A successor node receives a new genesis key.",
+    "Mergers may reference multiple predecessor_keys.",
+    "Splits may reference one predecessor from multiple successor_keys.",
+    "Parent changes require a new effective relationship interval.",
+    "No succession relationship is admitted without authoritative source evidence."
+  ],
+  "examples_populated": false
+}

--- a/scripts/validation/court/README.md
+++ b/scripts/validation/court/README.md
@@ -1,0 +1,16 @@
+# Court Validation
+
+Status: SHELL_ONLY
+Authority: false
+
+Reserved for deterministic validation entry points shared by court adapters.
+
+Planned lanes:
+- receipt-core validation
+- JCS/SHA-256 replay
+- PACER QA checks
+- EAS mapping dry-run
+- secret/PII exclusion gates
+- cost and retrieval-state validation
+
+No validator may promote a failed retrieval into MATCH.

--- a/scripts/validation/court/validate_pacer_auth_cache_v0_1.py
+++ b/scripts/validation/court/validate_pacer_auth_cache_v0_1.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import tempfile
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from adapters.courts.pacer.auth.pacer_auth import (
+    PacerAuthClient,
+    PacerCredentials,
+    password_rotation_status,
+)
+from adapters.courts.pacer.cache.pacer_token_cache import (
+    CacheCorruptionError,
+    PacerTokenCache,
+)
+
+
+class FakeSecretStore:
+    def __init__(self) -> None:
+        self.values = {}
+
+    def get(self, ref):
+        return self.values.get(ref)
+
+    def put(self, ref, value):
+        self.values[ref] = value
+
+    def delete(self, ref):
+        self.values.pop(ref, None)
+
+
+class FakeResponse:
+    def __init__(self, status_code, data):
+        self.status_code = status_code
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.calls = []
+        self.auth_token = "A" * 128
+
+    def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        if url.endswith("/cso-auth"):
+            return FakeResponse(
+                200,
+                {
+                    "loginResult": "0",
+                    "nextGenCSO": self.auth_token,
+                    "errorDescription": "",
+                },
+            )
+        if url.endswith("/cso-logout"):
+            return FakeResponse(200, {"loginResult": "0", "errorDescription": ""})
+        raise AssertionError(f"unexpected URL: {url}")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        secrets = FakeSecretStore()
+        cache = PacerTokenCache(root / "cache", "qa", "fixture", secrets)
+        transport = FakeTransport()
+        client = PacerAuthClient("qa", cache, transport=transport)
+
+        creds = PacerCredentials(
+            login_id="fixture-user",
+            password="fixture-password",
+            otp_code="123456",
+            client_code="fixture-client",
+            filer=True,
+        )
+        body = creds.request_body()
+        assert body["redactFlag"] == "1"
+        assert body["otpCode"] == "123456"
+
+        first = client.get_or_authenticate(creds)
+        assert first.source == "AUTHENTICATION"
+        assert first.server_validity == "ISSUED_BY_PACER"
+        assert len(transport.calls) == 1
+
+        metadata_text = cache.meta_path.read_text(encoding="utf-8")
+        assert transport.auth_token not in metadata_text
+        assert "fixture-password" not in metadata_text
+        assert "123456" not in metadata_text
+        assert "fixture-client" not in metadata_text
+        metadata = json.loads(metadata_text)
+        assert metadata["environment"] == "qa"
+        assert metadata["server_validity"] == "UNKNOWN"
+
+        second = client.get_or_authenticate()
+        assert second.source == "CACHE"
+        assert second.server_validity == "UNKNOWN"
+        assert len(transport.calls) == 1
+
+        replacement = "B" * 128
+        client.observe_reissued_token(replacement, client_code_present=True)
+        assert cache.get().token == replacement
+
+        # ACTIVE metadata without its delegated secret must fail closed.
+        secrets.delete(cache.secret_ref)
+        try:
+            cache.get()
+        except CacheCorruptionError:
+            pass
+        else:
+            raise AssertionError("missing delegated token did not fail closed")
+
+        # Restore then validate explicit logout invalidation.
+        cache.put(replacement, client_code_present=True)
+        assert client.logout() is True
+        assert cache.get() is None
+        assert cache.metadata().state == "INVALIDATED"
+        assert len(transport.calls) == 2
+
+        d179 = password_rotation_status(date(2026, 1, 1), today=date(2026, 6, 29))
+        assert d179.age_days == 179
+        assert d179.reminder_due is True
+        assert d179.update_required is False
+
+        d180 = password_rotation_status(date(2026, 1, 1), today=date(2026, 6, 30))
+        assert d180.age_days == 180
+        assert d180.update_required is True
+
+    print(
+        json.dumps(
+            {
+                "state": "GREEN",
+                "network_calls": 0,
+                "real_credentials_used": False,
+                "persistent_cache_semantics": "VALIDATED_WITH_FAKE_SECRET_STORE",
+                "second_auth_call_avoided": True,
+                "reissued_token_replaced": True,
+                "missing_secret_fail_closed": True,
+                "logout_invalidated": True,
+                "password_day_179_reminder": True,
+                "password_day_180_required": True,
+                "authority": False,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/validate_court_adapter_v0_1.py
+++ b/scripts/validation/validate_court_adapter_v0_1.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -13,10 +14,12 @@ SEAL = ROOT / "fixtures" / "court" / "SEAL_ENVELOPE_DRY_RUN_001.json"
 
 
 def load_adapter():
-    spec = importlib.util.spec_from_file_location("replay_court_adapter_v0_1", ADAPTER)
+    name = "replay_court_adapter_v0_1"
+    spec = importlib.util.spec_from_file_location(name, ADAPTER)
     if spec is None or spec.loader is None:
         raise RuntimeError("unable to load adapter")
     module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
 

--- a/scripts/validation/validate_court_adapter_v0_1.py
+++ b/scripts/validation/validate_court_adapter_v0_1.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ADAPTER = ROOT / "adapters" / "courts" / "replay_court_adapter_v0_1.py"
+RECEIPT = ROOT / "fixtures" / "court" / "RECAP_TEST_RECEIPT_001.json"
+DRY = ROOT / "fixtures" / "court" / "EAS_DRY_RUN_001.json"
+SEAL = ROOT / "fixtures" / "court" / "SEAL_ENVELOPE_DRY_RUN_001.json"
+
+
+def load_adapter():
+    spec = importlib.util.spec_from_file_location("replay_court_adapter_v0_1", ADAPTER)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load adapter")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    adapter = load_adapter()
+    receipt = read_json(RECEIPT)
+    expected_dry = read_json(DRY)
+    expected_seal = read_json(SEAL)
+
+    adapter.validate_receipt_core(receipt)
+    actual_dry = adapter.build_eas_dry_run(receipt)
+    if actual_dry != expected_dry:
+        raise RuntimeError("EAS dry-run fixture mismatch")
+
+    actual_seal = adapter.build_pending_seal_envelope(receipt, actual_dry)
+    if actual_seal != expected_seal:
+        raise RuntimeError("seal-envelope fixture mismatch")
+
+    print(json.dumps({
+        "state": "GREEN",
+        "receipt_hash": receipt["integrity"]["self_hash"],
+        "schema_uid": adapter.EAS_SCHEMA_UID,
+        "attestation_created": False,
+        "authority": False,
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## RePlay Global Genesis v0.1 — shell-only scaffold

This draft PR materializes the global jurisdiction product shell without claiming production readiness, governmental authority, populated jurisdiction data, or issued Genesis keys.

### Added
- `replay/genesis/` namespace, key schema, jurisdiction types, succession rules
- sparse `128x128` map shell
- nonbinding quadratic-priority shell
- daily RePlay receipt schema shell
- `adapters/jurisdictions/` with template + US / France / Kenya placeholder packs
- `receipts/genesis/` placeholder surface
- repeatable marketing, SKU, and Joy Nightly templates

### Hard boundaries
- `AUTHORITY = false`
- `SHELL_ONLY` / `NOT_POPULATED` where implementation or data is absent
- no jurisdiction key is issued by directory presence
- authoritative sources must be bound before jurisdiction eligibility is admitted
- QV does not replace official votes or civic acts
- parody remains presentation-only and cannot promote facts
- history/succession is append-only

### Current state
- sources bound: 0
- Genesis keys issued: 0
- active 128x128 cells: 0
- QV implementation: NOT_IMPLEMENTED
- production adapters: 0

This PR is intentionally draft until source adapters, fixtures, validators, and receipts are implemented and replay-tested.