### PR TITLE
Add fail-closed game receipt renderer v0.1

### DIFF
--- a/.github/workflows/agentic-game-renderer.yml
+++ b/.github/workflows/agentic-game-renderer.yml
@@ -1,0 +1,28 @@
+name: Agentic Game Receipt Renderer
+
+on:
+  pull_request:
+    paths:
+      - 'agentic-game/**'
+      - 'revenue_agent/schemas/receipt.schema.json'
+      - '.github/workflows/agentic-game-renderer.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  renderer-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agentic-game
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install game dependencies
+        run: npm install --no-audit --no-fund
+      - name: Run renderer security tests
+        run: npm test

--- a/agentic-game/README.md
+++ b/agentic-game/README.md
@@ -91,6 +91,36 @@ state/wisdom-graph.json
 
 That file is gitignored. Do not submit personal/private session state in issues.
 
+## Receipt Renderer V0.1
+
+`src/renderer/` is a read-only projection boundary for canonical `REPLAY_HANDOFF_V0_1` receipts from `../revenue_agent/schemas/receipt.schema.json`.
+
+The renderer:
+
+- rejects any key matching `^authority(_|$)` anywhere in the receipt;
+- rejects malformed receipt digests;
+- validates against the canonical closed receipt schema;
+- deep-clones and deep-freezes projected values;
+- copies `receipt_digest` unchanged and never recomputes it;
+- exposes only the projection whitelist;
+- never promotes semantic, verification, economic, or authority state.
+
+```text
+RECEIPT = SOURCE OF RECORD
+RENDERER = READ-ONLY PROJECTION
+UI = EXPERIENCE ONLY
+AUTHORITY FIELD PRESENT = REJECT
+```
+
+Run the renderer security suite with:
+
+```bash
+npm install
+npm test
+```
+
+The current Game Zero CLI does not contain a `SIGNOFF` state. Renderer-to-SIGNOFF wiring is therefore intentionally not fabricated in v0.1; integration remains a separate change after a real state-machine seam exists.
+
 ## David + Friends Playtest
 
 For the first public test, play Game Zero once and report:

--- a/agentic-game/package.json
+++ b/agentic-game/package.json
@@ -5,7 +5,14 @@
   "description": "RePlay Wisdom Factory Game — a cooperative agentic game for learning replay, verification, and reflection.",
   "type": "module",
   "scripts": {
-    "start": "node src/cli.js"
+    "start": "node src/cli.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand"
+  },
+  "dependencies": {
+    "ajv": "^8.17.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   },
   "license": "MIT"
 }

--- a/agentic-game/src/renderer/__tests__/fixtures/validReceipt.json
+++ b/agentic-game/src/renderer/__tests__/fixtures/validReceipt.json
@@ -1,0 +1,43 @@
+{
+  "receipt_version": "REPLAY_HANDOFF_V0_1",
+  "work_order_id": "JOY-CD8D67E3",
+  "parent_id": "fixture_parent",
+  "work_order_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "baseline_anchor": "6caa38221c9f509c3ebe895a1c9ec0b45b9d2f93",
+  "input_claim_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+  "quadratic_weight": 1,
+  "replay_runner_version": "REPLAY_RUNNER_V0_1",
+  "observed_outputs": [
+    {
+      "kind": "fixture",
+      "value": "observable only"
+    }
+  ],
+  "evidence_refs": [
+    "fixture:evidence:1"
+  ],
+  "execution_trace": {
+    "seed": 7,
+    "work_order_hash": "3333333333333333333333333333333333333333333333333333333333333333",
+    "implementation_hash": "4444444444444444444444444444444444444444444444444444444444444444"
+  },
+  "semantic_validation": {
+    "result": "PASS",
+    "reason": "Fixture pipeline executed; semantic correctness is not asserted.",
+    "details": {
+      "overall_status": "PASS",
+      "dimensions": {
+        "schema": {
+          "status": "PASS",
+          "score": 1,
+          "reason": "Fixture conforms to the receipt schema."
+        }
+      },
+      "anomalies": [],
+      "aggregate_score": 1,
+      "validator_version": "v0.2"
+    }
+  },
+  "anomalies": [],
+  "receipt_digest": "5555555555555555555555555555555555555555555555555555555555555555"
+}

--- a/agentic-game/src/renderer/__tests__/renderer.test.js
+++ b/agentic-game/src/renderer/__tests__/renderer.test.js
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { project, RendererError } from '../index.js';
+
+const fixturePath = fileURLToPath(new URL('./fixtures/validReceipt.json', import.meta.url));
+const validReceipt = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+
+function expectRendererCode(receipt, code) {
+  try {
+    project(receipt);
+    throw new Error(`Expected renderer error ${code}`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(RendererError);
+    expect(error.code).toBe(code);
+  }
+}
+
+describe('GAME_RECEIPT_RENDERER_V0_1', () => {
+  it('T08: rejects any authority-related field, regardless of value or nesting', () => {
+    expectRendererCode({ ...validReceipt, authority_created: true }, 'AUTHORITY_FIELD_PRESENT');
+    expectRendererCode({ ...validReceipt, authority_created: false }, 'AUTHORITY_FIELD_PRESENT');
+    expectRendererCode({ ...validReceipt, authority: 'admin' }, 'AUTHORITY_FIELD_PRESENT');
+
+    const nested = structuredClone(validReceipt);
+    nested.observed_outputs[0].authority_claim = 'smuggled';
+    expectRendererCode(nested, 'AUTHORITY_FIELD_PRESENT');
+
+    expect(() => project(validReceipt)).not.toThrow();
+  });
+
+  it('T10: copies receipt_digest unchanged and never recomputes it', () => {
+    const projection = project(validReceipt);
+    expect(projection.receipt_digest).toBe(validReceipt.receipt_digest);
+  });
+
+  it('T11: omits schema-valid protocol fields outside the projection whitelist', () => {
+    const source = structuredClone(validReceipt);
+    const projection = project(source);
+
+    expect(projection).not.toHaveProperty('parent_id');
+    expect(projection).not.toHaveProperty('quadratic_weight');
+    expect(projection).not.toHaveProperty('execution_trace');
+    expect(source.parent_id).toBe(validReceipt.parent_id);
+    expect(source.execution_trace).toEqual(validReceipt.execution_trace);
+  });
+
+  it('rejects unknown top-level protocol fields because the canonical schema is closed', () => {
+    expectRendererCode({ ...validReceipt, future_field: 'some_value' }, 'SCHEMA_INVALID');
+  });
+
+  it('T12: projection is deeply immutable and does not leak source references', () => {
+    const source = structuredClone(validReceipt);
+    const projection = project(source);
+
+    expect(() => { projection.work_order_id = 'HACKED'; }).toThrow();
+    expect(() => { projection.anomalies.push({ type: 'injected' }); }).toThrow();
+    expect(() => { projection.observed_outputs[0].value = 'HACKED'; }).toThrow();
+
+    expect(source.work_order_id).toBe('JOY-CD8D67E3');
+    expect(source.anomalies).toEqual([]);
+    expect(source.observed_outputs[0].value).toBe('observable only');
+  });
+
+  it('T13: malformed digest fails closed with DIGEST_MALFORMED', () => {
+    expectRendererCode({ ...validReceipt, receipt_digest: 'short' }, 'DIGEST_MALFORMED');
+  });
+
+  it('projects only the approved safe fields', () => {
+    expect(Object.keys(project(validReceipt)).sort()).toEqual([
+      'anomalies',
+      'baseline_anchor',
+      'evidence_refs',
+      'observed_outputs',
+      'receipt_digest',
+      'semantic_validation',
+      'work_order_id',
+    ]);
+  });
+});

--- a/agentic-game/src/renderer/errors.js
+++ b/agentic-game/src/renderer/errors.js
@@ -1,0 +1,7 @@
+export class RendererError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.name = 'RendererError';
+    this.code = code;
+  }
+}

--- a/agentic-game/src/renderer/index.js
+++ b/agentic-game/src/renderer/index.js
@@ -1,0 +1,2 @@
+export { project } from './projection.js';
+export { RendererError } from './errors.js';

--- a/agentic-game/src/renderer/projection.js
+++ b/agentic-game/src/renderer/projection.js
@@ -1,0 +1,58 @@
+import { validateReceipt } from './schema.js';
+import { RendererError } from './errors.js';
+
+const AUTHORITY_FIELD_PATTERN = /^authority(_|$)/i;
+const DIGEST_PATTERN = /^[a-f0-9]{64}$/;
+
+function collectAuthorityKeys(value, path = '$', found = []) {
+  if (!value || typeof value !== 'object') return found;
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectAuthorityKeys(item, `${path}[${index}]`, found));
+    return found;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${path}.${key}`;
+    if (AUTHORITY_FIELD_PATTERN.test(key)) found.push(childPath);
+    collectAuthorityKeys(child, childPath, found);
+  }
+
+  return found;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}
+
+export function project(receipt) {
+  const authorityKeys = collectAuthorityKeys(receipt);
+  if (authorityKeys.length > 0) {
+    throw new RendererError(
+      `Receipt contains prohibited authority field(s): ${authorityKeys.join(', ')}`,
+      'AUTHORITY_FIELD_PRESENT',
+    );
+  }
+
+  if (typeof receipt?.receipt_digest !== 'string' || !DIGEST_PATTERN.test(receipt.receipt_digest)) {
+    throw new RendererError('Invalid receipt_digest format', 'DIGEST_MALFORMED');
+  }
+
+  validateReceipt(receipt);
+
+  const safeReceipt = structuredClone(receipt);
+  const projection = {
+    work_order_id: safeReceipt.work_order_id,
+    baseline_anchor: safeReceipt.baseline_anchor,
+    semantic_validation: safeReceipt.semantic_validation,
+    observed_outputs: safeReceipt.observed_outputs,
+    evidence_refs: safeReceipt.evidence_refs,
+    anomalies: safeReceipt.anomalies,
+    receipt_digest: safeReceipt.receipt_digest,
+  };
+
+  return deepFreeze(projection);
+}

--- a/agentic-game/src/renderer/schema.js
+++ b/agentic-game/src/renderer/schema.js
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import { RendererError } from './errors.js';
+
+const schemaPath = fileURLToPath(
+  new URL('../../../revenue_agent/schemas/receipt.schema.json', import.meta.url),
+);
+const receiptSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+
+const ajv = new Ajv2020({ strict: true, allErrors: true });
+const validate = ajv.compile(receiptSchema);
+
+export function validateReceipt(receipt) {
+  if (!validate(receipt)) {
+    throw new RendererError(
+      `Receipt schema validation failed: ${ajv.errorsText(validate.errors)}`,
+      'SCHEMA_INVALID',
+    );
+  }
+  return true;
+}


### PR DESCRIPTION
## What changed

Adds `GAME_RECEIPT_RENDERER_V0_1` under the existing `agentic-game/` surface, based on frozen provenance commit `6caa38221c9f509c3ebe895a1c9ec0b45b9d2f93`.

- validates `REPLAY_HANDOFF_V0_1` against the canonical `revenue_agent/schemas/receipt.schema.json`
- rejects authority-shaped keys matching `^authority(_|$)` recursively before projection
- rejects malformed 64-hex receipt digests with a typed renderer error
- deep-clones and deep-freezes projected values
- copies `receipt_digest` unchanged; no digest recomputation exists in the renderer
- exposes an explicit projection whitelist only
- adds Jest security tests for authority rejection, digest preservation, whitelist omission, closed-schema rejection, immutability/reference isolation, and malformed digest rejection
- adds a scoped GitHub Actions gate for the renderer test suite
- documents the read-only UI boundary in the game README

## Corrections from the blueprint

The canonical replay schema has `additionalProperties: false`, so a synthetic top-level `future_field` is schema-invalid and must be rejected rather than silently ignored. T11 therefore tests omission of schema-valid fields that are outside the UI projection whitelist.

The existing Game Zero CLI has no `SIGNOFF` state machine. This PR does not invent one. Renderer-to-SIGNOFF integration remains a separate change once a concrete state-machine seam exists.

## Epistemic boundary

```text
RECEIPT = SOURCE OF RECORD
RENDERER = READ-ONLY PROJECTION
UI = EXPERIENCE ONLY
AUTHORITY FIELD PRESENT = REJECT
DIGEST RECOMPUTATION = FALSE
AUTHORITY CREATED = FALSE
```

## Validation

CI runs from `agentic-game/` on Node 20 using `npm install` followed by `npm test`.
