### PR TITLE
Add canonical prompt spine v0.1

### DIFF
--- a/revenue_agent/prompt/digest.py
+++ b/revenue_agent/prompt/digest.py
@@ -1,0 +1,28 @@
+import hashlib
+import json
+from typing import Any, Dict
+
+
+SPINE_VERSION = "v0.1"
+
+
+def compute_exchange_digest(
+    prompt: str,
+    model_response: Dict[str, Any],
+    spine_version: str = SPINE_VERSION,
+) -> str:
+    """Bind spine version and canonical exchange fields with SHA-256."""
+    canonical = json.dumps(
+        {
+            "spine_version": spine_version,
+            "prompt": prompt,
+            "model_answer": model_response["answer"],
+            "evidence_summary": model_response["evidence_summary"],
+            "confidence": model_response["confidence"],
+            "model_identity": model_response["model_id"],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/revenue_agent/prompt/engine.py
+++ b/revenue_agent/prompt/engine.py
@@ -1,0 +1,25 @@
+from typing import List
+
+
+def _normalize_items(items: List[str]) -> List[str]:
+    """Deduplicate, strip, remove empties, sort canonically."""
+    return sorted({i.strip() for i in items if i.strip()})
+
+
+def build_canonical_prompt(
+    question: str,
+    known_facts: List[str],
+    unknowns: List[str],
+    constraints: List[str],
+) -> str:
+    """Deterministic prompt construction. Same inputs -> identical bytes."""
+    sections = [
+        "[ROOT]",
+        f"[QUESTION]\n{question.strip()}",
+        "[KNOWN FACTS]\n" + "\n".join(f"- {f}" for f in _normalize_items(known_facts)),
+        "[UNKNOWNS]\n" + "\n".join(f"- {u}" for u in _normalize_items(unknowns)),
+        "[CONSTRAINTS]\n" + "\n".join(f"- {c}" for c in _normalize_items(constraints)),
+        "[INSTRUCTIONS]\nProvide your answer below. Then provide evidence/reasoning summary. Finally state confidence as float 0-1.",
+        "[MODEL ANSWER]",
+    ]
+    return "\n\n".join(sections)

--- a/revenue_agent/prompt/parser.py
+++ b/revenue_agent/prompt/parser.py
@@ -1,0 +1,84 @@
+from typing import Any, Dict
+
+
+REQUIRED_SECTIONS = ("answer", "summary", "confidence")
+
+SECTION_HEADERS = {
+    "[MODEL ANSWER]": "answer",
+    "[EVIDENCE / REASONING SUMMARY]": "summary",
+    "[CONFIDENCE": "confidence",
+}
+
+
+class ParseError(ValueError):
+    """Raised when model output violates the spine contract."""
+
+
+def _inline_content(line: str, header: str, section: str) -> str:
+    """Return content following a recognized section header."""
+    if section != "confidence":
+        return line[len(header) :].strip()
+
+    closing_bracket = line.find("]", len(header))
+    if closing_bracket == -1:
+        return ""
+    return line[closing_bracket + 1 :].strip()
+
+
+def parse_model_response(raw_output: str, model_id: str) -> Dict[str, Any]:
+    """Extract and validate deterministic fields from a model response."""
+    if not isinstance(raw_output, str) or not raw_output.strip():
+        raise ParseError(f"Model {model_id}: empty or non-string output")
+
+    sections: Dict[str, list] = {}
+    current_section = None
+
+    for line in raw_output.split("\n"):
+        stripped = line.strip()
+
+        matched = next(
+            (
+                (header, key)
+                for header, key in SECTION_HEADERS.items()
+                if stripped.startswith(header)
+            ),
+            None,
+        )
+        if matched:
+            header, current_section = matched
+            inline = _inline_content(stripped, header, current_section)
+            if inline:
+                sections.setdefault(current_section, []).append(inline)
+            continue
+
+        if current_section and stripped:
+            sections.setdefault(current_section, []).append(stripped)
+
+    missing = [
+        section
+        for section in REQUIRED_SECTIONS
+        if section not in sections or not sections[section]
+    ]
+    if missing:
+        raise ParseError(
+            f"Model {model_id}: missing or empty required sections: {missing}"
+        )
+
+    conf_raw = " ".join(sections["confidence"]).strip()
+    try:
+        confidence = float(conf_raw)
+    except (TypeError, ValueError):
+        raise ParseError(
+            f"Model {model_id}: invalid confidence format '{conf_raw}'"
+        )
+    if not 0.0 <= confidence <= 1.0:
+        raise ParseError(
+            f"Model {model_id}: confidence {confidence} out of range [0.0, 1.0]"
+        )
+
+    return {
+        "answer": "\n".join(sections["answer"]).strip(),
+        "summary": "\n".join(sections["summary"]).strip(),
+        "confidence": confidence,
+        "model_id": model_id,
+    }

--- a/revenue_agent/tests/test_parser.py
+++ b/revenue_agent/tests/test_parser.py
@@ -1,0 +1,91 @@
+import pytest
+
+from revenue_agent.prompt.digest import compute_exchange_digest
+from revenue_agent.prompt.parser import ParseError, parse_model_response
+
+
+def _valid_response(confidence: str = "0.85") -> str:
+    return f"""[MODEL ANSWER]
+The answer.
+
+[EVIDENCE / REASONING SUMMARY]
+The evidence summary.
+
+[CONFIDENCE]
+{confidence}"""
+
+
+def test_valid_full_response():
+    assert parse_model_response(_valid_response(), "model-a") == {
+        "answer": "The answer.",
+        "summary": "The evidence summary.",
+        "confidence": 0.85,
+        "model_id": "model-a",
+    }
+
+
+def test_missing_section_raises():
+    raw = "[MODEL ANSWER]\nA\n[CONFIDENCE]\n0.5"
+    with pytest.raises(ParseError, match="summary"):
+        parse_model_response(raw, "model-a")
+
+
+def test_empty_section_raises():
+    raw = "[MODEL ANSWER]\n[EVIDENCE / REASONING SUMMARY]\nS\n[CONFIDENCE]\n0.5"
+    with pytest.raises(ParseError, match="answer"):
+        parse_model_response(raw, "model-a")
+
+
+def test_invalid_confidence_format():
+    with pytest.raises(ParseError, match="invalid confidence format"):
+        parse_model_response(_valid_response("high"), "model-a")
+
+
+@pytest.mark.parametrize("confidence", ["-0.01", "1.01"])
+def test_confidence_out_of_range(confidence):
+    with pytest.raises(ParseError, match=r"out of range \[0.0, 1.0\]"):
+        parse_model_response(_valid_response(confidence), "model-a")
+
+
+def test_inline_confidence():
+    raw = _valid_response().replace("[CONFIDENCE]\n0.85", "[CONFIDENCE] 0.9")
+    assert parse_model_response(raw, "model-a")["confidence"] == 0.9
+
+
+def test_whitespace_normalization():
+    spaced = """  [MODEL ANSWER]  
+  The answer.  
+
+ [EVIDENCE / REASONING SUMMARY]
+ The evidence summary. 
+
+ [CONFIDENCE]  0.85  """
+    assert parse_model_response(spaced, "model-a") == parse_model_response(
+        _valid_response(), "model-a"
+    )
+
+
+@pytest.mark.parametrize("raw_output", [None, 7, {}, []])
+def test_non_string_input_raises(raw_output):
+    with pytest.raises(ParseError, match="empty or non-string output"):
+        parse_model_response(raw_output, "model-a")
+
+
+def test_field_names_match_digest():
+    parsed = parse_model_response(_valid_response(), "model-a")
+    digest_input = {
+        "answer": parsed["answer"],
+        "evidence_summary": parsed["summary"],
+        "confidence": parsed["confidence"],
+        "model_id": parsed["model_id"],
+    }
+    assert set(parsed) == {"answer", "summary", "confidence", "model_id"}
+    assert len(compute_exchange_digest("prompt", digest_input)) == 64
+
+
+@pytest.mark.parametrize(
+    "header", ["[CONFIDENCE:] 0.9", "[CONFIDENCE (0-1)] 0.9"]
+)
+def test_confidence_prefix_variants(header):
+    raw = _valid_response().replace("[CONFIDENCE]\n0.85", header)
+    assert parse_model_response(raw, "model-a")["confidence"] == 0.9

--- a/revenue_agent/tests/test_prompt_digest.py
+++ b/revenue_agent/tests/test_prompt_digest.py
@@ -1,0 +1,27 @@
+from revenue_agent.prompt.digest import compute_exchange_digest
+
+
+def _response(evidence_summary: str = "S") -> dict:
+    return {
+        "answer": "A",
+        "evidence_summary": evidence_summary,
+        "confidence": 0.5,
+        "model_id": "M",
+    }
+
+
+def test_digest_deterministic_for_identical_exchange():
+    prompt = "P"
+    assert compute_exchange_digest(prompt, _response()) == compute_exchange_digest(prompt, _response())
+
+
+def test_digest_changes_when_evidence_summary_changes():
+    prompt = "P"
+    assert compute_exchange_digest(prompt, _response("S1")) != compute_exchange_digest(prompt, _response("S2"))
+
+
+def test_digest_model_response_key_order_independent():
+    prompt = "P"
+    r1 = {"answer": "A", "evidence_summary": "S", "confidence": 0.5, "model_id": "M"}
+    r2 = {"model_id": "M", "confidence": 0.5, "evidence_summary": "S", "answer": "A"}
+    assert compute_exchange_digest(prompt, r1) == compute_exchange_digest(prompt, r2)


### PR DESCRIPTION
## Scope

Completes the canonical multi-model prompt spine v0.1 as a test-first, authority-free protocol seam.

### Added
- `revenue_agent/prompt/engine.py`
  - deterministic prompt construction only
  - strips, removes empty entries, deduplicates, and sorts list inputs
  - fixed section ordering and whitespace
  - no timestamps, consensus, authority, or digest logic
- `revenue_agent/prompt/digest.py`
  - SHA-256 exchange binding
  - binds `spine_version = v0.1`
  - binds canonical `evidence_summary` field
  - no timestamp inside digest
- `revenue_agent/prompt/parser.py`
  - strict deterministic extraction of answer / summary / confidence
  - confidence prefix variants supported without silent defaults
  - invalid, missing, empty, non-string, malformed, and out-of-range responses fail closed
- parser and digest contract tests

## Frozen boundary

```text
engine.py = canonical prompt bytes only
digest.py = exchange evidence binding only
parser.py = strict model-output extraction only
FIELD = evidence_summary
VERSION_BINDING = digest only
AUTHORITY_CREATED = FALSE
CONSENSUS = ABSENT
```

## Validation

Head: `f73c7e43d0b294a50856424ba2aac14bf28d296b`

All observed GitHub workflows are green, including:
- Revenue Agent Qualification Harness
- verify
- Receipt Core
- MANIC Validation Gate
- Verify Canon Chain Receipt
- watch-trigger-engine-v0-1
- Federal AI Observer Advisory Sidecar

Local parser contract suite: 15/15 PASS.

## Next bounded step

Add one end-to-end integration test that exercises:

`build prompt -> mock model response -> parse -> compute digest -> validate receipt/schema boundary`

Do this before wiring the spine into the game/replay handoff so integration failures remain attributable.

This PR remains authority-free and consensus-free.