### PR TITLE
Add canonical query hook for RePlay/game integration

### DIFF
--- a/.github/workflows/revenue-agent-eev-harness.yml
+++ b/.github/workflows/revenue-agent-eev-harness.yml
@@ -46,6 +46,7 @@ jobs:
             revenue_agent/tests/test_parser.py \
             revenue_agent/tests/test_prompt_digest.py \
             revenue_agent/tests/test_canonical_spine.py \
+            revenue_agent/tests/test_prompt_hook.py \
             -rX
 
       - name: Emit qualified membrane state
@@ -63,6 +64,7 @@ jobs:
           echo "- Locality Matrix router: LOCALITY_MATRIX_ROUTER_V0_1" >> "$GITHUB_STEP_SUMMARY"
           echo "- Prompt spine: CANONICAL_PROMPT_SPINE_V0_1" >> "$GITHUB_STEP_SUMMARY"
           echo "- Prompt spine e2e: QUALIFIED" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Prompt hook: CANONICAL_QUERY_HOOK_V0_1" >> "$GITHUB_STEP_SUMMARY"
           echo "- Program mode: RESEARCH_AND_DEVELOPMENT" >> "$GITHUB_STEP_SUMMARY"
           echo "- Production execution: false" >> "$GITHUB_STEP_SUMMARY"
           echo "- Human review: deferred" >> "$GITHUB_STEP_SUMMARY"

--- a/revenue_agent/prompt/hook.py
+++ b/revenue_agent/prompt/hook.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from revenue_agent.prompt.digest import compute_exchange_digest
+from revenue_agent.prompt.engine import build_canonical_prompt
+from revenue_agent.prompt.parser import parse_model_response
+
+
+HOOK_VERSION = "CANONICAL_QUERY_HOOK_V0_1"
+
+
+def canonical_query_receipt(
+    question: str,
+    known_facts: list[str],
+    unknowns: list[str],
+    constraints: list[str],
+    raw_model_output: str,
+    model_id: str,
+) -> Dict[str, Any]:
+    """Build a deterministic prompt-exchange receipt for downstream replay/game use.
+
+    This function does not call a model, create consensus, authorize execution,
+    or promote any claim. It only canonicalizes a supplied exchange.
+    """
+    prompt = build_canonical_prompt(question, known_facts, unknowns, constraints)
+    parsed = parse_model_response(raw_model_output, model_id)
+    digest_input = {
+        "answer": parsed["answer"],
+        "evidence_summary": parsed["summary"],
+        "confidence": parsed["confidence"],
+        "model_id": parsed["model_id"],
+    }
+    return {
+        "hook_version": HOOK_VERSION,
+        "spine_version": "v0.1",
+        "question": question.strip(),
+        "known_facts": sorted({item.strip() for item in known_facts if item.strip()}),
+        "unknowns": sorted({item.strip() for item in unknowns if item.strip()}),
+        "constraints": sorted({item.strip() for item in constraints if item.strip()}),
+        "model_response": digest_input,
+        "exchange_digest": compute_exchange_digest(prompt, digest_input),
+        "authority_created": False,
+        "consensus": None,
+    }

--- a/revenue_agent/tests/test_prompt_hook.py
+++ b/revenue_agent/tests/test_prompt_hook.py
@@ -1,0 +1,36 @@
+from revenue_agent.prompt.hook import canonical_query_receipt
+
+
+RAW = """[MODEL ANSWER]
+A
+
+[EVIDENCE / REASONING SUMMARY]
+S
+
+[CONFIDENCE] 0.5"""
+
+
+def test_hook_is_deterministic_and_authority_free():
+    kwargs = dict(
+        question="Q",
+        known_facts=["B", "A", "A"],
+        unknowns=["U"],
+        constraints=["C"],
+        raw_model_output=RAW,
+        model_id="M",
+    )
+    first = canonical_query_receipt(**kwargs)
+    second = canonical_query_receipt(**kwargs)
+    assert first == second
+    assert first["known_facts"] == ["A", "B"]
+    assert first["model_response"]["evidence_summary"] == "S"
+    assert first["authority_created"] is False
+    assert first["consensus"] is None
+    assert len(first["exchange_digest"]) == 64
+
+
+def test_hook_digest_changes_when_model_output_changes():
+    first = canonical_query_receipt("Q", [], [], [], RAW, "M")
+    changed = RAW.replace("[MODEL ANSWER]\nA", "[MODEL ANSWER]\nB")
+    second = canonical_query_receipt("Q", [], [], [], changed, "M")
+    assert first["exchange_digest"] != second["exchange_digest"]


### PR DESCRIPTION
## Scope

Introduces the first bounded integration seam after the qualified canonical prompt spine.

### Added
- `revenue_agent/prompt/hook.py`
  - builds a canonical prompt from supplied question/facts/unknowns/constraints
  - strictly parses supplied model output
  - computes the frozen exchange digest
  - returns an authority-free, consensus-free hook receipt
  - performs no model call, no execution, no promotion, and no truth adjudication
- `revenue_agent/tests/test_prompt_hook.py`
  - deterministic hook output
  - canonical list normalization
  - `summary -> evidence_summary` mapping
  - digest sensitivity to changed model output
  - explicit `authority_created=false` and `consensus=null`
- Revenue Agent Qualification Harness now executes the hook contract test and emits `CANONICAL_QUERY_HOOK_V0_1` on success.

## Composition boundary

```text
SUPPLIED QUESTION + CONTEXT
        ↓
CANONICAL PROMPT SPINE
        ↓
SUPPLIED MODEL OUTPUT
        ↓
STRICT PARSER
        ↓
EXCHANGE DIGEST
        ↓
CANONICAL QUERY HOOK RECEIPT
        ↓
FUTURE REPLAY / GAME ADAPTER
```

This PR does **not** modify the game CLI, call a model, invoke authorization, or reinterpret RePlay results as authority.

```text
AUTHORITY_CREATED = FALSE
CONSENSUS = ABSENT
MODEL_CALLS = NONE
GAME_PROMOTION = NONE
```

Base is the qualified #442 merge `e471c4dc9ed6a10831be2d46e90b33d217f4b216`.
