### PR TITLE
Qualify canonical prompt spine end to end

### DIFF
--- a/.github/workflows/revenue-agent-eev-harness.yml
+++ b/.github/workflows/revenue-agent-eev-harness.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   qualification-contract:
-    name: EEV + RePlay + Locality Matrix + Authorization v0.1 contracts
+    name: EEV + RePlay + Locality Matrix + Authorization + Prompt Spine v0.1 contracts
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -43,6 +43,9 @@ jobs:
             revenue_agent/tests/test_locality_anomaly.py \
             revenue_agent/tests/test_locality_matrix_router.py \
             revenue_agent/tests/test_authorization_verifier.py \
+            revenue_agent/tests/test_parser.py \
+            revenue_agent/tests/test_prompt_digest.py \
+            revenue_agent/tests/test_canonical_spine.py \
             -rX
 
       - name: Emit qualified membrane state
@@ -58,6 +61,8 @@ jobs:
           echo "- Locality anomaly: LOCALITY_ANOMALY_ENGINE_V0_1" >> "$GITHUB_STEP_SUMMARY"
           echo "- Locality evidence: NON_AUTHORITATIVE" >> "$GITHUB_STEP_SUMMARY"
           echo "- Locality Matrix router: LOCALITY_MATRIX_ROUTER_V0_1" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Prompt spine: CANONICAL_PROMPT_SPINE_V0_1" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Prompt spine e2e: QUALIFIED" >> "$GITHUB_STEP_SUMMARY"
           echo "- Program mode: RESEARCH_AND_DEVELOPMENT" >> "$GITHUB_STEP_SUMMARY"
           echo "- Production execution: false" >> "$GITHUB_STEP_SUMMARY"
           echo "- Human review: deferred" >> "$GITHUB_STEP_SUMMARY"

--- a/revenue_agent/schemas/prompt_receipt.schema.json
+++ b/revenue_agent/schemas/prompt_receipt.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jsonwisdom.dev/computerwisdom/revenue-agent/prompt_receipt.schema.json",
+  "title": "Canonical Prompt Spine Receipt V0.1",
+  "description": "Authority-free receipt binding a deterministic prompt, strict parsed model response, and exchange digest.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "spine_version",
+    "question",
+    "known_facts",
+    "unknowns",
+    "constraints",
+    "model_responses",
+    "exchange_digest",
+    "timestamp"
+  ],
+  "properties": {
+    "spine_version": {"type": "string", "const": "v0.1"},
+    "question": {"type": "string", "minLength": 1},
+    "known_facts": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "unknowns": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "constraints": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "model_responses": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["model_id", "answer", "evidence_summary", "confidence"],
+        "properties": {
+          "model_id": {"type": "string", "minLength": 1},
+          "answer": {"type": "string", "minLength": 1},
+          "evidence_summary": {"type": "string", "minLength": 1},
+          "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0}
+        }
+      }
+    },
+    "exchange_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "timestamp": {"type": "string", "format": "date-time"}
+  }
+}

--- a/revenue_agent/tests/test_canonical_spine.py
+++ b/revenue_agent/tests/test_canonical_spine.py
@@ -1,0 +1,106 @@
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from revenue_agent.prompt.digest import compute_exchange_digest
+from revenue_agent.prompt.engine import build_canonical_prompt
+from revenue_agent.prompt.parser import ParseError, parse_model_response
+
+
+QUESTION = "What caused the 2023 St. Cloud power outage?"
+KNOWN_FACTS = [
+    "Transformer failure at Substation 7",
+    "Occurred 2023-11-15T14:30:00Z",
+]
+UNKNOWNS = ["Root cause of transformer failure", "Maintenance history"]
+CONSTRAINTS = [
+    "Use only public utility reports",
+    "No speculation beyond evidence",
+]
+
+# Synthetic frozen model output used only to qualify the deterministic spine.
+# Its substantive claims are not asserted as real-world facts by this test.
+MOCK_MODEL_RESPONSE = """[MODEL ANSWER]
+The 2023 St. Cloud power outage was caused by a catastrophic transformer failure 
+at Substation 7 due to insulation degradation from prolonged moisture exposure.
+
+[EVIDENCE / REASONING SUMMARY]
+Public utility report PU-2023-1142 documents insulation resistance testing showing 
+values below threshold for 6 months prior to failure. Weather records confirm 
+above-average precipitation in the preceding quarter. No maintenance was scheduled 
+despite flagged test results.
+
+[CONFIDENCE] 0.82"""
+
+EXPECTED_DIGEST = "a4bcb83d5cc5f4daa995b18a397d63eae1d7988ad3d0c2538612e2a52ed9baa3"
+SCHEMA_PATH = Path(__file__).parents[1] / "schemas" / "prompt_receipt.schema.json"
+
+
+def _exchange():
+    prompt = build_canonical_prompt(QUESTION, KNOWN_FACTS, UNKNOWNS, CONSTRAINTS)
+    parsed = parse_model_response(MOCK_MODEL_RESPONSE, "mock-model-v1")
+    digest_input = {
+        "answer": parsed["answer"],
+        "evidence_summary": parsed["summary"],
+        "confidence": parsed["confidence"],
+        "model_id": parsed["model_id"],
+    }
+    return prompt, parsed, compute_exchange_digest(prompt, digest_input)
+
+
+class TestCanonicalSpineEndToEnd:
+    def test_deterministic_prompt_construction(self):
+        p1 = build_canonical_prompt(QUESTION, KNOWN_FACTS, UNKNOWNS, CONSTRAINTS)
+        p2 = build_canonical_prompt(QUESTION, KNOWN_FACTS, UNKNOWNS, CONSTRAINTS)
+        p3 = build_canonical_prompt(
+            QUESTION,
+            list(reversed(KNOWN_FACTS)) + [KNOWN_FACTS[0]],
+            UNKNOWNS,
+            CONSTRAINTS,
+        )
+        assert p1 == p2 == p3
+
+    def test_parser_extracts_correct_fields(self):
+        _, parsed, _ = _exchange()
+        assert parsed["model_id"] == "mock-model-v1"
+        assert "transformer failure" in parsed["answer"].lower()
+        assert "insulation resistance" in parsed["summary"].lower()
+        assert parsed["confidence"] == pytest.approx(0.82)
+
+    def test_digest_is_stable_for_frozen_exchange(self):
+        _, _, digest = _exchange()
+        assert digest == EXPECTED_DIGEST
+
+    def test_receipt_validates_against_frozen_schema(self):
+        _, parsed, digest = _exchange()
+        receipt = {
+            "spine_version": "v0.1",
+            "question": QUESTION,
+            "known_facts": sorted(KNOWN_FACTS),
+            "unknowns": sorted(UNKNOWNS),
+            "constraints": sorted(CONSTRAINTS),
+            "model_responses": [
+                {
+                    "model_id": parsed["model_id"],
+                    "answer": parsed["answer"],
+                    "evidence_summary": parsed["summary"],
+                    "confidence": parsed["confidence"],
+                }
+            ],
+            "exchange_digest": digest,
+            "timestamp": "2026-08-09T00:00:00Z",
+        }
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=receipt, schema=schema)
+
+    def test_malformed_response_rejected(self):
+        bad = "[MODEL ANSWER]\nSome answer\n[EVIDENCE / REASONING SUMMARY]\nS\n[CONFIDENCE] not-a-number"
+        with pytest.raises(ParseError, match="invalid confidence"):
+            parse_model_response(bad, "bad-model")
+
+    def test_missing_evidence_summary_rejected(self):
+        no_summary = "[MODEL ANSWER]\nAnswer here.\n[CONFIDENCE] 0.5"
+        with pytest.raises(ParseError, match="missing or empty required sections.*summary"):
+            parse_model_response(no_summary, "incomplete-model")


### PR DESCRIPTION
## Scope

Adds the isolated end-to-end qualification layer for `CANONICAL_PROMPT_SPINE_V0_1` after merge of PR #441.

### Added
- `revenue_agent/schemas/prompt_receipt.schema.json`
  - frozen authority-free prompt receipt contract
  - canonical `evidence_summary` field
  - closed schema (`additionalProperties: false`)
- `revenue_agent/tests/test_canonical_spine.py`
  - deterministic prompt construction
  - strict parser extraction
  - frozen exchange digest vector
  - prompt receipt schema validation
  - malformed response rejection
  - missing evidence summary rejection
- Revenue Agent qualification workflow now explicitly executes:
  - `test_parser.py`
  - `test_prompt_digest.py`
  - `test_canonical_spine.py`

## Frozen digest vector

`a4bcb83d5cc5f4daa995b18a397d63eae1d7988ad3d0c2538612e2a52ed9baa3`

The St. Cloud text is explicitly marked synthetic qualification data. The test does not assert those substantive claims as real-world facts.

## Important CI correction

PR #441 had green repository workflows, but the Revenue Agent Qualification Harness did not yet list the prompt parser/digest tests in its explicit pytest command. This PR closes that gap so the prompt spine has a true canonical qualification gate.

## Boundary

```text
PROMPT -> PARSE -> DIGEST -> PROMPT RECEIPT SCHEMA
AUTHORITY_CREATED = FALSE
CONSENSUS = ABSENT
EXTERNAL_API_CALLS = NONE
```

No RePlay/game integration is included here. Composition remains the next atomic unit after this qualification PR is green and merged.