### PR TITLE
Materialize bounded MOVE-018 Purpose/RePlay design

### DIFF
--- a/docs/PURPOSE_REPLAY_INTEGRATION_MOVE_018_V0_1.md
+++ b/docs/PURPOSE_REPLAY_INTEGRATION_MOVE_018_V0_1.md
@@ -1,0 +1,103 @@
+# MOVE-018 — Purpose/RePlay Integration v0.1
+
+```text
+MOVE                 = MOVE_018
+ROUND                = MATERIALIZED_DESIGN
+VERIFICATION_LEVEL   = LEVEL_2_DESIGN_DISCUSSION
+PROTOCOL_CLAIM       = FALSE
+IMPLEMENTED          = FALSE
+AUTHORITY_CREATED    = FALSE
+NEXT_TRANSITION      = HUMAN_REVIEWS_PURPOSE_INTEGRATION
+```
+
+## Purpose
+
+Define a bounded design for passing a human-authored purpose reference through RePlay receipts without allowing purpose, repository identity, routing, or storage to become verification authority.
+
+## Verified repository roles
+
+| Repository | Bounded role | Explicit non-claim |
+| --- | --- | --- |
+| `jsonwisdom/COMPUTERWISDOM` | Corporate/operational doctrine root and proposed integration host | Not the canonical Anchor 001 proof source |
+| `jsonwisdom/AL` | Receipt and proof machinery; compatibility target | Not a source-of-truth authority |
+| `jsonwisdom/JOY` | Separate family-safe witness/context surface | Not a universal identity constant or routing authority |
+| `jsonwisdom/layered-proofing-state-level-alms` | Existing ALMS-named repository requiring separate inspection | Not automatically injected or renamed |
+
+Cross-repository relationships are digest-bound pointers. No repository is imported as a monorepo, mounted as a shared filesystem, or granted authority by this design.
+
+## Proposed receipt extension
+
+```json
+{
+  "purpose_ref": {
+    "repository": "jsonwisdom/COMPUTERWISDOM",
+    "path": "docs/PURPOSE.md",
+    "commit_sha": "<40-hex Git commit>",
+    "sha256": "<64-hex SHA-256 of exact file bytes>"
+  },
+  "joy_ref": {
+    "repository": "jsonwisdom/JOY",
+    "commit_sha": "<40-hex Git commit>",
+    "artifact_path": "<explicit path>",
+    "sha256": "<64-hex SHA-256 of exact artifact bytes>"
+  },
+  "al_compatibility": {
+    "repository": "jsonwisdom/AL",
+    "commit_sha": "<40-hex Git commit>",
+    "test_command": "<exact command>",
+    "result": "NOT_RUN"
+  },
+  "alms_ref": null,
+  "authority_created": false
+}
+```
+
+`purpose_ref.sha256` binds the exact canonical purpose artifact bytes. It must not hash an informal paraphrase. `joy_ref` is an optional contextual pointer, not the literal constant `JOY`. AL compatibility can be claimed only after a pinned AL commit and exact test command execute successfully.
+
+## Routing boundary
+
+Purpose may select an eligible fixture or validator profile. Purpose must not:
+
+- change validation results;
+- bypass required checks;
+- select authority;
+- elevate a claim;
+- mutate evidence;
+- enable publication.
+
+The selected profile, selection rule version, and purpose digest must be recorded for deterministic replay.
+
+## ALMS boundary
+
+`ALMS` has no newly accepted expansion in MOVE-018. The existing ALMS-named repository must first be inspected and its role reconciled. Until a later human-reviewed artifact defines the interface:
+
+```text
+ALMS_EXPANSION_ACCEPTED = FALSE
+ALMS_SERVICE_CREATED    = FALSE
+ALMS_STORAGE_VERIFIED   = FALSE
+ALMS_REF                = NULL
+```
+
+Indexing, retention, minimization, query, and deletion behavior are implementation claims requiring data-flow tests, storage inspection, log audits, and deletion tests.
+
+## Proposed implementation sequence
+
+1. Freeze exact purpose bytes and compute SHA-256.
+2. Define a JSON Schema for the receipt extension.
+3. Add synthetic fixtures only.
+4. Implement parsing and digest binding without routing authority.
+5. Pin AL by commit and add a compatibility adapter; do not execute another repository's unreviewed code implicitly.
+6. Inspect and reconcile the existing ALMS repository before defining any ALMS interface.
+7. Run unit, replay, negative, privacy, and cross-repository drift tests.
+8. Produce a verification receipt for human review.
+
+## How we will fail
+
+MOVE-018 fails if a repository is called a truth authority; a floating branch replaces a commit pin; purpose changes verification outcomes; JOY is treated as identity or authority; AL tests are claimed without execution; ALMS is expanded without reconciliation; private or real youth data enters fixtures; non-storage is inferred from declarations; or any receipt reports `authority_created=true`.
+
+## Amendment history
+
+| Version | Change | State |
+| --- | --- | --- |
+| v0.1 | Corrected repository roles and bounded purpose, JOY, AL, and ALMS integration. | Design candidate |
+

--- a/receipts/MOVE_018_PURPOSE_REPLAY_DESIGN_V0_1.md
+++ b/receipts/MOVE_018_PURPOSE_REPLAY_DESIGN_V0_1.md
@@ -1,0 +1,38 @@
+# MOVE-018 Purpose/RePlay Design Receipt
+
+```json
+{
+  "move": "MOVE_018",
+  "round": "MATERIALIZED_DESIGN",
+  "repository": "jsonwisdom/COMPUTERWISDOM",
+  "branch": "agent/move-018-purpose-replay-design",
+  "verified_commit": "1fc01ebd31c198536fce6456fd5110bf1c493f31",
+  "artifact_path": "docs/PURPOSE_REPLAY_INTEGRATION_MOVE_018_V0_1.md",
+  "artifact_bytes": 4335,
+  "artifact_sha256": "37540378d888a39a380d3d13ca6e29c0f9ad2c52f96f863c8fb86f936fb6604e",
+  "test_path": "test_move_018_design.py",
+  "test_bytes": 1450,
+  "test_sha256": "a26012b8bd86f8be03fc2258ef729fe254648c2fc3c13c6f79152a3ebaf9f00e",
+  "tests": "5/5_PASS",
+  "implemented": false,
+  "protocol_claim": false,
+  "authority_created": false,
+  "next_transition": "HUMAN_REVIEWS_PURPOSE_INTEGRATION"
+}
+```
+
+## Method
+
+The exact UTF-8 contents committed at `1fc01ebd31c198536fce6456fd5110bf1c493f31` were fetched and matched to the locally tested artifact. SHA-256 was computed over complete file bytes. `python -m unittest -v test_move_018_design.py` passed five tests.
+
+## Boundary
+
+This receipt proves design bytes, commit identity, and structural test execution. It does not prove implementation, AL compatibility, ALMS behavior, cross-repository replay, privacy, non-storage, or protocol correctness.
+
+```text
+DESIGN_MATERIALIZED = TRUE
+IMPLEMENTED         = FALSE
+AL_TESTS_RUN        = FALSE
+ALMS_RECONCILED     = FALSE
+AUTHORITY_CREATED   = FALSE
+```

--- a/test_move_018_design.py
+++ b/test_move_018_design.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import unittest
+
+
+TEXT = (Path(__file__).parent / "docs" / "PURPOSE_REPLAY_INTEGRATION_MOVE_018_V0_1.md").read_text(encoding="utf-8")
+
+
+class Move018DesignTests(unittest.TestCase):
+    def test_state_is_bounded(self):
+        for value in (
+            "PROTOCOL_CLAIM       = FALSE",
+            "IMPLEMENTED          = FALSE",
+            "AUTHORITY_CREATED    = FALSE",
+            "NEXT_TRANSITION      = HUMAN_REVIEWS_PURPOSE_INTEGRATION",
+        ):
+            self.assertIn(value, TEXT)
+
+    def test_repository_roles_do_not_create_truth_authority(self):
+        self.assertIn("Not a source-of-truth authority", TEXT)
+        self.assertIn("Not a universal identity constant or routing authority", TEXT)
+        self.assertIn("digest-bound pointers", TEXT)
+
+    def test_purpose_cannot_change_verification(self):
+        self.assertIn("Purpose must not:", TEXT)
+        self.assertIn("change validation results", TEXT)
+        self.assertIn("bypass required checks", TEXT)
+
+    def test_alms_remains_unresolved(self):
+        self.assertIn("ALMS_EXPANSION_ACCEPTED = FALSE", TEXT)
+        self.assertIn("ALMS_SERVICE_CREATED    = FALSE", TEXT)
+        self.assertIn("ALMS_STORAGE_VERIFIED   = FALSE", TEXT)
+
+    def test_failure_and_amendment_sections_exist(self):
+        self.assertIn("## How we will fail", TEXT)
+        self.assertIn("## Amendment history", TEXT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Adds the bounded MOVE-018 Purpose/RePlay integration design.
- Corrects repository roles for COMPUTERWISDOM, AL, and JOY.
- Keeps ALMS unresolved pending inspection of the existing ALMS-named repository.
- Adds five executable structural boundary tests.
- Adds a commit-bound verification receipt.

## Verification

```text
python -m unittest -v test_move_018_design.py
5 tests / 5 pass
```

Artifact SHA-256: `37540378d888a39a380d3d13ca6e29c0f9ad2c52f96f863c8fb86f936fb6604e`

## Boundaries

```text
DESIGN_MATERIALIZED = TRUE
IMPLEMENTED         = FALSE
AL_TESTS_RUN        = FALSE
ALMS_RECONCILED     = FALSE
AUTHORITY_CREATED   = FALSE
```