### PR TITLE
Add Quadratic Family validation observability

### DIFF
--- a/.github/workflows/revenue-agent-eev-harness.yml
+++ b/.github/workflows/revenue-agent-eev-harness.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   qualification-contract:
-    name: EEV + Decomposition + RePlay v0.1 contracts
+    name: EEV + Decomposition + RePlay v0.2 contracts
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -39,6 +39,7 @@ jobs:
             revenue_agent/tests/test_score_schema.py \
             revenue_agent/tests/test_decomposition.py \
             revenue_agent/tests/test_replay_handoff.py \
+            revenue_agent/tests/test_quadratic_family.py \
             -rX
 
       - name: Emit qualified membrane state
@@ -50,7 +51,8 @@ jobs:
           echo "- Formula: EEV_V0_1" >> "$GITHUB_STEP_SUMMARY"
           echo "- Decomposition: DECOMPOSITION_V0_1" >> "$GITHUB_STEP_SUMMARY"
           echo "- RePlay handoff: REPLAY_HANDOFF_V0_1" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Semantic validator: STUB_V0_1" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Semantic validator: QUADRATIC_FAMILY_V0_2" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Aggregate score: INFORMATIONAL_ONLY" >> "$GITHUB_STEP_SUMMARY"
           echo "- Threshold: \$15.00 USD" >> "$GITHUB_STEP_SUMMARY"
           echo "- Authority: false" >> "$GITHUB_STEP_SUMMARY"
           echo "- Scanner lane: UNLOCKED" >> "$GITHUB_STEP_SUMMARY"

--- a/revenue_agent/replay/aggregator.py
+++ b/revenue_agent/replay/aggregator.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List
+
+VALIDATOR_VERSION = "v0.2"
+
+
+def aggregate_results(
+    validator_results: List[Dict[str, Any]],
+    anomalies: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Aggregate dimensions into a bounded informational RMS score.
+
+    The aggregate score is observability only. It MUST NOT be used for routing,
+    execution authority, verification authority, or receipt authority.
+    """
+    normalized: List[Dict[str, Any]] = []
+    seen_names = set()
+
+    for result in validator_results:
+        name = result.get("name")
+        status = result.get("status")
+        score = result.get("score")
+        if not isinstance(name, str) or not name:
+            raise ValueError("validator result name must be a non-empty string")
+        if name in seen_names:
+            raise ValueError(f"duplicate validator result name: {name}")
+        if status not in {"PASS", "FAIL"}:
+            raise ValueError(f"validator {name} status must be PASS or FAIL")
+        if not isinstance(score, (int, float)) or isinstance(score, bool):
+            raise ValueError(f"validator {name} score must be numeric")
+        if not math.isfinite(float(score)) or not 0.0 <= float(score) <= 1.0:
+            raise ValueError(f"validator {name} score must be finite and bounded [0, 1]")
+        seen_names.add(name)
+        normalized.append(result)
+
+    scores = [float(result["score"]) for result in normalized]
+    if scores:
+        aggregate_score = min(
+            1.0,
+            max(0.0, math.sqrt(sum(score**2 for score in scores) / len(scores))),
+        )
+    else:
+        aggregate_score = 0.0
+
+    high_severity_anomalies = [
+        anomaly for anomaly in anomalies if anomaly.get("severity") == "HIGH"
+    ]
+    failed_validators = [
+        result for result in normalized if result.get("status") == "FAIL"
+    ]
+
+    if high_severity_anomalies:
+        overall_status = "ANOMALY"
+    elif failed_validators:
+        overall_status = "FAIL"
+    elif aggregate_score < 0.5:
+        overall_status = "INDETERMINATE"
+    else:
+        overall_status = "PASS"
+
+    dimensions = {
+        result["name"]: {
+            "status": result["status"],
+            "score": result["score"],
+            **({"reason": result["reason"]} if result.get("reason") else {}),
+        }
+        for result in sorted(normalized, key=lambda item: item["name"])
+    }
+
+    return {
+        "overall_status": overall_status,
+        "dimensions": dimensions,
+        "anomalies": anomalies,
+        "aggregate_score": round(aggregate_score, 4),
+        "validator_version": VALIDATOR_VERSION,
+    }

--- a/revenue_agent/replay/anomaly_detector.py
+++ b/revenue_agent/replay/anomaly_detector.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, List
+
+ANOMALY_TYPES = {
+    "missing_required_field",
+    "unexpected_output_shape",
+    "temporal_drift",
+    "evidence_mismatch",
+    "logical_contradiction",
+}
+
+_REQUIRED_OBSERVED_FIELDS = {
+    "work_order_id",
+    "claim_text",
+    "verification_status",
+    "authority_created",
+}
+_TEMPORAL_KEYS = {"timestamp", "created_at", "updated_at"}
+
+
+def _canonical_work_order_hash(work_order: Dict[str, Any]) -> str:
+    payload = json.dumps(
+        work_order,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _anomaly(
+    anomaly_type: str,
+    severity: str,
+    description: str,
+    *,
+    field: str | None = None,
+    expected: Any = None,
+    actual: Any = None,
+) -> Dict[str, Any]:
+    item: Dict[str, Any] = {
+        "type": anomaly_type,
+        "severity": severity,
+        "description": description,
+    }
+    if field is not None:
+        item["field"] = field
+    if expected is not None:
+        item["expected"] = expected
+    if actual is not None:
+        item["actual"] = actual
+    return item
+
+
+def detect_anomalies(
+    work_order: Dict[str, Any],
+    observed_outputs: List[Dict[str, Any]],
+    evidence_refs: List[str],
+    baseline_anchor: str,
+) -> List[Dict[str, Any]]:
+    """Return structured anomalies as evidence; anomalies do not create authority."""
+    anomalies: List[Dict[str, Any]] = []
+
+    if not isinstance(observed_outputs, list):
+        return [
+            _anomaly(
+                "unexpected_output_shape",
+                "HIGH",
+                "Observed outputs are not a list.",
+                field="observed_outputs",
+                expected="array",
+                actual=type(observed_outputs).__name__,
+            )
+        ]
+
+    for index, output in enumerate(observed_outputs):
+        if not isinstance(output, dict):
+            anomalies.append(
+                _anomaly(
+                    "unexpected_output_shape",
+                    "HIGH",
+                    "Observed output is not an object.",
+                    field=f"observed_outputs[{index}]",
+                    expected="object",
+                    actual=type(output).__name__,
+                )
+            )
+            continue
+
+        for field in sorted(_REQUIRED_OBSERVED_FIELDS - set(output)):
+            anomalies.append(
+                _anomaly(
+                    "missing_required_field",
+                    "HIGH",
+                    f"Observed output is missing required field '{field}'.",
+                    field=f"observed_outputs[{index}].{field}",
+                    expected="present",
+                    actual="missing",
+                )
+            )
+
+        if output.get("authority_created") is not False:
+            anomalies.append(
+                _anomaly(
+                    "logical_contradiction",
+                    "HIGH",
+                    "Replay output attempted to create or omit the frozen authority boundary.",
+                    field=f"observed_outputs[{index}].authority_created",
+                    expected=False,
+                    actual=output.get("authority_created"),
+                )
+            )
+
+        if output.get("verification_status") not in {None, "UNVERIFIED"}:
+            anomalies.append(
+                _anomaly(
+                    "logical_contradiction",
+                    "HIGH",
+                    "Replay output promoted verification status without a separate authority path.",
+                    field=f"observed_outputs[{index}].verification_status",
+                    expected="UNVERIFIED",
+                    actual=output.get("verification_status"),
+                )
+            )
+
+        for key in sorted(_TEMPORAL_KEYS.intersection(output)):
+            anomalies.append(
+                _anomaly(
+                    "temporal_drift",
+                    "LOW",
+                    "Timestamp-like replay output detected in a deterministic receipt surface.",
+                    field=f"observed_outputs[{index}].{key}",
+                    expected="no temporal field",
+                    actual=output.get(key),
+                )
+            )
+
+    expected_evidence = f"trace:sha256:{_canonical_work_order_hash(work_order)}"
+    if not isinstance(evidence_refs, list) or expected_evidence not in evidence_refs:
+        anomalies.append(
+            _anomaly(
+                "evidence_mismatch",
+                "HIGH",
+                "Canonical work-order trace evidence is missing or mismatched.",
+                field="evidence_refs",
+                expected=expected_evidence,
+                actual=evidence_refs,
+            )
+        )
+
+    if (
+        not isinstance(baseline_anchor, str)
+        or len(baseline_anchor) != 40
+        or any(ch not in "0123456789abcdef" for ch in baseline_anchor)
+    ):
+        anomalies.append(
+            _anomaly(
+                "evidence_mismatch",
+                "HIGH",
+                "Baseline anchor is not a full lowercase git SHA.",
+                field="baseline_anchor",
+                expected="40-character lowercase git SHA",
+                actual=baseline_anchor,
+            )
+        )
+
+    return anomalies

--- a/revenue_agent/replay/handoff.py
+++ b/revenue_agent/replay/handoff.py
@@ -2,9 +2,58 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
+from replay.aggregator import aggregate_results
+from replay.anomaly_detector import detect_anomalies
 from replay.executor import run_replay
 from replay.receipt_builder import build_receipt
-from replay.semantic_validator import SemanticValidator, StubValidator
+from replay.semantic_validator import SemanticValidator
+from replay.validators import DependencyValidator, RangeValidator, SchemaValidator
+
+
+def _quadratic_family_validation(
+    work_order: Dict[str, Any],
+    baseline_anchor: str,
+    observed_outputs: list,
+    evidence_refs: list,
+) -> tuple[Dict[str, Any], list]:
+    validators = [
+        SchemaValidator(),
+        DependencyValidator(evidence_refs, baseline_anchor),
+        RangeValidator(),
+    ]
+    validator_results = []
+    for validator in validators:
+        result = validator.validate(work_order, observed_outputs)
+        if result.get("name") != validator.name:
+            raise ValueError(
+                f"validator identity mismatch: expected {validator.name!r}, "
+                f"got {result.get('name')!r}"
+            )
+        validator_results.append(result)
+
+    anomalies = detect_anomalies(
+        work_order,
+        observed_outputs,
+        evidence_refs,
+        baseline_anchor,
+    )
+    details = aggregate_results(validator_results, anomalies)
+    failed_validators = [
+        result for result in validator_results if result.get("status") == "FAIL"
+    ]
+    semantic_result = "FAIL" if failed_validators else "PASS"
+
+    return (
+        {
+            "result": semantic_result,
+            "reason": (
+                "Quadratic Family v0.2 completed as a non-authoritative observability "
+                f"surface; overall_status={details['overall_status']}."
+            ),
+            "details": details,
+        },
+        anomalies,
+    )
 
 
 def run_replay_handoff(
@@ -14,12 +63,21 @@ def run_replay_handoff(
 ) -> Dict[str, Any]:
     """Execute deterministic replay, validate it, and return a receipt only."""
     replay_result = run_replay(work_order, baseline_anchor)
-    semantic_validator = validator or StubValidator()
-    semantic_validation = semantic_validator.validate(
-        work_order,
-        replay_result["observed_outputs"],
-        replay_result["evidence_refs"],
-    )
+
+    if validator is None:
+        semantic_validation, anomalies = _quadratic_family_validation(
+            work_order,
+            baseline_anchor,
+            replay_result["observed_outputs"],
+            replay_result["evidence_refs"],
+        )
+    else:
+        semantic_validation = validator.validate(
+            work_order,
+            replay_result["observed_outputs"],
+            replay_result["evidence_refs"],
+        )
+        anomalies = []
 
     if semantic_validation.get("result") not in {"PASS", "FAIL"}:
         raise ValueError("semantic validator result must be PASS or FAIL")
@@ -31,4 +89,5 @@ def run_replay_handoff(
         evidence_refs=replay_result["evidence_refs"],
         execution_trace=replay_result["execution_trace"],
         semantic_validation=semantic_validation,
+        anomalies=anomalies,
     )

--- a/revenue_agent/replay/receipt_builder.py
+++ b/revenue_agent/replay/receipt_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 from typing import Any, Dict, List
@@ -23,15 +24,30 @@ def sha256_json(value: Any) -> str:
     return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
 
 
+def receipt_digest_payload(receipt: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the digest-bound payload with informational aggregate score removed."""
+    payload = copy.deepcopy(receipt)
+    payload.pop("receipt_digest", None)
+    details = payload.get("semantic_validation", {}).get("details")
+    if isinstance(details, dict):
+        details.pop("aggregate_score", None)
+    return payload
+
+
 def build_receipt(
     work_order: Dict[str, Any],
     baseline_anchor: str,
     observed_outputs: List[Dict[str, Any]],
     evidence_refs: List[str],
     execution_trace: Dict[str, Any],
-    semantic_validation: Dict[str, str],
+    semantic_validation: Dict[str, Any],
+    anomalies: List[Dict[str, Any]] | None = None,
 ) -> Dict[str, Any]:
-    """Build an immutable, content-addressed replay receipt with no authority claim."""
+    """Build an immutable replay receipt with no authority claim.
+
+    Validator dimensions and anomaly evidence are digest-bound. The quadratic
+    aggregate_score is deliberately excluded because it is informational only.
+    """
     receipt: Dict[str, Any] = {
         "receipt_version": RECEIPT_VERSION,
         "work_order_id": work_order["work_order_id"],
@@ -47,6 +63,7 @@ def build_receipt(
         "evidence_refs": evidence_refs,
         "execution_trace": execution_trace,
         "semantic_validation": semantic_validation,
+        "anomalies": anomalies or [],
     }
-    receipt["receipt_digest"] = sha256_json(receipt)
+    receipt["receipt_digest"] = sha256_json(receipt_digest_payload(receipt))
     return receipt

--- a/revenue_agent/replay/validators/__init__.py
+++ b/revenue_agent/replay/validators/__init__.py
@@ -1,0 +1,13 @@
+"""Quadratic Family validator plugins for RePlay semantic observability v0.2."""
+
+from replay.validators.base import Validator
+from replay.validators.dependency_validator import DependencyValidator
+from replay.validators.range_validator import RangeValidator
+from replay.validators.schema_validator import SchemaValidator
+
+__all__ = [
+    "Validator",
+    "SchemaValidator",
+    "DependencyValidator",
+    "RangeValidator",
+]

--- a/revenue_agent/replay/validators/base.py
+++ b/revenue_agent/replay/validators/base.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+
+class Validator(ABC):
+    """Strict plugin contract for non-authoritative validation dimensions."""
+
+    name: str = "base"
+    version: str = "v0.2"
+
+    @abstractmethod
+    def validate(
+        self,
+        work_order: Dict[str, Any],
+        observed_outputs: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """
+        Return a dimension result with this exact semantic shape:
+
+        {
+            "name": str,          # must equal self.name
+            "status": "PASS" | "FAIL",
+            "score": float,       # bounded [0, 1]
+            "reason": str,        # optional but recommended
+        }
+
+        A validator result is evidence/observability only. It creates no authority.
+        """
+        raise NotImplementedError
+
+    def result(self, status: str, score: float, reason: str = "") -> Dict[str, Any]:
+        if status not in {"PASS", "FAIL"}:
+            raise ValueError("validator status must be PASS or FAIL")
+        bounded = min(1.0, max(0.0, float(score)))
+        result: Dict[str, Any] = {
+            "name": self.name,
+            "status": status,
+            "score": bounded,
+        }
+        if reason:
+            result["reason"] = reason
+        return result

--- a/revenue_agent/replay/validators/dependency_validator.py
+++ b/revenue_agent/replay/validators/dependency_validator.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, List
+
+from replay.validators.base import Validator
+
+
+def _canonical_work_order_hash(work_order: Dict[str, Any]) -> str:
+    payload = json.dumps(
+        work_order,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+class DependencyValidator(Validator):
+    """Bind replay evidence refs to the immutable work order and baseline context."""
+
+    name = "dependency"
+
+    def __init__(self, evidence_refs: List[str], baseline_anchor: str) -> None:
+        self.evidence_refs = evidence_refs
+        self.baseline_anchor = baseline_anchor
+
+    def validate(
+        self,
+        work_order: Dict[str, Any],
+        observed_outputs: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        del observed_outputs
+
+        if (
+            not isinstance(self.baseline_anchor, str)
+            or len(self.baseline_anchor) != 40
+            or any(ch not in "0123456789abcdef" for ch in self.baseline_anchor)
+        ):
+            return self.result("FAIL", 0.0, "Baseline anchor is not a full lowercase git SHA.")
+
+        if not isinstance(self.evidence_refs, list) or not self.evidence_refs:
+            return self.result("FAIL", 0.0, "Replay evidence_refs are missing.")
+        if any(not isinstance(ref, str) or not ref for ref in self.evidence_refs):
+            return self.result("FAIL", 0.0, "Replay evidence_refs contain an invalid reference.")
+
+        expected = f"trace:sha256:{_canonical_work_order_hash(work_order)}"
+        if expected not in self.evidence_refs:
+            return self.result(
+                "FAIL",
+                0.0,
+                "Replay evidence does not contain the canonical work-order trace hash.",
+            )
+
+        return self.result(
+            "PASS",
+            1.0,
+            "Evidence refs exist and the trace hash matches the canonical work order; "
+            "baseline anchor format is valid.",
+        )

--- a/revenue_agent/replay/validators/range_validator.py
+++ b/revenue_agent/replay/validators/range_validator.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List
+
+from replay.validators.base import Validator
+
+
+class RangeValidator(Validator):
+    """Sanity-check observed numeric values without letting token weight decide truth."""
+
+    name = "range"
+
+    def validate(
+        self,
+        work_order: Dict[str, Any],
+        observed_outputs: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        del work_order
+        invalid_fields: List[str] = []
+
+        def walk(value: Any, path: str = "") -> None:
+            if isinstance(value, dict):
+                for key, child in value.items():
+                    child_path = f"{path}.{key}" if path else key
+                    if key == "quadratic_weight":
+                        continue
+                    walk(child, child_path)
+            elif isinstance(value, list):
+                for index, child in enumerate(value):
+                    walk(child, f"{path}[{index}]")
+            elif isinstance(value, (int, float)) and not isinstance(value, bool):
+                if not math.isfinite(float(value)):
+                    invalid_fields.append(path)
+
+        walk(observed_outputs)
+
+        if invalid_fields:
+            return self.result(
+                "FAIL",
+                0.0,
+                "Non-finite numeric observations at: " + ", ".join(sorted(invalid_fields)),
+            )
+
+        return self.result(
+            "PASS",
+            1.0,
+            "Observed numeric values are finite; quadratic_weight is intentionally ignored "
+            "for pass/fail.",
+        )

--- a/revenue_agent/replay/validators/schema_validator.py
+++ b/revenue_agent/replay/validators/schema_validator.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import jsonschema
+
+from replay.validators.base import Validator
+
+
+class SchemaValidator(Validator):
+    """Validate observed outputs against a concrete work-order output schema."""
+
+    name = "schema"
+
+    def validate(
+        self,
+        work_order: Dict[str, Any],
+        observed_outputs: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        if not isinstance(observed_outputs, list) or any(
+            not isinstance(item, dict) for item in observed_outputs
+        ):
+            return self.result("FAIL", 0.0, "Observed outputs must be a list of objects.")
+
+        output_schema = work_order.get("output_schema")
+        if output_schema in {None, "", "PENDING"}:
+            return self.result(
+                "PASS",
+                1.0,
+                "No concrete output_schema is declared; observed object shape is replayable, "
+                "but semantic schema correctness is not asserted.",
+            )
+
+        if not isinstance(output_schema, dict):
+            return self.result("FAIL", 0.0, "output_schema must be an object or PENDING.")
+
+        try:
+            validator_cls = jsonschema.validators.validator_for(output_schema)
+            validator_cls.check_schema(output_schema)
+            validator = validator_cls(output_schema)
+            for item in observed_outputs:
+                validator.validate(item)
+        except jsonschema.exceptions.SchemaError as exc:
+            return self.result("FAIL", 0.0, f"Invalid output_schema: {exc.message}")
+        except jsonschema.exceptions.ValidationError as exc:
+            return self.result("FAIL", 0.0, f"Observed output schema mismatch: {exc.message}")
+
+        return self.result("PASS", 1.0, "All observed outputs match the declared output_schema.")

--- a/revenue_agent/replay/validators/schema_validator.py
+++ b/revenue_agent/replay/validators/schema_validator.py
@@ -23,7 +23,7 @@ class SchemaValidator(Validator):
             return self.result("FAIL", 0.0, "Observed outputs must be a list of objects.")
 
         output_schema = work_order.get("output_schema")
-        if output_schema in {None, "", "PENDING"}:
+        if output_schema is None or output_schema in ("", "PENDING"):
             return self.result(
                 "PASS",
                 1.0,

--- a/revenue_agent/schemas/receipt.schema.json
+++ b/revenue_agent/schemas/receipt.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://jsonwisdom.dev/computerwisdom/revenue-agent/receipt.schema.json",
   "title": "JAYWISDOM RePlay Handoff Receipt V0.1",
-  "description": "Deterministic replay receipt. The receipt records execution and validation evidence but never creates authority.",
+  "description": "Deterministic replay receipt with Quadratic Family v0.2 observability. It records execution, dimensional validation, and anomaly evidence but never creates authority.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -18,8 +18,59 @@
     "evidence_refs",
     "execution_trace",
     "semantic_validation",
+    "anomalies",
     "receipt_digest"
   ],
+  "$defs": {
+    "anomaly": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "severity", "description"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "missing_required_field",
+            "unexpected_output_shape",
+            "temporal_drift",
+            "evidence_mismatch",
+            "logical_contradiction"
+          ]
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["LOW", "MEDIUM", "HIGH"]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 5
+        },
+        "field": {"type": "string"},
+        "expected": {},
+        "actual": {}
+      }
+    },
+    "dimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "score"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["PASS", "FAIL"]
+        },
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  },
   "properties": {
     "receipt_version": {
       "type": "string",
@@ -88,9 +139,48 @@
         "reason": {
           "type": "string",
           "minLength": 1
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "overall_status",
+            "dimensions",
+            "anomalies",
+            "aggregate_score",
+            "validator_version"
+          ],
+          "properties": {
+            "overall_status": {
+              "type": "string",
+              "enum": ["PASS", "FAIL", "ANOMALY", "INDETERMINATE"]
+            },
+            "dimensions": {
+              "type": "object",
+              "additionalProperties": {"$ref": "#/$defs/dimension"}
+            },
+            "anomalies": {
+              "type": "array",
+              "items": {"$ref": "#/$defs/anomaly"}
+            },
+            "aggregate_score": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Informational bounded RMS only; excluded from receipt digest computation and never authoritative."
+            },
+            "validator_version": {
+              "type": "string",
+              "const": "v0.2"
+            }
+          }
         }
       },
       "required": ["result", "reason"]
+    },
+    "anomalies": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/anomaly"}
     },
     "receipt_digest": {
       "type": "string",

--- a/revenue_agent/tests/test_quadratic_family.py
+++ b/revenue_agent/tests/test_quadratic_family.py
@@ -1,0 +1,135 @@
+import copy
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import replay.handoff as handoff_module
+from decomposition.agent import decompose_claim
+from replay.aggregator import aggregate_results
+from replay.executor import run_replay
+from replay.handoff import run_replay_handoff
+from replay.receipt_builder import receipt_digest_payload, sha256_json
+from replay.validators.schema_validator import SchemaValidator
+
+BASELINE = "c44fd4423ec412de811edbc8e41f7781bc880cea"
+UPDATED_RECEIPT_SCHEMA = json.loads(
+    (ROOT / "schemas" / "receipt.schema.json").read_text(encoding="utf-8")
+)
+
+
+def sample_work_order(token_weight=42.0):
+    work_order = decompose_claim(
+        "Replay fixture claim",
+        parent_id="fixture_parent",
+        token_weight=token_weight,
+    )[0]
+    work_order["work_order_id"] = "JOY-CD8D67E3"
+    return work_order
+
+
+def test_existing_work_order_remains_pass():
+    """JOY-CD8D67E3 remains clean under the v0.2 validator family."""
+    receipt = run_replay_handoff(sample_work_order(), BASELINE)
+
+    assert receipt["semantic_validation"]["result"] == "PASS"
+    details = receipt["semantic_validation"]["details"]
+    assert details["overall_status"] == "PASS"
+    assert details["aggregate_score"] >= 0.9
+    assert set(details["dimensions"]) == {"dependency", "range", "schema"}
+    assert len(receipt["anomalies"]) == 0
+    assert "authority_created" not in receipt
+    jsonschema.validate(instance=receipt, schema=UPDATED_RECEIPT_SCHEMA)
+
+
+def test_missing_required_field_is_anomaly_not_validator_failure(monkeypatch):
+    work_order = sample_work_order()
+    replay_result = copy.deepcopy(run_replay(work_order, BASELINE))
+    replay_result["observed_outputs"][0].pop("authority_created")
+
+    monkeypatch.setattr(
+        handoff_module,
+        "run_replay",
+        lambda supplied_work_order, supplied_baseline: replay_result,
+    )
+    receipt = run_replay_handoff(work_order, BASELINE)
+
+    assert receipt["semantic_validation"]["result"] == "PASS"
+    assert receipt["semantic_validation"]["details"]["overall_status"] == "ANOMALY"
+    assert any(
+        anomaly["type"] == "missing_required_field"
+        and anomaly["severity"] == "HIGH"
+        for anomaly in receipt["anomalies"]
+    )
+    assert "authority_created" not in receipt
+    jsonschema.validate(instance=receipt, schema=UPDATED_RECEIPT_SCHEMA)
+
+
+def test_quadratic_weight_never_changes_validation_outcome():
+    low = run_replay_handoff(sample_work_order(token_weight=0.0), BASELINE)
+    high = run_replay_handoff(sample_work_order(token_weight=1_000_000.0), BASELINE)
+
+    low_details = low["semantic_validation"]["details"]
+    high_details = high["semantic_validation"]["details"]
+    assert low_details["overall_status"] == high_details["overall_status"] == "PASS"
+    assert low_details["aggregate_score"] == high_details["aggregate_score"]
+    assert low_details["dimensions"] == high_details["dimensions"]
+
+
+def test_aggregate_score_is_bounded_and_high_anomaly_overrides_status():
+    result = aggregate_results(
+        [
+            {"name": "a", "status": "PASS", "score": 1.0},
+            {"name": "b", "status": "PASS", "score": 0.0},
+        ],
+        [],
+    )
+    assert 0.0 <= result["aggregate_score"] <= 1.0
+    assert result["aggregate_score"] == 0.7071
+
+    anomalous = aggregate_results(
+        [{"name": "a", "status": "FAIL", "score": 0.0}],
+        [
+            {
+                "type": "logical_contradiction",
+                "severity": "HIGH",
+                "description": "Injected high severity anomaly.",
+            }
+        ],
+    )
+    assert anomalous["overall_status"] == "ANOMALY"
+
+
+def test_aggregate_score_is_excluded_from_receipt_digest_only():
+    receipt = run_replay_handoff(sample_work_order(), BASELINE)
+    digest = receipt["receipt_digest"]
+
+    score_only_change = copy.deepcopy(receipt)
+    score_only_change["semantic_validation"]["details"]["aggregate_score"] = 0.1234
+    assert sha256_json(receipt_digest_payload(score_only_change)) == digest
+
+    dimension_change = copy.deepcopy(receipt)
+    dimension_change["semantic_validation"]["details"]["dimensions"]["range"]["score"] = 0.5
+    assert sha256_json(receipt_digest_payload(dimension_change)) != digest
+
+
+def test_schema_validator_uses_declared_json_schema():
+    validator = SchemaValidator()
+    work_order = sample_work_order()
+    work_order["output_schema"] = {
+        "type": "object",
+        "required": ["claim_text"],
+        "properties": {"claim_text": {"type": "string"}},
+    }
+
+    passed = validator.validate(work_order, [{"claim_text": "ok"}])
+    failed = validator.validate(work_order, [{"claim_text": 7}])
+
+    assert passed["status"] == "PASS"
+    assert passed["score"] == 1.0
+    assert failed["status"] == "FAIL"
+    assert failed["score"] == 0.0

--- a/revenue_agent/tests/test_replay_handoff.py
+++ b/revenue_agent/tests/test_replay_handoff.py
@@ -9,8 +9,8 @@ sys.path.insert(0, str(ROOT))
 
 from decomposition.agent import decompose_claim
 from replay.handoff import run_replay_handoff
-from replay.receipt_builder import sha256_json
-from replay.semantic_validator import SemanticValidator
+from replay.receipt_builder import receipt_digest_payload, sha256_json
+from replay.semantic_validator import SemanticValidator, StubValidator
 
 BASELINE = "c44fd4423ec412de811edbc8e41f7781bc880cea"
 RECEIPT_SCHEMA = json.loads(
@@ -54,16 +54,21 @@ def test_authority_never_created_by_handoff():
 
 
 def test_stub_pass_does_not_claim_semantic_correctness():
-    receipt = run_replay_handoff(sample_work_order(), BASELINE)
+    receipt = run_replay_handoff(
+        sample_work_order(),
+        BASELINE,
+        validator=StubValidator(),
+    )
     assert receipt["semantic_validation"]["result"] == "PASS"
     assert "semantic correctness is not asserted" in receipt["semantic_validation"]["reason"]
     assert "Evidence refs bound: 1" in receipt["semantic_validation"]["reason"]
+    assert receipt["anomalies"] == []
+    VALIDATOR.validate(receipt)
 
 
-def test_receipt_digest_covers_execution_trace_and_validation():
+def test_receipt_digest_covers_execution_trace_and_validation_except_aggregate_score():
     receipt = run_replay_handoff(sample_work_order(), BASELINE)
-    digest = receipt.pop("receipt_digest")
-    assert digest == sha256_json(receipt)
+    assert receipt["receipt_digest"] == sha256_json(receipt_digest_payload(receipt))
 
 
 def test_baseline_changes_seed_and_receipt_digest():
@@ -115,5 +120,6 @@ def test_fail_validation_is_recorded_not_promoted_to_authority():
     )
 
     assert receipt["semantic_validation"]["result"] == "FAIL"
+    assert receipt["anomalies"] == []
     assert "authority_created" not in receipt
     VALIDATOR.validate(receipt)


### PR DESCRIPTION
## What changed

Evolves `REPLAY_HANDOFF_V0_1` from the v0.1 stub-only semantic seam into a structured, non-authoritative Quadratic Family v0.2 observability surface.

- adds strict validator plugin interface with name/version metadata
- adds schema, dependency/evidence, and numeric-range validators
- adds typed anomaly detection with LOW/MEDIUM/HIGH severity
- adds bounded RMS aggregation with `PASS | FAIL | ANOMALY | INDETERMINATE`
- keeps `quadratic_weight` out of validator pass/fail logic
- keeps legacy injected `SemanticValidator` compatibility
- adds typed anomalies and dimensional details to the receipt schema
- excludes only informational `aggregate_score` from receipt digest computation; dimensions/anomalies remain digest-bound
- adds JOY-CD8D67E3 regression, anomaly injection, schema, weight-independence, and digest-boundary tests
- extends the qualification harness to the Quadratic Family suite

## Epistemic firewall

`ECONOMIC/QUADRATIC SIGNAL != AUTHORITY` remains invariant. This PR creates no `authority_created` field, no verification promotion, no payment authority, and no semantic truth claim.

`ANOMALY` is a distinct observability state, not silently collapsed into authority or truth. A high anomaly can coexist with legacy binary semantic `PASS` when no validator itself fails.

The aggregate RMS score is informational only and is excluded from receipt digest computation so it cannot become an accidental authority primitive.

## Required checks

Merge only if the exact PR head passes the Revenue Agent Qualification Harness, including existing EEV/decomposition/replay regressions and `test_quadratic_family.py`.