### PR TITLE
Materialize first content-addressed JAYWISDOM work-order fixture

### DIFF
--- a/revenue_agent/decomposition/agent.py
+++ b/revenue_agent/decomposition/agent.py
@@ -7,9 +7,15 @@ from typing import Dict, List
 DECOMPOSITION_VERSION = "DECOMPOSITION_V0_1"
 
 
-def _work_order_id(claim_text: str, parent_id: str | None) -> str:
-    material = f"{parent_id or ''}\0{claim_text}".encode("utf-8")
-    return f"wo_{hashlib.sha256(material).hexdigest()[:16]}"
+def generate_work_order_id(
+    claim_text: str,
+    parent_id: str | None,
+    quadratic_weight: float,
+) -> str:
+    """Return a deterministic content-addressed work-order ID."""
+    canonical = f"{parent_id or ''}|{claim_text}|{quadratic_weight:.6f}"
+    hash_suffix = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:8].upper()
+    return f"JOY-{hash_suffix}"
 
 
 def decompose_claim(
@@ -37,9 +43,15 @@ def decompose_claim(
     if parent_id is not None and not normalized_parent:
         raise ValueError("parent_id must be non-empty when provided")
 
+    quadratic_weight = float(token_weight)
+
     return [
         {
-            "work_order_id": _work_order_id(normalized_claim, normalized_parent),
+            "work_order_id": generate_work_order_id(
+                normalized_claim,
+                normalized_parent,
+                quadratic_weight,
+            ),
             "parent_id": normalized_parent,
             "claim_text": normalized_claim,
             "decomposition_version": DECOMPOSITION_VERSION,
@@ -51,7 +63,7 @@ def decompose_claim(
             "hazards": [],
             "output_schema": "PENDING",
             "replay_requirement": "REQUIRED",
-            "quadratic_weight": float(token_weight),
+            "quadratic_weight": quadratic_weight,
             "authority_created": False,
         }
     ]

--- a/revenue_agent/schemas/work_order.schema.json
+++ b/revenue_agent/schemas/work_order.schema.json
@@ -24,8 +24,8 @@
   "properties": {
     "work_order_id": {
       "type": "string",
-      "pattern": "^wo_[a-f0-9]{16}$",
-      "description": "Deterministic identifier derived from parent_id and normalized claim text."
+      "pattern": "^JOY-[A-F0-9]{8}$",
+      "description": "Deterministic content-addressed identifier derived from parent_id, normalized claim text, and quadratic_weight."
     },
     "parent_id": {
       "type": ["string", "null"],

--- a/revenue_agent/tests/fixtures/work_order_first_eev.json
+++ b/revenue_agent/tests/fixtures/work_order_first_eev.json
@@ -1,0 +1,16 @@
+{
+  "work_order_id": "JOY-CD8D67E3",
+  "parent_id": "opp_eth_foundation_rfp_001",
+  "claim_text": "EEV fixture opp_eth_foundation_rfp_001 has expected economic value 1960.00 USD under EEV_V0_1 and passes the 15.00 USD qualification threshold.",
+  "decomposition_version": "DECOMPOSITION_V0_1",
+  "verification_status": "UNVERIFIED",
+  "assumptions": [],
+  "evidence_requirements": [],
+  "method": "PENDING",
+  "acceptance_test": "PENDING",
+  "hazards": [],
+  "output_schema": "PENDING",
+  "replay_requirement": "REQUIRED",
+  "quadratic_weight": 1.0,
+  "authority_created": false
+}

--- a/revenue_agent/tests/test_decomposition.py
+++ b/revenue_agent/tests/test_decomposition.py
@@ -9,12 +9,18 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from decomposition.agent import DECOMPOSITION_VERSION, decompose_claim
+from decomposition.agent import (
+    DECOMPOSITION_VERSION,
+    decompose_claim,
+    generate_work_order_id,
+)
+from src.qualification.eev_calculator import OpportunityInputs, compute_eev_usd
 
 SCHEMA = json.loads(
     (ROOT / "schemas" / "work_order.schema.json").read_text(encoding="utf-8")
 )
 VALIDATOR = jsonschema.Draft202012Validator(SCHEMA)
+FIXTURES = ROOT / "tests" / "fixtures"
 
 
 def test_work_order_validates_against_schema():
@@ -40,16 +46,26 @@ def test_decomposition_version_is_locked():
 
 
 def test_work_order_id_is_deterministic():
-    a = decompose_claim("  Test claim  ", parent_id="parent_1")[0]
-    b = decompose_claim("Test claim", parent_id="parent_1")[0]
+    a = decompose_claim("  Test claim  ", parent_id="parent_1", token_weight=1.5)[0]
+    b = decompose_claim("Test claim", parent_id="parent_1", token_weight=1.5)[0]
     assert a["work_order_id"] == b["work_order_id"]
+    assert a["work_order_id"] == generate_work_order_id("Test claim", "parent_1", 1.5)
+    assert a["work_order_id"].startswith("JOY-")
     assert a["claim_text"] == "Test claim"
 
 
 def test_parent_changes_identity():
-    a = decompose_claim("Test claim", parent_id="parent_1")[0]
-    b = decompose_claim("Test claim", parent_id="parent_2")[0]
+    a = decompose_claim("Test claim", parent_id="parent_1", token_weight=1.5)[0]
+    b = decompose_claim("Test claim", parent_id="parent_2", token_weight=1.5)[0]
     assert a["work_order_id"] != b["work_order_id"]
+
+
+def test_quadratic_weight_changes_identity_but_not_verification_state():
+    a = decompose_claim("Test claim", parent_id="parent_1", token_weight=1.0)[0]
+    b = decompose_claim("Test claim", parent_id="parent_1", token_weight=2.0)[0]
+    assert a["work_order_id"] != b["work_order_id"]
+    assert a["verification_status"] == b["verification_status"] == "UNVERIFIED"
+    assert a["authority_created"] is b["authority_created"] is False
 
 
 @pytest.mark.parametrize("bad_weight", [-0.01, math.inf, -math.inf, math.nan])
@@ -78,3 +94,33 @@ def test_schema_rejects_authority_creation():
     work_order["authority_created"] = True
     with pytest.raises(jsonschema.ValidationError):
         VALIDATOR.validate(work_order)
+
+
+def test_first_eev_work_order_fixture_is_deterministic():
+    score_inputs = json.loads(
+        (FIXTURES / "score_high_pass.json").read_text(encoding="utf-8")
+    )
+    score = compute_eev_usd(
+        OpportunityInputs(**score_inputs),
+        scored_at="2026-08-08T00:00:00+00:00",
+    )
+    assert score["expected_value_usd"] == 1960.0
+    assert score["threshold_pass"] is True
+
+    claim_text = (
+        f"EEV fixture {score['opportunity_id']} has expected economic value "
+        f"{score['expected_value_usd']:.2f} USD under {score['formula_version']} "
+        f"and passes the {score['threshold_usd']:.2f} USD qualification threshold."
+    )
+    generated = decompose_claim(
+        claim_text,
+        parent_id=score["opportunity_id"],
+        token_weight=1.0,
+    )[0]
+    expected = json.loads(
+        (FIXTURES / "work_order_first_eev.json").read_text(encoding="utf-8")
+    )
+
+    assert generated == expected
+    assert generated["work_order_id"] == "JOY-CD8D67E3"
+    VALIDATOR.validate(generated)


### PR DESCRIPTION
## What changed

- evolves the atomic work-order ID from `wo_<16hex>` to deterministic `JOY-<8HEX>`
- derives ID from normalized `parent_id | claim_text | quadratic_weight(6dp)`
- materializes the first deterministic EEV→Decomposition fixture: `JOY-CD8D67E3`
- validates the fixture against the Work Order schema
- proves quadratic weight can change routing identity without changing verification state or authority

## First fixture

Source fixture: `revenue_agent/tests/fixtures/score_high_pass.json`

```text
opportunity_id      = opp_eth_foundation_rfp_001
EEV_V0_1            = 1960.00 USD
threshold           = 15.00 USD
threshold_pass      = true
quadratic_weight    = 1.0 (synthetic fixture routing metadata)
work_order_id       = JOY-CD8D67E3
verification_status = UNVERIFIED
authority_created   = false
```

The quadratic weight is synthetic test metadata. It is not a live token-balance observation and does not represent real revenue.

## Boundary

This PR does not implement RePlay handoff, receipt generation, verification-state promotion, authority creation, deployment, or real-revenue claims.

`AUTHORITY_CREATED = FALSE` remains structurally enforced at decomposition.