### PR TITLE
Add deterministic locality anomaly evidence v0.1

### DIFF
--- a/.github/workflows/revenue-agent-eev-harness.yml
+++ b/.github/workflows/revenue-agent-eev-harness.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   qualification-contract:
-    name: EEV + Decomposition + RePlay v0.2 contracts
+    name: EEV + Decomposition + RePlay v0.2 + Locality v0.1 contracts
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -40,6 +40,7 @@ jobs:
             revenue_agent/tests/test_decomposition.py \
             revenue_agent/tests/test_replay_handoff.py \
             revenue_agent/tests/test_quadratic_family.py \
+            revenue_agent/tests/test_locality_anomaly.py \
             -rX
 
       - name: Emit qualified membrane state
@@ -52,6 +53,8 @@ jobs:
           echo "- Decomposition: DECOMPOSITION_V0_1" >> "$GITHUB_STEP_SUMMARY"
           echo "- RePlay handoff: REPLAY_HANDOFF_V0_1" >> "$GITHUB_STEP_SUMMARY"
           echo "- Semantic validator: QUADRATIC_FAMILY_V0_2" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Locality anomaly: LOCALITY_ANOMALY_ENGINE_V0_1" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Locality evidence: NON_AUTHORITATIVE" >> "$GITHUB_STEP_SUMMARY"
           echo "- Aggregate score: INFORMATIONAL_ONLY" >> "$GITHUB_STEP_SUMMARY"
           echo "- Threshold: \$15.00 USD" >> "$GITHUB_STEP_SUMMARY"
           echo "- Authority: false" >> "$GITHUB_STEP_SUMMARY"

--- a/revenue_agent/anomaly/__init__.py
+++ b/revenue_agent/anomaly/__init__.py
@@ -1,0 +1,17 @@
+"""Privacy-preserving locality anomaly evidence for deterministic replay."""
+
+from anomaly.baseline import BaselineStore, SnapshotStore
+from anomaly.engine import LocalityAnomalyEngine
+from anomaly.ring import RingLocality, resolve_ring
+from anomaly.signals import NWSWeatherAlertsSignal
+from anomaly.validator import LocalityAnomalyValidator
+
+__all__ = [
+    "BaselineStore",
+    "SnapshotStore",
+    "LocalityAnomalyEngine",
+    "RingLocality",
+    "resolve_ring",
+    "NWSWeatherAlertsSignal",
+    "LocalityAnomalyValidator",
+]

--- a/revenue_agent/anomaly/baseline.py
+++ b/revenue_agent/anomaly/baseline.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from anomaly.ring import resolve_ring
+
+SNAPSHOT_VERSION = "LOCALITY_SIGNAL_SNAPSHOT_V0_1"
+BASELINE_VERSION = "LOCALITY_BASELINE_V0_1"
+_ALLOWED_SIGNAL_TYPES = {
+    "weather_alert",
+    "infrastructure_outage",
+    "emergency_broadcast",
+    "traffic_disruption",
+}
+
+
+class ImmutableStoreConflict(RuntimeError):
+    pass
+
+
+class SnapshotMissing(FileNotFoundError):
+    pass
+
+
+class BaselineMissing(FileNotFoundError):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _validate_baseline_anchor(baseline_anchor: str) -> None:
+    if (
+        not isinstance(baseline_anchor, str)
+        or len(baseline_anchor) != 40
+        or any(ch not in "0123456789abcdef" for ch in baseline_anchor)
+    ):
+        raise ValueError("baseline_anchor must be a full lowercase 40-character git SHA")
+
+
+def _validate_time_window(time_window: str) -> str:
+    if not isinstance(time_window, str) or not time_window:
+        raise ValueError("time_window must be a non-empty string")
+    value = time_window.strip()
+    if len(value) > 32:
+        raise ValueError("time_window is too long")
+    return value
+
+
+class _ImmutableJsonStore:
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _key_digest(kind: str, locality: str, time_window: str, baseline_anchor: str) -> str:
+        key = {
+            "kind": kind,
+            "locality": locality,
+            "time_window": time_window,
+            "baseline_anchor": baseline_anchor,
+        }
+        return sha256_bytes(canonical_json_bytes(key))
+
+    def _path(self, kind: str, locality: str, time_window: str, baseline_anchor: str) -> Path:
+        return self.root / f"{self._key_digest(kind, locality, time_window, baseline_anchor)}.json"
+
+    def _put_once(
+        self,
+        kind: str,
+        locality: str,
+        time_window: str,
+        baseline_anchor: str,
+        payload: Dict[str, Any],
+    ) -> Tuple[Dict[str, Any], str]:
+        path = self._path(kind, locality, time_window, baseline_anchor)
+        data = canonical_json_bytes(payload)
+        digest = sha256_bytes(data)
+        if path.exists():
+            existing = path.read_bytes()
+            if existing != data:
+                raise ImmutableStoreConflict(f"immutable {kind} already exists with different bytes")
+            return json.loads(existing), sha256_bytes(existing)
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        fd = os.open(path, flags, 0o600)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except Exception:
+            path.unlink(missing_ok=True)
+            raise
+        return payload, digest
+
+    def _get(
+        self,
+        kind: str,
+        locality: str,
+        time_window: str,
+        baseline_anchor: str,
+        missing_exc: type[FileNotFoundError],
+    ) -> Tuple[Dict[str, Any], str]:
+        path = self._path(kind, locality, time_window, baseline_anchor)
+        if not path.exists():
+            raise missing_exc(f"{kind} is not frozen for this locality/time/baseline")
+        data = path.read_bytes()
+        return json.loads(data), sha256_bytes(data)
+
+
+class SnapshotStore(_ImmutableJsonStore):
+    def put(
+        self,
+        locality: str,
+        time_window: str,
+        baseline_anchor: str,
+        signals: list[Dict[str, Any]],
+    ) -> Tuple[Dict[str, Any], str]:
+        locality_id = resolve_ring(locality).locality_id
+        window = _validate_time_window(time_window)
+        _validate_baseline_anchor(baseline_anchor)
+        payload = {
+            "snapshot_version": SNAPSHOT_VERSION,
+            "locality": locality_id,
+            "time_window": window,
+            "baseline_anchor": baseline_anchor,
+            "signals": signals,
+        }
+        return self._put_once("snapshot", locality_id, window, baseline_anchor, payload)
+
+    def get(
+        self,
+        locality: str,
+        time_window: str,
+        baseline_anchor: str,
+    ) -> Tuple[Dict[str, Any], str]:
+        locality_id = resolve_ring(locality).locality_id
+        window = _validate_time_window(time_window)
+        _validate_baseline_anchor(baseline_anchor)
+        return self._get("snapshot", locality_id, window, baseline_anchor, SnapshotMissing)
+
+
+class BaselineStore(_ImmutableJsonStore):
+    def put(
+        self,
+        locality: str,
+        time_window: str,
+        baseline_anchor: str,
+        metrics: Dict[str, float],
+    ) -> Tuple[Dict[str, Any], str]:
+        locality_id = resolve_ring(locality).locality_id
+        window = _validate_time_window(time_window)
+        _validate_baseline_anchor(baseline_anchor)
+        if not isinstance(metrics, dict):
+            raise TypeError("metrics must be an object")
+        normalized: Dict[str, float] = {}
+        for key, value in sorted(metrics.items()):
+            if key not in _ALLOWED_SIGNAL_TYPES:
+                raise ValueError(f"unsupported baseline metric: {key}")
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                raise TypeError(f"baseline metric {key} must be numeric")
+            if not math.isfinite(float(value)) or float(value) < 0:
+                raise ValueError(f"baseline metric {key} must be finite and non-negative")
+            normalized[key] = float(value)
+        payload = {
+            "baseline_version": BASELINE_VERSION,
+            "locality": locality_id,
+            "time_window": window,
+            "baseline_anchor": baseline_anchor,
+            "metrics": normalized,
+        }
+        return self._put_once("baseline", locality_id, window, baseline_anchor, payload)
+
+    def get(
+        self,
+        locality: str,
+        time_window: str,
+        baseline_anchor: str,
+    ) -> Tuple[Dict[str, Any], str]:
+        locality_id = resolve_ring(locality).locality_id
+        window = _validate_time_window(time_window)
+        _validate_baseline_anchor(baseline_anchor)
+        return self._get("baseline", locality_id, window, baseline_anchor, BaselineMissing)

--- a/revenue_agent/anomaly/engine.py
+++ b/revenue_agent/anomaly/engine.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Protocol
+
+from anomaly.baseline import BaselineStore, SnapshotMissing, SnapshotStore
+from anomaly.ring import resolve_ring
+
+ENGINE_VERSION = "v0.1"
+_ALLOWED_WHAT = {
+    "weather_alert",
+    "infrastructure_outage",
+    "emergency_broadcast",
+    "traffic_disruption",
+}
+_ALLOWED_SEVERITY = {"LOW", "MEDIUM", "HIGH"}
+
+
+class SignalProvider(Protocol):
+    def fetch_all(self, locality: str, time_window: str) -> list[Dict[str, Any]]: ...
+
+
+class BaselineIncomplete(RuntimeError):
+    pass
+
+
+class LocalityAnomalyEngine:
+    """Replayable locality-scoped evidence provider.
+
+    Signal acquisition is explicitly separated from analysis: capture_snapshot()
+    may touch a public API once, while analyze() only reads immutable frozen bytes.
+    """
+
+    def __init__(
+        self,
+        signals: SignalProvider,
+        snapshot_store: SnapshotStore,
+        baseline_store: BaselineStore,
+    ) -> None:
+        self.signals = signals
+        self.snapshot_store = snapshot_store
+        self.baseline_store = baseline_store
+
+    def capture_snapshot(
+        self,
+        locality: str,
+        time_window: str,
+        baseline_anchor: str,
+    ) -> Dict[str, Any]:
+        locality_id = resolve_ring(locality).locality_id
+        try:
+            snapshot, digest = self.snapshot_store.get(
+                locality_id, time_window, baseline_anchor
+            )
+            return {"snapshot": snapshot, "snapshot_digest": digest}
+        except SnapshotMissing:
+            pass
+
+        safe_signals = self.signals.fetch_all(locality_id, time_window)
+        normalized = [self._normalize_signal(item) for item in safe_signals]
+        snapshot, digest = self.snapshot_store.put(
+            locality_id,
+            time_window,
+            baseline_anchor,
+            sorted(
+                normalized,
+                key=lambda item: (item["when"], item["what"], item["sources"]),
+            ),
+        )
+        return {"snapshot": snapshot, "snapshot_digest": digest}
+
+    def analyze(
+        self,
+        locality: str,
+        time_window: str,
+        baseline_anchor: str,
+    ) -> Dict[str, Any]:
+        locality_id = resolve_ring(locality).locality_id
+        snapshot, snapshot_digest = self.snapshot_store.get(
+            locality_id, time_window, baseline_anchor
+        )
+        baseline, baseline_digest = self.baseline_store.get(
+            locality_id, time_window, baseline_anchor
+        )
+        metrics = baseline.get("metrics", {})
+
+        observations: list[Dict[str, Any]] = []
+        for signal in snapshot.get("signals", []):
+            normalized = self._normalize_signal(signal)
+            what = normalized["what"]
+            if what not in metrics:
+                raise BaselineIncomplete(f"baseline does not contain metric for {what}")
+            baseline_value = float(metrics[what])
+            delta = float(normalized["value"]) - baseline_value
+            observations.append(
+                {
+                    "where": locality_id,
+                    "when": normalized["when"],
+                    "what": what,
+                    "baseline": baseline_value,
+                    "delta": delta,
+                    "corroboration": len(normalized["sources"]),
+                    "confidence": float(normalized["confidence"]),
+                    "severity": normalized["severity"],
+                    "sources": normalized["sources"],
+                }
+            )
+
+        observations.sort(
+            key=lambda item: (
+                item["when"],
+                item["what"],
+                item["severity"],
+                item["sources"],
+            )
+        )
+        return {
+            "source": "locality_anomaly",
+            "engine_version": ENGINE_VERSION,
+            "locality": locality_id,
+            "time_window": time_window,
+            "snapshot_digest": snapshot_digest,
+            "baseline_digest": baseline_digest,
+            "observations": observations,
+        }
+
+    @staticmethod
+    def _normalize_signal(item: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(item, dict):
+            raise TypeError("signal must be an object")
+        what = item.get("what")
+        when = item.get("when")
+        value = item.get("value")
+        confidence = item.get("confidence")
+        severity = item.get("severity")
+        sources = item.get("sources")
+        if what not in _ALLOWED_WHAT:
+            raise ValueError("signal what is not allowed")
+        if not isinstance(when, str) or not when:
+            raise ValueError("signal when must be a non-empty date-time string")
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise TypeError("signal value must be numeric")
+        if not math.isfinite(float(value)):
+            raise ValueError("signal value must be finite")
+        if not isinstance(confidence, (int, float)) or isinstance(confidence, bool):
+            raise TypeError("signal confidence must be numeric")
+        if not math.isfinite(float(confidence)) or not 0.0 <= float(confidence) <= 1.0:
+            raise ValueError("signal confidence must be bounded [0, 1]")
+        if severity not in _ALLOWED_SEVERITY:
+            raise ValueError("signal severity is not allowed")
+        if not isinstance(sources, list) or not sources:
+            raise ValueError("signal sources must be a non-empty list")
+        safe_sources = sorted({source for source in sources if isinstance(source, str) and source})
+        if not safe_sources:
+            raise ValueError("signal sources contain no valid references")
+        return {
+            "what": what,
+            "when": when,
+            "value": float(value),
+            "confidence": float(confidence),
+            "severity": severity,
+            "sources": safe_sources[:5],
+        }

--- a/revenue_agent/anomaly/ring.py
+++ b/revenue_agent/anomaly/ring.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_RING_LOCALITY_RE = re.compile(r"^R([0-5])-([A-Z0-9]+)$")
+
+
+@dataclass(frozen=True)
+class RingLocality:
+    locality_id: str
+    ring: int
+    code: str
+
+
+def resolve_ring(locality: str) -> RingLocality:
+    """Parse and validate a privacy-preserving R0-R5 locality identifier."""
+    if not isinstance(locality, str):
+        raise TypeError("locality must be a ring-locality string")
+    normalized = locality.strip().upper()
+    match = _RING_LOCALITY_RE.fullmatch(normalized)
+    if not match:
+        raise ValueError("locality must match ^R[0-5]-[A-Z0-9]+$")
+    return RingLocality(
+        locality_id=normalized,
+        ring=int(match.group(1)),
+        code=match.group(2),
+    )

--- a/revenue_agent/anomaly/signals.py
+++ b/revenue_agent/anomaly/signals.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Callable, Dict, Mapping
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from anomaly.ring import resolve_ring
+
+NWS_ALERTS_ENDPOINT = "https://api.weather.gov/alerts/active"
+DEFAULT_USER_AGENT = (
+    "COMPUTERWISDOM-locality-anomaly/0.1 "
+    "(https://github.com/jsonwisdom/COMPUTERWISDOM)"
+)
+
+
+class SignalConfigurationError(RuntimeError):
+    pass
+
+
+def _severity(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"extreme", "severe"}:
+        return "HIGH"
+    if normalized == "moderate":
+        return "MEDIUM"
+    return "LOW"
+
+
+def _confidence(value: Any) -> float:
+    normalized = str(value or "").strip().lower()
+    return {
+        "observed": 1.0,
+        "likely": 0.9,
+        "possible": 0.6,
+        "unlikely": 0.3,
+        "unknown": 0.5,
+    }.get(normalized, 0.5)
+
+
+def _source_ref(value: str) -> str:
+    return "nws:sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class NWSWeatherAlertsSignal:
+    """Capture privacy-reduced public NWS alerts for configured ring localities.
+
+    Locality controls map ring IDs to public NWS county/forecast-zone identifiers.
+    Raw descriptions, area names, addresses, and person-level data are never retained.
+    """
+
+    def __init__(
+        self,
+        locality_controls: Mapping[str, Mapping[str, str]],
+        *,
+        user_agent: str = DEFAULT_USER_AGENT,
+        opener: Callable[..., Any] | None = None,
+    ) -> None:
+        self.locality_controls = {
+            resolve_ring(locality).locality_id: dict(control)
+            for locality, control in locality_controls.items()
+        }
+        self.user_agent = user_agent
+        self.opener = opener or urlopen
+
+    def fetch_all(self, locality: str, time_window: str) -> list[Dict[str, Any]]:
+        del time_window  # v0.1 captures the active-alert set; scope is frozen by snapshot.
+        locality_id = resolve_ring(locality).locality_id
+        control = self.locality_controls.get(locality_id)
+        if not control:
+            raise SignalConfigurationError(f"no public signal control configured for {locality_id}")
+        zone = control.get("nws_zone")
+        if not isinstance(zone, str) or not zone.strip():
+            raise SignalConfigurationError("locality control must define nws_zone")
+
+        url = f"{NWS_ALERTS_ENDPOINT}?{urlencode({'zone': zone.strip().upper()})}"
+        request = Request(
+            url,
+            headers={
+                "User-Agent": self.user_agent,
+                "Accept": "application/geo+json",
+            },
+        )
+        with self.opener(request, timeout=15) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+
+        features = payload.get("features", []) if isinstance(payload, dict) else []
+        safe_signals: list[Dict[str, Any]] = []
+        for feature in features:
+            if not isinstance(feature, dict):
+                continue
+            properties = feature.get("properties")
+            if not isinstance(properties, dict):
+                continue
+            when = (
+                properties.get("sent")
+                or properties.get("effective")
+                or properties.get("onset")
+            )
+            if not isinstance(when, str) or not when:
+                continue
+            raw_id = feature.get("id") or properties.get("id") or properties.get("@id")
+            if not isinstance(raw_id, str) or not raw_id:
+                raw_id = json.dumps(
+                    {
+                        "when": when,
+                        "severity": properties.get("severity"),
+                        "certainty": properties.get("certainty"),
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            safe_signals.append(
+                {
+                    "what": "weather_alert",
+                    "when": when,
+                    "value": 1.0,
+                    "confidence": _confidence(properties.get("certainty")),
+                    "severity": _severity(properties.get("severity")),
+                    "sources": [_source_ref(raw_id)],
+                }
+            )
+
+        return sorted(
+            safe_signals,
+            key=lambda item: (item["when"], item["severity"], item["sources"]),
+        )

--- a/revenue_agent/anomaly/validator.py
+++ b/revenue_agent/anomaly/validator.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+from replay.validators.base import Validator
+
+_RING_RE = re.compile(r"^R[0-5]-[A-Z0-9]+$")
+_HEX64_RE = re.compile(r"^[a-f0-9]{64}$")
+
+_ALLOWED_OBSERVATION_KEYS = (
+    "where",
+    "when",
+    "what",
+    "baseline",
+    "delta",
+    "corroboration",
+    "confidence",
+    "severity",
+    "sources",
+)
+_ALLOWED_REPORT_KEYS = (
+    "source",
+    "engine_version",
+    "locality",
+    "time_window",
+    "snapshot_digest",
+    "baseline_digest",
+)
+
+
+class LocalityAnomalyValidator(Validator):
+    name = "locality_anomaly"
+    version = "v0.1"
+
+    def validate(
+        self,
+        work_order: Dict[str, Any],
+        observed_outputs: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        locality = work_order.get("locality")
+        if not locality:
+            return self.result("PASS", 1.0, "No locality specified.")
+
+        report = next(
+            (
+                output
+                for output in observed_outputs
+                if isinstance(output, dict) and output.get("source") == "locality_anomaly"
+            ),
+            None,
+        )
+        if report is None:
+            return self.result(
+                "INDETERMINATE",
+                0.5,
+                "No frozen locality anomaly report is present in observed outputs.",
+            )
+
+        safe_report = self._sanitize_report(report)
+        if not self._is_structured_report(safe_report, work_order):
+            return self.result(
+                "INDETERMINATE",
+                0.5,
+                "Locality anomaly report is present but malformed or mismatched.",
+            )
+
+        severe = [
+            observation
+            for observation in safe_report["observations"]
+            if float(observation.get("confidence", 0.0)) > 0.8
+            and int(observation.get("corroboration", 0)) >= 2
+            and observation.get("severity") == "HIGH"
+        ]
+        status = "FAIL" if severe else "PASS"
+        result = self.result(
+            status,
+            0.0 if severe else 1.0,
+            f"{len(severe)} severe locality anomalies detected."
+            if severe
+            else "No severe locality anomalies detected.",
+        )
+        result["details"] = safe_report
+        return result
+
+    @staticmethod
+    def _is_structured_report(report: Dict[str, Any], work_order: Dict[str, Any]) -> bool:
+        locality = report.get("locality")
+        if not isinstance(locality, str) or not _RING_RE.fullmatch(locality):
+            return False
+        if locality != work_order.get("locality"):
+            return False
+        if report.get("time_window") != work_order.get("time_window"):
+            return False
+        if report.get("engine_version") != "v0.1":
+            return False
+        if not isinstance(report.get("snapshot_digest"), str) or not _HEX64_RE.fullmatch(report["snapshot_digest"]):
+            return False
+        if not isinstance(report.get("baseline_digest"), str) or not _HEX64_RE.fullmatch(report["baseline_digest"]):
+            return False
+        observations = report.get("observations")
+        if not isinstance(observations, list):
+            return False
+        required = {"where", "when", "what", "baseline", "delta", "corroboration", "confidence", "severity"}
+        for observation in observations:
+            if not isinstance(observation, dict) or not required.issubset(observation):
+                return False
+            if observation.get("where") != locality:
+                return False
+        return True
+
+    @staticmethod
+    def _sanitize_report(report: Dict[str, Any]) -> Dict[str, Any]:
+        safe = {key: report.get(key) for key in _ALLOWED_REPORT_KEYS}
+        safe["source"] = "locality_anomaly"
+        safe_observations = []
+        for observation in report.get("observations", []):
+            if not isinstance(observation, dict):
+                continue
+            safe_observations.append(
+                {
+                    key: observation[key]
+                    for key in _ALLOWED_OBSERVATION_KEYS
+                    if key in observation
+                }
+            )
+        safe["observations"] = safe_observations
+        return safe

--- a/revenue_agent/replay/aggregator.py
+++ b/revenue_agent/replay/aggregator.py
@@ -26,8 +26,10 @@ def aggregate_results(
             raise ValueError("validator result name must be a non-empty string")
         if name in seen_names:
             raise ValueError(f"duplicate validator result name: {name}")
-        if status not in {"PASS", "FAIL"}:
-            raise ValueError(f"validator {name} status must be PASS or FAIL")
+        if status not in {"PASS", "FAIL", "INDETERMINATE"}:
+            raise ValueError(
+                f"validator {name} status must be PASS, FAIL, or INDETERMINATE"
+            )
         if not isinstance(score, (int, float)) or isinstance(score, bool):
             raise ValueError(f"validator {name} score must be numeric")
         if not math.isfinite(float(score)) or not 0.0 <= float(score) <= 1.0:
@@ -50,11 +52,16 @@ def aggregate_results(
     failed_validators = [
         result for result in normalized if result.get("status") == "FAIL"
     ]
+    indeterminate_validators = [
+        result for result in normalized if result.get("status") == "INDETERMINATE"
+    ]
 
     if high_severity_anomalies:
         overall_status = "ANOMALY"
     elif failed_validators:
         overall_status = "FAIL"
+    elif indeterminate_validators:
+        overall_status = "INDETERMINATE"
     elif aggregate_score < 0.5:
         overall_status = "INDETERMINATE"
     else:

--- a/revenue_agent/replay/handoff.py
+++ b/revenue_agent/replay/handoff.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
+from anomaly.baseline import BaselineMissing, SnapshotMissing
+from anomaly.engine import BaselineIncomplete, LocalityAnomalyEngine
+from anomaly.validator import LocalityAnomalyValidator
 from replay.aggregator import aggregate_results
 from replay.anomaly_detector import detect_anomalies
 from replay.executor import run_replay
@@ -10,34 +13,51 @@ from replay.semantic_validator import SemanticValidator
 from replay.validators import DependencyValidator, RangeValidator, SchemaValidator
 
 
+def _is_locality_report(output: Any) -> bool:
+    return isinstance(output, dict) and output.get("source") == "locality_anomaly"
+
+
 def _quadratic_family_validation(
     work_order: Dict[str, Any],
     baseline_anchor: str,
     observed_outputs: list,
     evidence_refs: list,
 ) -> tuple[Dict[str, Any], list]:
+    core_outputs = [output for output in observed_outputs if not _is_locality_report(output)]
     validators = [
         SchemaValidator(),
         DependencyValidator(evidence_refs, baseline_anchor),
         RangeValidator(),
     ]
+    if work_order.get("locality"):
+        validators.append(LocalityAnomalyValidator())
+
     validator_results = []
+    locality_report = None
     for validator in validators:
-        result = validator.validate(work_order, observed_outputs)
+        target_outputs = (
+            observed_outputs if validator.name == "locality_anomaly" else core_outputs
+        )
+        result = validator.validate(work_order, target_outputs)
         if result.get("name") != validator.name:
             raise ValueError(
                 f"validator identity mismatch: expected {validator.name!r}, "
                 f"got {result.get('name')!r}"
             )
+        if validator.name == "locality_anomaly" and isinstance(result.get("details"), dict):
+            locality_report = result["details"]
         validator_results.append(result)
 
     anomalies = detect_anomalies(
         work_order,
-        observed_outputs,
+        core_outputs,
         evidence_refs,
         baseline_anchor,
     )
     details = aggregate_results(validator_results, anomalies)
+    if locality_report is not None:
+        details["anomaly_report"] = locality_report
+
     failed_validators = [
         result for result in validator_results if result.get("status") == "FAIL"
     ]
@@ -60,21 +80,37 @@ def run_replay_handoff(
     work_order: Dict[str, Any],
     baseline_anchor: str,
     validator: Optional[SemanticValidator] = None,
+    locality_engine: Optional[LocalityAnomalyEngine] = None,
 ) -> Dict[str, Any]:
-    """Execute deterministic replay, validate it, and return a receipt only."""
+    """Execute deterministic replay, validate it, and return a receipt only.
+
+    RePlay never performs live locality acquisition. A locality engine may analyze
+    a previously frozen snapshot; missing frozen evidence becomes INDETERMINATE.
+    """
     replay_result = run_replay(work_order, baseline_anchor)
+    observed_outputs = list(replay_result["observed_outputs"])
+
+    locality = work_order.get("locality")
+    time_window = work_order.get("time_window")
+    if validator is None and locality and time_window and locality_engine is not None:
+        try:
+            observed_outputs.append(
+                locality_engine.analyze(locality, time_window, baseline_anchor)
+            )
+        except (SnapshotMissing, BaselineMissing, BaselineIncomplete):
+            pass
 
     if validator is None:
         semantic_validation, anomalies = _quadratic_family_validation(
             work_order,
             baseline_anchor,
-            replay_result["observed_outputs"],
+            observed_outputs,
             replay_result["evidence_refs"],
         )
     else:
         semantic_validation = validator.validate(
             work_order,
-            replay_result["observed_outputs"],
+            observed_outputs,
             replay_result["evidence_refs"],
         )
         anomalies = []
@@ -85,7 +121,7 @@ def run_replay_handoff(
     return build_receipt(
         work_order=work_order,
         baseline_anchor=baseline_anchor,
-        observed_outputs=replay_result["observed_outputs"],
+        observed_outputs=observed_outputs,
         evidence_refs=replay_result["evidence_refs"],
         execution_trace=replay_result["execution_trace"],
         semantic_validation=semantic_validation,

--- a/revenue_agent/replay/validators/base.py
+++ b/revenue_agent/replay/validators/base.py
@@ -16,23 +16,12 @@ class Validator(ABC):
         work_order: Dict[str, Any],
         observed_outputs: List[Dict[str, Any]],
     ) -> Dict[str, Any]:
-        """
-        Return a dimension result with this exact semantic shape:
-
-        {
-            "name": str,          # must equal self.name
-            "status": "PASS" | "FAIL",
-            "score": float,       # bounded [0, 1]
-            "reason": str,        # optional but recommended
-        }
-
-        A validator result is evidence/observability only. It creates no authority.
-        """
+        """Return non-authoritative PASS, FAIL, or INDETERMINATE evidence."""
         raise NotImplementedError
 
     def result(self, status: str, score: float, reason: str = "") -> Dict[str, Any]:
-        if status not in {"PASS", "FAIL"}:
-            raise ValueError("validator status must be PASS or FAIL")
+        if status not in {"PASS", "FAIL", "INDETERMINATE"}:
+            raise ValueError("validator status must be PASS, FAIL, or INDETERMINATE")
         bounded = min(1.0, max(0.0, float(score)))
         result: Dict[str, Any] = {
             "name": self.name,

--- a/revenue_agent/schemas/anomaly_observation.schema.json
+++ b/revenue_agent/schemas/anomaly_observation.schema.json
@@ -7,7 +7,10 @@
   "additionalProperties": false,
   "properties": {
     "where": {"type": "string", "pattern": "^R[0-5]-[A-Z0-9]+$"},
-    "when": {"type": "string", "format": "date-time"},
+    "when": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$"
+    },
     "what": {
       "type": "string",
       "enum": ["weather_alert", "infrastructure_outage", "emergency_broadcast", "traffic_disruption"]

--- a/revenue_agent/schemas/anomaly_observation.schema.json
+++ b/revenue_agent/schemas/anomaly_observation.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jsonwisdom.dev/computerwisdom/revenue-agent/anomaly_observation.schema.json",
+  "title": "Locality Anomaly Observation V0.1",
+  "type": "object",
+  "required": ["where", "when", "what", "baseline", "delta", "corroboration", "confidence", "severity"],
+  "additionalProperties": false,
+  "properties": {
+    "where": {"type": "string", "pattern": "^R[0-5]-[A-Z0-9]+$"},
+    "when": {"type": "string", "format": "date-time"},
+    "what": {
+      "type": "string",
+      "enum": ["weather_alert", "infrastructure_outage", "emergency_broadcast", "traffic_disruption"]
+    },
+    "baseline": {"type": "number"},
+    "delta": {"type": "number"},
+    "corroboration": {"type": "integer", "minimum": 0},
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+    "severity": {"type": "string", "enum": ["LOW", "MEDIUM", "HIGH"]},
+    "sources": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1, "maxLength": 160},
+      "maxItems": 5
+    }
+  }
+}

--- a/revenue_agent/schemas/receipt.schema.json
+++ b/revenue_agent/schemas/receipt.schema.json
@@ -2,24 +2,14 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://jsonwisdom.dev/computerwisdom/revenue-agent/receipt.schema.json",
   "title": "JAYWISDOM RePlay Handoff Receipt V0.1",
-  "description": "Deterministic replay receipt with Quadratic Family v0.2 observability. It records execution, dimensional validation, and anomaly evidence but never creates authority.",
+  "description": "Deterministic replay receipt with Quadratic Family v0.2 observability and optional locality evidence. It never creates authority.",
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "receipt_version",
-    "work_order_id",
-    "parent_id",
-    "work_order_sha256",
-    "baseline_anchor",
-    "input_claim_sha256",
-    "quadratic_weight",
-    "replay_runner_version",
-    "observed_outputs",
-    "evidence_refs",
-    "execution_trace",
-    "semantic_validation",
-    "anomalies",
-    "receipt_digest"
+    "receipt_version", "work_order_id", "parent_id", "work_order_sha256",
+    "baseline_anchor", "input_claim_sha256", "quadratic_weight",
+    "replay_runner_version", "observed_outputs", "evidence_refs",
+    "execution_trace", "semantic_validation", "anomalies", "receipt_digest"
   ],
   "$defs": {
     "anomaly": {
@@ -27,27 +17,10 @@
       "additionalProperties": false,
       "required": ["type", "severity", "description"],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "missing_required_field",
-            "unexpected_output_shape",
-            "temporal_drift",
-            "evidence_mismatch",
-            "logical_contradiction"
-          ]
-        },
-        "severity": {
-          "type": "string",
-          "enum": ["LOW", "MEDIUM", "HIGH"]
-        },
-        "description": {
-          "type": "string",
-          "minLength": 5
-        },
-        "field": {"type": "string"},
-        "expected": {},
-        "actual": {}
+        "type": {"type": "string", "enum": ["missing_required_field", "unexpected_output_shape", "temporal_drift", "evidence_mismatch", "logical_contradiction"]},
+        "severity": {"type": "string", "enum": ["LOW", "MEDIUM", "HIGH"]},
+        "description": {"type": "string", "minLength": 5},
+        "field": {"type": "string"}, "expected": {}, "actual": {}
       }
     },
     "dimension": {
@@ -55,136 +28,82 @@
       "additionalProperties": false,
       "required": ["status", "score"],
       "properties": {
-        "status": {
-          "type": "string",
-          "enum": ["PASS", "FAIL"]
-        },
-        "score": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1
-        },
-        "reason": {
-          "type": "string",
-          "minLength": 1
-        }
+        "status": {"type": "string", "enum": ["PASS", "FAIL", "INDETERMINATE"]},
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "reason": {"type": "string", "minLength": 1}
+      }
+    },
+    "localityObservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["where", "when", "what", "baseline", "delta", "corroboration", "confidence", "severity"],
+      "properties": {
+        "where": {"type": "string", "pattern": "^R[0-5]-[A-Z0-9]+$"},
+        "when": {"type": "string", "format": "date-time"},
+        "what": {"type": "string", "enum": ["weather_alert", "infrastructure_outage", "emergency_broadcast", "traffic_disruption"]},
+        "baseline": {"type": "number"}, "delta": {"type": "number"},
+        "corroboration": {"type": "integer", "minimum": 0},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "severity": {"type": "string", "enum": ["LOW", "MEDIUM", "HIGH"]},
+        "sources": {"type": "array", "items": {"type": "string", "minLength": 1, "maxLength": 160}, "maxItems": 5}
+      }
+    },
+    "localityAnomalyReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "engine_version", "locality", "time_window", "snapshot_digest", "baseline_digest", "observations"],
+      "properties": {
+        "source": {"type": "string", "const": "locality_anomaly"},
+        "engine_version": {"type": "string", "const": "v0.1"},
+        "locality": {"type": "string", "pattern": "^R[0-5]-[A-Z0-9]+$"},
+        "time_window": {"type": "string", "pattern": "^[1-9][0-9]*(h|d)$"},
+        "snapshot_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "baseline_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "observations": {"type": "array", "items": {"$ref": "#/$defs/localityObservation"}}
       }
     }
   },
   "properties": {
-    "receipt_version": {
-      "type": "string",
-      "const": "REPLAY_HANDOFF_V0_1"
-    },
-    "work_order_id": {
-      "type": "string",
-      "minLength": 1
-    },
-    "parent_id": {
-      "type": ["string", "null"]
-    },
-    "work_order_sha256": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{64}$"
-    },
-    "baseline_anchor": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{40}$"
-    },
-    "input_claim_sha256": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{64}$"
-    },
-    "quadratic_weight": {
-      "type": "number",
-      "minimum": 0
-    },
-    "replay_runner_version": {
-      "type": "string",
-      "const": "REPLAY_RUNNER_V0_1"
-    },
-    "observed_outputs": {
-      "type": "array",
-      "items": {"type": "object"}
-    },
-    "evidence_refs": {
-      "type": "array",
-      "minItems": 1,
-      "items": {"type": "string", "minLength": 1}
-    },
+    "receipt_version": {"type": "string", "const": "REPLAY_HANDOFF_V0_1"},
+    "work_order_id": {"type": "string", "minLength": 1},
+    "parent_id": {"type": ["string", "null"]},
+    "work_order_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "baseline_anchor": {"type": "string", "pattern": "^[a-f0-9]{40}$"},
+    "input_claim_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "quadratic_weight": {"type": "number", "minimum": 0},
+    "replay_runner_version": {"type": "string", "const": "REPLAY_RUNNER_V0_1"},
+    "observed_outputs": {"type": "array", "items": {"type": "object"}},
+    "evidence_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
     "execution_trace": {
-      "type": "object",
-      "additionalProperties": false,
+      "type": "object", "additionalProperties": false,
       "properties": {
         "seed": {"type": "integer", "minimum": 0},
-        "work_order_hash": {
-          "type": "string",
-          "pattern": "^[a-f0-9]{64}$"
-        },
-        "implementation_hash": {
-          "type": "string",
-          "pattern": "^[a-f0-9]{64}$"
-        }
+        "work_order_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "implementation_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
       },
       "required": ["seed", "work_order_hash", "implementation_hash"]
     },
     "semantic_validation": {
-      "type": "object",
-      "additionalProperties": false,
+      "type": "object", "additionalProperties": false,
       "properties": {
-        "result": {
-          "type": "string",
-          "enum": ["PASS", "FAIL"]
-        },
-        "reason": {
-          "type": "string",
-          "minLength": 1
-        },
+        "result": {"type": "string", "enum": ["PASS", "FAIL"]},
+        "reason": {"type": "string", "minLength": 1},
         "details": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "overall_status",
-            "dimensions",
-            "anomalies",
-            "aggregate_score",
-            "validator_version"
-          ],
+          "type": "object", "additionalProperties": false,
+          "required": ["overall_status", "dimensions", "anomalies", "aggregate_score", "validator_version"],
           "properties": {
-            "overall_status": {
-              "type": "string",
-              "enum": ["PASS", "FAIL", "ANOMALY", "INDETERMINATE"]
-            },
-            "dimensions": {
-              "type": "object",
-              "additionalProperties": {"$ref": "#/$defs/dimension"}
-            },
-            "anomalies": {
-              "type": "array",
-              "items": {"$ref": "#/$defs/anomaly"}
-            },
-            "aggregate_score": {
-              "type": "number",
-              "minimum": 0,
-              "maximum": 1,
-              "description": "Informational bounded RMS only; excluded from receipt digest computation and never authoritative."
-            },
-            "validator_version": {
-              "type": "string",
-              "const": "v0.2"
-            }
+            "overall_status": {"type": "string", "enum": ["PASS", "FAIL", "ANOMALY", "INDETERMINATE"]},
+            "dimensions": {"type": "object", "additionalProperties": {"$ref": "#/$defs/dimension"}},
+            "anomalies": {"type": "array", "items": {"$ref": "#/$defs/anomaly"}},
+            "aggregate_score": {"type": "number", "minimum": 0, "maximum": 1},
+            "validator_version": {"type": "string", "const": "v0.2"},
+            "anomaly_report": {"$ref": "#/$defs/localityAnomalyReport"}
           }
         }
       },
       "required": ["result", "reason"]
     },
-    "anomalies": {
-      "type": "array",
-      "items": {"$ref": "#/$defs/anomaly"}
-    },
-    "receipt_digest": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{64}$"
-    }
+    "anomalies": {"type": "array", "items": {"$ref": "#/$defs/anomaly"}},
+    "receipt_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
   }
 }

--- a/revenue_agent/schemas/receipt.schema.json
+++ b/revenue_agent/schemas/receipt.schema.json
@@ -39,7 +39,7 @@
       "required": ["where", "when", "what", "baseline", "delta", "corroboration", "confidence", "severity"],
       "properties": {
         "where": {"type": "string", "pattern": "^R[0-5]-[A-Z0-9]+$"},
-        "when": {"type": "string", "format": "date-time"},
+        "when": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$"},
         "what": {"type": "string", "enum": ["weather_alert", "infrastructure_outage", "emergency_broadcast", "traffic_disruption"]},
         "baseline": {"type": "number"}, "delta": {"type": "number"},
         "corroboration": {"type": "integer", "minimum": 0},

--- a/revenue_agent/schemas/work_order.schema.json
+++ b/revenue_agent/schemas/work_order.schema.json
@@ -5,86 +5,40 @@
   "description": "Atomic, institution-agnostic verification work unit. Economic priority metadata may route work but cannot affect verification outcome or create authority.",
   "type": "object",
   "additionalProperties": false,
+  "dependentRequired": {
+    "locality": ["time_window"],
+    "time_window": ["locality"]
+  },
   "required": [
-    "work_order_id",
-    "parent_id",
-    "claim_text",
-    "decomposition_version",
-    "verification_status",
-    "assumptions",
-    "evidence_requirements",
-    "method",
-    "acceptance_test",
-    "hazards",
-    "output_schema",
-    "replay_requirement",
-    "quadratic_weight",
-    "authority_created"
+    "work_order_id", "parent_id", "claim_text", "decomposition_version",
+    "verification_status", "assumptions", "evidence_requirements", "method",
+    "acceptance_test", "hazards", "output_schema", "replay_requirement",
+    "quadratic_weight", "authority_created"
   ],
   "properties": {
-    "work_order_id": {
+    "work_order_id": {"type": "string", "pattern": "^wo_[a-f0-9]{16}$"},
+    "parent_id": {"type": ["string", "null"], "minLength": 1},
+    "claim_text": {"type": "string", "minLength": 1},
+    "decomposition_version": {"type": "string", "const": "DECOMPOSITION_V0_1"},
+    "verification_status": {"type": "string", "const": "UNVERIFIED"},
+    "assumptions": {"type": "array", "items": {"type": "string"}, "default": []},
+    "evidence_requirements": {"type": "array", "items": {"type": "string"}, "default": []},
+    "method": {"type": "string", "const": "PENDING"},
+    "acceptance_test": {"type": "string", "const": "PENDING"},
+    "hazards": {"type": "array", "items": {"type": "string"}, "default": []},
+    "output_schema": {"type": "string", "const": "PENDING"},
+    "replay_requirement": {"type": "string", "const": "REQUIRED"},
+    "quadratic_weight": {"type": "number", "minimum": 0},
+    "authority_created": {"type": "boolean", "const": false},
+    "locality": {
       "type": "string",
-      "pattern": "^wo_[a-f0-9]{16}$",
-      "description": "Deterministic identifier derived from parent_id and normalized claim text."
+      "pattern": "^R[0-5]-[A-Z0-9]+$",
+      "description": "Privacy-preserving ring-locality identifier only; names and addresses are prohibited."
     },
-    "parent_id": {
-      "type": ["string", "null"],
-      "minLength": 1,
-      "description": "Optional parent claim or work-order identifier."
-    },
-    "claim_text": {
+    "time_window": {
       "type": "string",
-      "minLength": 1,
-      "description": "Precisely scoped claim entering verification. Source identity does not confer evidentiary weight."
-    },
-    "decomposition_version": {
-      "type": "string",
-      "const": "DECOMPOSITION_V0_1"
-    },
-    "verification_status": {
-      "type": "string",
-      "const": "UNVERIFIED"
-    },
-    "assumptions": {
-      "type": "array",
-      "items": {"type": "string"},
-      "default": []
-    },
-    "evidence_requirements": {
-      "type": "array",
-      "items": {"type": "string"},
-      "default": []
-    },
-    "method": {
-      "type": "string",
-      "const": "PENDING"
-    },
-    "acceptance_test": {
-      "type": "string",
-      "const": "PENDING"
-    },
-    "hazards": {
-      "type": "array",
-      "items": {"type": "string"},
-      "default": []
-    },
-    "output_schema": {
-      "type": "string",
-      "const": "PENDING"
-    },
-    "replay_requirement": {
-      "type": "string",
-      "const": "REQUIRED"
-    },
-    "quadratic_weight": {
-      "type": "number",
-      "minimum": 0,
-      "description": "Token-weighted priority signal from $JAYWISDOM router. Does NOT affect verification outcome."
-    },
-    "authority_created": {
-      "type": "boolean",
-      "const": false,
-      "description": "Decomposition never creates epistemic, legal, or computational authority."
+      "pattern": "^[1-9][0-9]*(h|d)$",
+      "description": "Locality evidence scope label, such as 24h or 7d."
     }
   }
 }

--- a/revenue_agent/tests/test_locality_anomaly.py
+++ b/revenue_agent/tests/test_locality_anomaly.py
@@ -1,0 +1,304 @@
+import copy
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from anomaly.baseline import BaselineStore, ImmutableStoreConflict, SnapshotStore
+from anomaly.engine import LocalityAnomalyEngine
+from anomaly.signals import NWSWeatherAlertsSignal
+from anomaly.validator import LocalityAnomalyValidator
+from decomposition.agent import decompose_claim
+from replay.handoff import run_replay_handoff
+
+BASELINE = "6caa38221c9f509c3ebe895a1c9ec0b45b9d2f93"
+LOCALITY = "R2-COUNTY042"
+WINDOW = "24h"
+OBSERVATION_SCHEMA = json.loads(
+    (ROOT / "schemas" / "anomaly_observation.schema.json").read_text(encoding="utf-8")
+)
+RECEIPT_SCHEMA = json.loads(
+    (ROOT / "schemas" / "receipt.schema.json").read_text(encoding="utf-8")
+)
+
+
+class FakeSignals:
+    def __init__(self, signals=None):
+        self.calls = 0
+        self.signals = signals or [
+            {
+                "what": "weather_alert",
+                "when": "2026-08-08T18:00:00+00:00",
+                "value": 1.0,
+                "confidence": 0.9,
+                "severity": "MEDIUM",
+                "sources": ["nws:sha256:" + "a" * 64],
+            }
+        ]
+
+    def fetch_all(self, locality, time_window):
+        assert locality == LOCALITY
+        assert time_window == WINDOW
+        self.calls += 1
+        return copy.deepcopy(self.signals)
+
+
+def make_engine(tmp_path, signals=None):
+    provider = FakeSignals(signals)
+    snapshots = SnapshotStore(tmp_path / "snapshots")
+    baselines = BaselineStore(tmp_path / "baselines")
+    engine = LocalityAnomalyEngine(provider, snapshots, baselines)
+    return engine, provider, snapshots, baselines
+
+
+def locality_work_order():
+    work_order = decompose_claim(
+        "Locality-scoped replay fixture",
+        parent_id="fixture_parent",
+        token_weight=42.0,
+    )[0]
+    work_order["locality"] = LOCALITY
+    work_order["time_window"] = WINDOW
+    return work_order
+
+
+def freeze_default(engine, baselines):
+    engine.capture_snapshot(LOCALITY, WINDOW, BASELINE)
+    baselines.put(LOCALITY, WINDOW, BASELINE, {"weather_alert": 0.0})
+
+
+def test_no_pii_in_observations(tmp_path):
+    engine, _, _, baselines = make_engine(tmp_path)
+    freeze_default(engine, baselines)
+    report = engine.analyze(LOCALITY, WINDOW, BASELINE)
+
+    assert report["locality"] == LOCALITY
+    for observation in report["observations"]:
+        jsonschema.Draft7Validator(OBSERVATION_SCHEMA).validate(observation)
+        rendered = json.dumps(observation, sort_keys=True).lower()
+        assert "person" not in rendered
+        assert "address" not in rendered
+        assert "headline" not in rendered
+        assert "description" not in rendered
+        assert observation["where"] == LOCALITY
+
+
+def test_replay_is_deterministic_from_frozen_snapshot(tmp_path):
+    engine, provider, _, baselines = make_engine(tmp_path)
+    freeze_default(engine, baselines)
+
+    first = engine.analyze(LOCALITY, WINDOW, BASELINE)
+    second = engine.analyze(LOCALITY, WINDOW, BASELINE)
+
+    assert first == second
+    assert first["snapshot_digest"] == second["snapshot_digest"]
+    assert first["baseline_digest"] == second["baseline_digest"]
+    assert provider.calls == 1
+
+
+def test_capture_snapshot_never_refetches_same_key(tmp_path):
+    engine, provider, _, _ = make_engine(tmp_path)
+    first = engine.capture_snapshot(LOCALITY, WINDOW, BASELINE)
+    second = engine.capture_snapshot(LOCALITY, WINDOW, BASELINE)
+
+    assert provider.calls == 1
+    assert first == second
+
+
+def test_snapshot_store_is_immutable(tmp_path):
+    _, _, snapshots, _ = make_engine(tmp_path)
+    signals_a = [
+        {
+            "what": "weather_alert",
+            "when": "2026-08-08T18:00:00+00:00",
+            "value": 1.0,
+            "confidence": 0.9,
+            "severity": "LOW",
+            "sources": ["nws:sha256:" + "a" * 64],
+        }
+    ]
+    signals_b = copy.deepcopy(signals_a)
+    signals_b[0]["severity"] = "HIGH"
+
+    snapshots.put(LOCALITY, WINDOW, BASELINE, signals_a)
+    with pytest.raises(ImmutableStoreConflict):
+        snapshots.put(LOCALITY, WINDOW, BASELINE, signals_b)
+
+
+def test_validator_ignores_attention_score():
+    validator = LocalityAnomalyValidator()
+    work_order = {"locality": LOCALITY, "time_window": WINDOW}
+    report = {
+        "source": "locality_anomaly",
+        "engine_version": "v0.1",
+        "locality": LOCALITY,
+        "time_window": WINDOW,
+        "snapshot_digest": "a" * 64,
+        "baseline_digest": "b" * 64,
+        "observations": [
+            {
+                "where": LOCALITY,
+                "when": "2026-08-08T18:00:00+00:00",
+                "what": "weather_alert",
+                "baseline": 0.0,
+                "delta": 1.0,
+                "corroboration": 3,
+                "confidence": 0.9,
+                "severity": "HIGH",
+                "sources": ["nws:sha256:" + "a" * 64],
+                "attention_score": 999999,
+            }
+        ],
+    }
+
+    result = validator.validate(work_order, [report])
+
+    assert result["status"] == "FAIL"
+    assert "attention_score" not in json.dumps(result, sort_keys=True)
+
+
+def test_mismatched_report_is_indeterminate():
+    validator = LocalityAnomalyValidator()
+    work_order = {"locality": LOCALITY, "time_window": WINDOW}
+    report = {
+        "source": "locality_anomaly",
+        "engine_version": "v0.1",
+        "locality": "R2-COUNTY999",
+        "time_window": WINDOW,
+        "snapshot_digest": "a" * 64,
+        "baseline_digest": "b" * 64,
+        "observations": [],
+    }
+
+    result = validator.validate(work_order, [report])
+    assert result["status"] == "INDETERMINATE"
+    assert "details" not in result
+
+
+def test_locality_without_frozen_report_is_indeterminate():
+    result = LocalityAnomalyValidator().validate(
+        {"locality": LOCALITY, "time_window": WINDOW},
+        [],
+    )
+    assert result["status"] == "INDETERMINATE"
+    assert result["score"] == 0.5
+
+
+def test_handoff_binds_locality_report_without_core_false_anomaly(tmp_path):
+    engine, _, _, baselines = make_engine(tmp_path)
+    freeze_default(engine, baselines)
+    work_order = locality_work_order()
+
+    receipt = run_replay_handoff(
+        work_order,
+        BASELINE,
+        locality_engine=engine,
+    )
+
+    details = receipt["semantic_validation"]["details"]
+    assert details["dimensions"]["locality_anomaly"]["status"] == "PASS"
+    assert details["anomaly_report"]["source"] == "locality_anomaly"
+    assert receipt["anomalies"] == []
+    assert "authority_created" not in receipt
+    jsonschema.Draft202012Validator(RECEIPT_SCHEMA).validate(receipt)
+
+
+def test_severe_locality_signal_fails_dimension_not_authority(tmp_path):
+    severe = [
+        {
+            "what": "weather_alert",
+            "when": "2026-08-08T18:00:00+00:00",
+            "value": 1.0,
+            "confidence": 0.95,
+            "severity": "HIGH",
+            "sources": [
+                "nws:sha256:" + "a" * 64,
+                "nws:sha256:" + "b" * 64,
+            ],
+        }
+    ]
+    engine, _, _, baselines = make_engine(tmp_path, severe)
+    freeze_default(engine, baselines)
+
+    receipt = run_replay_handoff(
+        locality_work_order(),
+        BASELINE,
+        locality_engine=engine,
+    )
+
+    details = receipt["semantic_validation"]["details"]
+    assert details["dimensions"]["locality_anomaly"]["status"] == "FAIL"
+    assert receipt["semantic_validation"]["result"] == "FAIL"
+    assert "authority_created" not in receipt
+
+
+def test_non_locality_work_order_preserves_original_dimension_set():
+    work_order = decompose_claim(
+        "Replay fixture claim",
+        parent_id="fixture_parent",
+        token_weight=42.0,
+    )[0]
+    receipt = run_replay_handoff(work_order, BASELINE)
+
+    assert set(receipt["semantic_validation"]["details"]["dimensions"]) == {
+        "dependency",
+        "range",
+        "schema",
+    }
+    assert "anomaly_report" not in receipt["semantic_validation"]["details"]
+
+
+def test_nws_fetcher_strips_raw_free_text_and_sets_required_headers():
+    payload = {
+        "features": [
+            {
+                "id": "https://api.weather.gov/alerts/example",
+                "properties": {
+                    "sent": "2026-08-08T18:00:00+00:00",
+                    "severity": "Severe",
+                    "certainty": "Likely",
+                    "headline": "Private-looking free text must not survive",
+                    "description": "123 Example Street and a person's name",
+                    "areaDesc": "Named place that must not survive",
+                },
+            }
+        ]
+    }
+    seen = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(payload).encode("utf-8")
+
+    def opener(request, timeout):
+        seen["url"] = request.full_url
+        seen["headers"] = dict(request.header_items())
+        seen["timeout"] = timeout
+        return Response()
+
+    signal = NWSWeatherAlertsSignal(
+        {LOCALITY: {"nws_zone": "MNC145"}},
+        opener=opener,
+    )
+    observations = signal.fetch_all(LOCALITY, WINDOW)
+
+    assert "zone=MNC145" in seen["url"]
+    assert any(key.lower() == "user-agent" for key in seen["headers"])
+    assert observations[0]["what"] == "weather_alert"
+    assert observations[0]["severity"] == "HIGH"
+    assert observations[0]["confidence"] == 0.9
+    rendered = json.dumps(observations, sort_keys=True)
+    assert "Private-looking" not in rendered
+    assert "123 Example Street" not in rendered
+    assert "Named place" not in rendered


### PR DESCRIPTION
## What changed

Adds `LOCALITY_ANOMALY_ENGINE_V0_1` as a privacy-preserving, deterministic evidence lane over the existing Quadratic Family replay surface.

- adds immutable file-backed signal snapshots keyed by locality + time window + baseline anchor
- separates live acquisition (`capture_snapshot`) from deterministic replay analysis (`analyze`); replay never calls NWS
- adds a public NWS active-alert adapter using explicit ring-locality → NWS-zone controls
- strips raw NWS headline/description/area text before persistence and stores only hashed source references
- adds a pure R0-R5 ring-locality resolver
- adds digest-versioned immutable baseline storage
- adds `LocalityAnomalyValidator` with `PASS | FAIL | INDETERMINATE` evidence states
- severe status requires structured `confidence > 0.8`, `corroboration >= 2`, and `severity == HIGH`
- sanitizes locality reports so `attention_score` cannot enter validator output
- conditionally adds locality validation only for work orders carrying paired `locality` + `time_window`
- preserves the existing dependency/range/schema dimension set for non-locality work orders
- adds strict PII-resistant anomaly observation and optional receipt `anomaly_report` schemas
- adds 11 locality tests and wires them into the existing Revenue Agent Qualification Harness

## Replay boundary

```text
LIVE PUBLIC API
  -> CAPTURE ONCE
  -> IMMUTABLE SNAPSHOT + SHA256
  -> REPLAY / ANALYZE SNAPSHOT ONLY
  -> STRUCTURED OBSERVATIONS
  -> NON-AUTHORITATIVE VALIDATOR DIMENSION
  -> DIGEST-BOUND RECEIPT EVIDENCE
```

A repeated capture for the same `(locality, time_window, baseline_anchor)` reads the frozen snapshot before touching the network. Existing bytes cannot be silently replaced.

## Privacy boundary

```text
LOCALITY = R0-R5 RING ID ONLY
PERSON / ADDRESS FIELDS = PROHIBITED
FREE-TEXT EVENT DESCRIPTIONS = NOT PERSISTED
NWS SOURCE IDS = HASHED
ADDITIONAL OBSERVATION FIELDS = REJECTED
```

The first signal adapter consumes public NWS alerts but stores no raw headline, description, area description, address, or person-level field.

## Epistemic firewall

```text
ANOMALY != THREAT / CRIME / INTENT
PUBLIC SIGNAL != VERIFIED TRUTH
ATTENTION SCORE != AUTHORITY
REPLAY != LIVE ACQUISITION
INDETERMINATE != FAIL
AUTHORITY_CREATED = FALSE
REAL_REVENUE_PROVEN = FALSE
```

Locality evidence may affect the non-authoritative semantic validation result under the explicit validator rule, but it creates no legal, emergency-dispatch, identity, payment, or execution authority.

## Compatibility

Non-locality work orders retain the original three Quadratic Family dimensions (`dependency`, `range`, `schema`). `validator_version` remains `v0.2`; the locality engine has its own `engine_version = v0.1`.

A first CI pass exposed a strict-AJV compatibility issue in the newly merged Game Receipt Renderer: JSON Schema `format: date-time` required an optional formats plugin. The locality schemas were corrected to use an explicit RFC3339-shaped regex instead, without adding renderer dependencies or weakening receipt closure. The renderer gate then returned green.

## V0.1 limitation

The NWS adapter captures the current active-alert set. `time_window` is therefore a frozen evidence-scope label in v0.1 rather than a historical-query guarantee. Historical window semantics require a separate source adapter or archived signal source.

## Validation

Final head: `277f4213c49078e9181f7a6e5212d30d8c44e5ec`.

Revenue Agent Qualification Harness: **48 passed / 0 failed**.

All observed PR-triggered repository workflows on the final head are green:

- Revenue Agent Qualification Harness
- Agentic Game Receipt Renderer
- `verify`
- Receipt Core
- MANIC Validation Gate
- watch-trigger-engine-v0-1
- Verify Canon Chain Receipt
- Federal AI Observer Advisory Sidecar

The PR remains draft and creates no authority.