### PR TITLE
Add deterministic RePlay handoff receipts

### DIFF
--- a/.github/workflows/revenue-agent-eev-harness.yml
+++ b/.github/workflows/revenue-agent-eev-harness.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   qualification-contract:
-    name: EEV + Decomposition v0.1 contracts
+    name: EEV + Decomposition + RePlay v0.1 contracts
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -33,11 +33,12 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest jsonschema
 
-      - name: Run EEV and decomposition qualification harness
+      - name: Run qualification and replay harness
         run: |
           python -m pytest -q \
             revenue_agent/tests/test_score_schema.py \
             revenue_agent/tests/test_decomposition.py \
+            revenue_agent/tests/test_replay_handoff.py \
             -rX
 
       - name: Emit qualified membrane state
@@ -48,6 +49,8 @@ jobs:
           echo "- Commit: \`$GITHUB_SHA\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Formula: EEV_V0_1" >> "$GITHUB_STEP_SUMMARY"
           echo "- Decomposition: DECOMPOSITION_V0_1" >> "$GITHUB_STEP_SUMMARY"
+          echo "- RePlay handoff: REPLAY_HANDOFF_V0_1" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Semantic validator: STUB_V0_1" >> "$GITHUB_STEP_SUMMARY"
           echo "- Threshold: \$15.00 USD" >> "$GITHUB_STEP_SUMMARY"
           echo "- Authority: false" >> "$GITHUB_STEP_SUMMARY"
           echo "- Scanner lane: UNLOCKED" >> "$GITHUB_STEP_SUMMARY"

--- a/revenue_agent/replay/__init__.py
+++ b/revenue_agent/replay/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic RePlay handoff primitives for the JAYWISDOM revenue agent."""
+
+from replay.handoff import run_replay_handoff
+
+__all__ = ["run_replay_handoff"]

--- a/revenue_agent/replay/executor.py
+++ b/revenue_agent/replay/executor.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import random
+from pathlib import Path
+from typing import Any, Dict
+
+from decomposition.agent import decompose_claim
+
+REPLAY_RUNNER_VERSION = "REPLAY_RUNNER_V0_1"
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _implementation_hash() -> str:
+    """Bind the trace to the replay executor and decomposition implementation."""
+    executor_bytes = Path(__file__).read_bytes()
+    decomposition_bytes = Path(decompose_claim.__code__.co_filename).read_bytes()
+    material = b"REPLAY_EXECUTOR\0" + executor_bytes + b"\0DECOMPOSITION\0" + decomposition_bytes
+    return _sha256_bytes(material)
+
+
+def _validate_inputs(work_order: Dict[str, Any], baseline_anchor: str) -> None:
+    if not isinstance(work_order, dict):
+        raise TypeError("work_order must be a dict")
+
+    work_order_id = work_order.get("work_order_id")
+    if not isinstance(work_order_id, str) or not work_order_id.strip():
+        raise ValueError("work_order_id must be a non-empty string")
+
+    claim_text = work_order.get("claim_text")
+    if not isinstance(claim_text, str) or not claim_text.strip():
+        raise ValueError("claim_text must be a non-empty string")
+
+    parent_id = work_order.get("parent_id")
+    if parent_id is not None and (not isinstance(parent_id, str) or not parent_id.strip()):
+        raise ValueError("parent_id must be null or a non-empty string")
+
+    weight = work_order.get("quadratic_weight")
+    if not isinstance(weight, (int, float)) or isinstance(weight, bool):
+        raise TypeError("quadratic_weight must be a finite non-negative number")
+    if not math.isfinite(float(weight)) or float(weight) < 0:
+        raise ValueError("quadratic_weight must be a finite non-negative number")
+
+    if not isinstance(baseline_anchor, str) or len(baseline_anchor) != 40:
+        raise ValueError("baseline_anchor must be a full 40-character git SHA")
+    if any(ch not in "0123456789abcdef" for ch in baseline_anchor):
+        raise ValueError("baseline_anchor must be a lowercase hexadecimal git SHA")
+
+
+def run_replay(work_order: Dict[str, Any], baseline_anchor: str) -> Dict[str, Any]:
+    """
+    Deterministically replay decomposition from an immutable work-order input.
+
+    v0.1 freezes Python's pseudo-random source for current pure replay code and
+    records both a deterministic seed and an implementation hash. The
+    implementation hash makes later code drift visible instead of allowing a
+    changed runner to masquerade as the same replay.
+    """
+    _validate_inputs(work_order, baseline_anchor)
+
+    work_order_hash = _sha256_bytes(_canonical_json_bytes(work_order))
+    seed_material = f"{work_order['work_order_id']}:{baseline_anchor}".encode("utf-8")
+    seed = int(hashlib.sha256(seed_material).hexdigest()[:8], 16)
+
+    random.seed(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+
+    observed_outputs = decompose_claim(
+        work_order["claim_text"],
+        parent_id=work_order.get("parent_id"),
+        token_weight=float(work_order["quadratic_weight"]),
+    )
+
+    execution_trace = {
+        "seed": seed,
+        "work_order_hash": work_order_hash,
+        "implementation_hash": _implementation_hash(),
+    }
+
+    return {
+        "observed_outputs": observed_outputs,
+        "evidence_refs": [f"trace:sha256:{work_order_hash}"],
+        "execution_trace": execution_trace,
+    }

--- a/revenue_agent/replay/handoff.py
+++ b/revenue_agent/replay/handoff.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from replay.executor import run_replay
+from replay.receipt_builder import build_receipt
+from replay.semantic_validator import SemanticValidator, StubValidator
+
+
+def run_replay_handoff(
+    work_order: Dict[str, Any],
+    baseline_anchor: str,
+    validator: Optional[SemanticValidator] = None,
+) -> Dict[str, Any]:
+    """Execute deterministic replay, validate it, and return a receipt only."""
+    replay_result = run_replay(work_order, baseline_anchor)
+    semantic_validator = validator or StubValidator()
+    semantic_validation = semantic_validator.validate(
+        work_order,
+        replay_result["observed_outputs"],
+        replay_result["evidence_refs"],
+    )
+
+    if semantic_validation.get("result") not in {"PASS", "FAIL"}:
+        raise ValueError("semantic validator result must be PASS or FAIL")
+
+    return build_receipt(
+        work_order=work_order,
+        baseline_anchor=baseline_anchor,
+        observed_outputs=replay_result["observed_outputs"],
+        evidence_refs=replay_result["evidence_refs"],
+        execution_trace=replay_result["execution_trace"],
+        semantic_validation=semantic_validation,
+    )

--- a/revenue_agent/replay/receipt_builder.py
+++ b/revenue_agent/replay/receipt_builder.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, List
+
+from replay.executor import REPLAY_RUNNER_VERSION
+
+RECEIPT_VERSION = "REPLAY_HANDOFF_V0_1"
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def build_receipt(
+    work_order: Dict[str, Any],
+    baseline_anchor: str,
+    observed_outputs: List[Dict[str, Any]],
+    evidence_refs: List[str],
+    execution_trace: Dict[str, Any],
+    semantic_validation: Dict[str, str],
+) -> Dict[str, Any]:
+    """Build an immutable, content-addressed replay receipt with no authority claim."""
+    receipt: Dict[str, Any] = {
+        "receipt_version": RECEIPT_VERSION,
+        "work_order_id": work_order["work_order_id"],
+        "parent_id": work_order.get("parent_id"),
+        "work_order_sha256": sha256_json(work_order),
+        "baseline_anchor": baseline_anchor,
+        "input_claim_sha256": hashlib.sha256(
+            work_order["claim_text"].encode("utf-8")
+        ).hexdigest(),
+        "quadratic_weight": float(work_order["quadratic_weight"]),
+        "replay_runner_version": REPLAY_RUNNER_VERSION,
+        "observed_outputs": observed_outputs,
+        "evidence_refs": evidence_refs,
+        "execution_trace": execution_trace,
+        "semantic_validation": semantic_validation,
+    }
+    receipt["receipt_digest"] = sha256_json(receipt)
+    return receipt

--- a/revenue_agent/replay/semantic_validator.py
+++ b/revenue_agent/replay/semantic_validator.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+
+class SemanticValidator(ABC):
+    @abstractmethod
+    def validate(
+        self,
+        work_order: Dict[str, Any],
+        observed_outputs: List[Dict[str, Any]],
+        evidence_refs: List[str],
+    ) -> Dict[str, str]:
+        """Validate replay outputs while binding the decision to evidence refs."""
+        raise NotImplementedError
+
+
+class StubValidator(SemanticValidator):
+    """v0.1 pipeline validator. PASS means handoff executed, not semantic truth."""
+
+    def validate(
+        self,
+        work_order: Dict[str, Any],
+        observed_outputs: List[Dict[str, Any]],
+        evidence_refs: List[str],
+    ) -> Dict[str, str]:
+        del work_order, observed_outputs
+        return {
+            "result": "PASS",
+            "reason": (
+                "Stub validator (v0.1): replay pipeline completed; semantic correctness "
+                f"is not asserted. Evidence refs bound: {len(evidence_refs)}."
+            ),
+        }

--- a/revenue_agent/schemas/receipt.schema.json
+++ b/revenue_agent/schemas/receipt.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jsonwisdom.dev/computerwisdom/revenue-agent/receipt.schema.json",
+  "title": "JAYWISDOM RePlay Handoff Receipt V0.1",
+  "description": "Deterministic replay receipt. The receipt records execution and validation evidence but never creates authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "receipt_version",
+    "work_order_id",
+    "parent_id",
+    "work_order_sha256",
+    "baseline_anchor",
+    "input_claim_sha256",
+    "quadratic_weight",
+    "replay_runner_version",
+    "observed_outputs",
+    "evidence_refs",
+    "execution_trace",
+    "semantic_validation",
+    "receipt_digest"
+  ],
+  "properties": {
+    "receipt_version": {
+      "type": "string",
+      "const": "REPLAY_HANDOFF_V0_1"
+    },
+    "work_order_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "parent_id": {
+      "type": ["string", "null"]
+    },
+    "work_order_sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "baseline_anchor": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "input_claim_sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "quadratic_weight": {
+      "type": "number",
+      "minimum": 0
+    },
+    "replay_runner_version": {
+      "type": "string",
+      "const": "REPLAY_RUNNER_V0_1"
+    },
+    "observed_outputs": {
+      "type": "array",
+      "items": {"type": "object"}
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "execution_trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "seed": {"type": "integer", "minimum": 0},
+        "work_order_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "implementation_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      },
+      "required": ["seed", "work_order_hash", "implementation_hash"]
+    },
+    "semantic_validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "result": {
+          "type": "string",
+          "enum": ["PASS", "FAIL"]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["result", "reason"]
+    },
+    "receipt_digest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/revenue_agent/tests/test_replay_handoff.py
+++ b/revenue_agent/tests/test_replay_handoff.py
@@ -1,0 +1,119 @@
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from decomposition.agent import decompose_claim
+from replay.handoff import run_replay_handoff
+from replay.receipt_builder import sha256_json
+from replay.semantic_validator import SemanticValidator
+
+BASELINE = "c44fd4423ec412de811edbc8e41f7781bc880cea"
+RECEIPT_SCHEMA = json.loads(
+    (ROOT / "schemas" / "receipt.schema.json").read_text(encoding="utf-8")
+)
+VALIDATOR = jsonschema.Draft202012Validator(RECEIPT_SCHEMA)
+
+
+def sample_work_order():
+    return decompose_claim(
+        "Replay fixture claim",
+        parent_id="fixture_parent",
+        token_weight=42.0,
+    )[0]
+
+
+def test_replay_is_deterministic():
+    """Same work order + baseline + implementation -> identical receipt digest."""
+    work_order = sample_work_order()
+
+    receipt1 = run_replay_handoff(work_order, BASELINE)
+    receipt2 = run_replay_handoff(work_order, BASELINE)
+
+    assert receipt1["receipt_digest"] == receipt2["receipt_digest"]
+    assert receipt1["execution_trace"]["seed"] == receipt2["execution_trace"]["seed"]
+    assert (
+        receipt1["execution_trace"]["implementation_hash"]
+        == receipt2["execution_trace"]["implementation_hash"]
+    )
+
+
+def test_receipt_validates_against_schema():
+    receipt = run_replay_handoff(sample_work_order(), BASELINE)
+    VALIDATOR.validate(receipt)
+
+
+def test_authority_never_created_by_handoff():
+    receipt = run_replay_handoff(sample_work_order(), BASELINE)
+    assert "authority_created" not in receipt
+    assert receipt["semantic_validation"]["result"] in {"PASS", "FAIL"}
+
+
+def test_stub_pass_does_not_claim_semantic_correctness():
+    receipt = run_replay_handoff(sample_work_order(), BASELINE)
+    assert receipt["semantic_validation"]["result"] == "PASS"
+    assert "semantic correctness is not asserted" in receipt["semantic_validation"]["reason"]
+    assert "Evidence refs bound: 1" in receipt["semantic_validation"]["reason"]
+
+
+def test_receipt_digest_covers_execution_trace_and_validation():
+    receipt = run_replay_handoff(sample_work_order(), BASELINE)
+    digest = receipt.pop("receipt_digest")
+    assert digest == sha256_json(receipt)
+
+
+def test_baseline_changes_seed_and_receipt_digest():
+    work_order = sample_work_order()
+    receipt1 = run_replay_handoff(work_order, BASELINE)
+    receipt2 = run_replay_handoff(work_order, "a" * 40)
+
+    assert receipt1["execution_trace"]["seed"] != receipt2["execution_trace"]["seed"]
+    assert receipt1["receipt_digest"] != receipt2["receipt_digest"]
+
+
+def test_work_order_hash_is_canonical_across_key_order():
+    work_order = sample_work_order()
+    reversed_work_order = dict(reversed(list(work_order.items())))
+
+    receipt1 = run_replay_handoff(work_order, BASELINE)
+    receipt2 = run_replay_handoff(reversed_work_order, BASELINE)
+
+    assert (
+        receipt1["execution_trace"]["work_order_hash"]
+        == receipt2["execution_trace"]["work_order_hash"]
+    )
+    assert receipt1["receipt_digest"] == receipt2["receipt_digest"]
+
+
+def test_joy_work_order_identifier_is_forward_compatible():
+    work_order = sample_work_order()
+    work_order["work_order_id"] = "JOY-CD8D67E3"
+
+    receipt = run_replay_handoff(work_order, BASELINE)
+
+    assert receipt["work_order_id"] == "JOY-CD8D67E3"
+    VALIDATOR.validate(receipt)
+
+
+class FailingValidator(SemanticValidator):
+    def validate(self, work_order, observed_outputs, evidence_refs):
+        assert work_order
+        assert observed_outputs
+        assert evidence_refs
+        return {"result": "FAIL", "reason": "Deliberate test failure."}
+
+
+def test_fail_validation_is_recorded_not_promoted_to_authority():
+    receipt = run_replay_handoff(
+        sample_work_order(),
+        BASELINE,
+        validator=FailingValidator(),
+    )
+
+    assert receipt["semantic_validation"]["result"] == "FAIL"
+    assert "authority_created" not in receipt
+    VALIDATOR.validate(receipt)


### PR DESCRIPTION
## What changed

Implements `REPLAY_HANDOFF_V0_1` as a deterministic receipt-producing seam over the existing decomposition baseline.

- adds deterministic replay execution with seed + canonical work-order hash
- binds the execution trace to an implementation SHA-256 so code drift is detectable
- adds an evidence-bound `SemanticValidator` interface and explicit `StubValidator`
- builds canonical, timestamp-free replay receipts with a deterministic `receipt_digest`
- adds `receipt.schema.json` with required `execution_trace`
- adds replay tests for determinism, schema validity, evidence binding, canonical key ordering, FAIL recording, JOY-ID forward compatibility, and absence of top-level authority claims
- extends the existing Revenue Agent GitHub Actions harness to run replay tests

## Epistemic boundary

`StubValidator.result = PASS` means only that the v0.1 replay pipeline executed. It explicitly does **not** claim semantic correctness.

The receipt contains no `authority_created` field. No verification-state promotion, legal authority, epistemic authority, deployment, or revenue claim is created.

`AUTHORITY_CREATED = FALSE` remains the system boundary.

## Determinism boundary

Python seeding alone cannot make an arbitrary future LLM call bitwise deterministic. V0.1 therefore records both a deterministic seed and an `implementation_hash`. If the executor or decomposition implementation changes, the trace changes rather than masquerading as the same replay.

## Compatibility

This PR is intentionally independent of draft PR #434. It starts from `master` at provenance anchor `c44fd4423ec412de811edbc8e41f7781bc880cea`, while the replay receipt schema accepts the future `JOY-*` identifier carried by #434.

The repository currently has no `revenue_agent/api.py` or HTTP framework, so this PR does not fabricate an endpoint. HTTP wiring remains a separate post-merge integration step.

## Required checks

The Revenue Agent Qualification Harness now runs:

- `test_score_schema.py`
- `test_decomposition.py`
- `test_replay_handoff.py`

Merge only if the exact PR head is green.