### PR TITLE
Fix CleanTree Merkle ordering and bind unsigned v0.2 attestation

### DIFF
--- a/attestations/CLEANTREE_MERKLE_V0_2_UNSIGNED.json
+++ b/attestations/CLEANTREE_MERKLE_V0_2_UNSIGNED.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "urn:jsonwisdom:cleantree:attestation:v0.2",
+  "attestation_id": "CLEANTREE_MERKLE_V0_2_UNSIGNED",
+  "attestation_status": "UNSIGNED_GITHUB_CANDIDATE",
+  "observed_v0_1_failure": {
+    "environment": "Windows PowerShell 7.6.4",
+    "expected_fixture_root": "656020bb502588bf3cd0574a6890950ccec3c5ffd2f2e4551594c8d13e32677a",
+    "observed_fixture_root": "b5aff300e2fa84af1009df2ff97e13c395e718e7767bf2878cf281d8e7630d52",
+    "leaf_hashes_matched": true,
+    "root_matched": false,
+    "root_cause": "culture-dependent case-insensitive leaf ordering"
+  },
+  "v0_2_patch": {
+    "algorithm": "UTF8_ORDINAL_HEX_SORT_V1",
+    "python_regression_tests": "PENDING_COMMIT_RECEIPT",
+    "windows_powershell_rerun": "NOT_RUN"
+  },
+  "onchain_handoff": {
+    "network": null,
+    "schema_uid": null,
+    "attestation_uid": null,
+    "transaction_hash": null,
+    "real_inventory_merkle_root": null,
+    "submission_authorized": false,
+    "wallet_signature": "HUMAN_ONLY"
+  },
+  "repository_visibility": "PUBLIC",
+  "publication_authority_created": false,
+  "authority_created": false,
+  "next_transition": "WINDOWS_RERUNS_SYNTHETIC_VECTOR"
+}

--- a/receipts/CLEANTREE_MERKLE_V0_2_GITHUB_RECEIPT.md
+++ b/receipts/CLEANTREE_MERKLE_V0_2_GITHUB_RECEIPT.md
@@ -1,0 +1,52 @@
+# CleanTree Merkle v0.2 GitHub Receipt
+
+```json
+{
+  "artifact": "CLEANTREE_MERKLE_V0_2",
+  "repository": "jsonwisdom/COMPUTERWISDOM",
+  "branch": "agent/cleantree-merkle-v0-2-attestation",
+  "verified_candidate_commit": "d6cc917c8e21d29ab4aea67a8d2eea9f7c015eb9",
+  "powershell_patch": {
+    "path": "tools/cleantree/Invoke-JSONWisdomCleanTreeMerkle.ps1",
+    "bytes": 9707,
+    "sha256": "594462292b688385f9c6a8018bdace01130e84df8bd5b42aba8d3756f5ae329d"
+  },
+  "regression_test": {
+    "path": "tests/test_cleantree_merkle_vector.py",
+    "bytes": 2386,
+    "sha256": "7ff21e1d63f9ad45222cfb4ef6b44b4ba2fe4a41dd82a05f7c40cce7edc41b30",
+    "result": "2/2_PASS"
+  },
+  "expected_fixture_root": "656020bb502588bf3cd0574a6890950ccec3c5ffd2f2e4551594c8d13e32677a",
+  "rejected_windows_v0_1_root": "b5aff300e2fa84af1009df2ff97e13c395e718e7767bf2878cf281d8e7630d52",
+  "windows_powershell_v0_2_rerun": "NOT_RUN",
+  "onchain_attestation_submitted": false,
+  "transaction_hash": null,
+  "attestation_uid": null,
+  "wallet_signature": "HUMAN_ONLY",
+  "authority_created": false,
+  "next_transition": "WINDOWS_RERUNS_SYNTHETIC_VECTOR"
+}
+```
+
+## Evidence
+
+The v0.1 Windows run used PowerShell 7.6.4. All three leaf hashes matched the independent vector, while culture-dependent case-insensitive ordering produced the rejected root. The v0.2 candidate converts repository/path UTF-8 bytes to an ASCII hexadecimal sort key before Merkle construction.
+
+Two Python regression tests pass:
+
+1. UTF-8 ordinal ordering produces the expected root.
+2. The former Windows ordering reproduces the rejected root.
+
+## Boundary
+
+This receipt binds the GitHub code candidate and regression tests. It does not claim that v0.2 has passed on Windows, scanned a real repository, produced a real inventory root, signed a wallet payload, or submitted an on-chain attestation.
+
+```text
+PATCH_CANDIDATE_MATERIALIZED = TRUE
+PYTHON_REGRESSION_TESTS      = 2/2_PASS
+WINDOWS_V0_2_TEST            = NOT_RUN
+REAL_INVENTORY               = NOT_RUN
+ONCHAIN_ATTESTATION          = NOT_SUBMITTED
+AUTHORITY_CREATED            = FALSE
+```

--- a/tests/test_cleantree_merkle_vector.py
+++ b/tests/test_cleantree_merkle_vector.py
@@ -1,0 +1,71 @@
+import csv
+import hashlib
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "fixtures" / "synthetic-inventory.csv"
+EXPECTED_ROOT = "656020bb502588bf3cd0574a6890950ccec3c5ffd2f2e4551594c8d13e32677a"
+
+
+def utf8_ordinal_key(row: dict[str, str]) -> bytes:
+    return f"{row['repository']}\0{row['relative_path']}".encode("utf-8")
+
+
+def leaf(row: dict[str, str]) -> bytes:
+    canonical = "\n".join(
+        (
+            "CLEANTREE_LEAF_V1",
+            row["repository"],
+            row["commit_sha"],
+            row["relative_path"],
+            row["bytes"],
+            row["sha256"].lower(),
+            row["suggested_classification"],
+            row["rule_ids"],
+            row["content_scan_state"],
+        )
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).digest()
+
+
+def merkle_root(nodes: list[bytes]) -> str:
+    if not nodes:
+        return hashlib.sha256(b"CLEANTREE_EMPTY_V1").hexdigest()
+    while len(nodes) > 1:
+        if len(nodes) % 2:
+            nodes.append(nodes[-1])
+        nodes = [
+            hashlib.sha256(nodes[index] + nodes[index + 1]).digest()
+            for index in range(0, len(nodes), 2)
+        ]
+    return nodes[0].hex()
+
+
+class MerkleVectorTests(unittest.TestCase):
+    def test_fixture_uses_utf8_ordinal_order_and_expected_root(self):
+        with FIXTURE.open(newline="", encoding="utf-8") as handle:
+            rows = sorted(csv.DictReader(handle), key=utf8_ordinal_key)
+        self.assertEqual(
+            [row["relative_path"] for row in rows],
+            ["README.md", "credentials.env", "internal/router.py"],
+        )
+        self.assertEqual(merkle_root([leaf(row) for row in rows]), EXPECTED_ROOT)
+
+    def test_windows_case_insensitive_order_reproduces_rejected_root(self):
+        with FIXTURE.open(newline="", encoding="utf-8") as handle:
+            rows = sorted(
+                csv.DictReader(handle),
+                key=lambda row: (
+                    row["repository"].lower(),
+                    row["relative_path"].lower(),
+                ),
+            )
+        rejected = "b5aff300e2fa84af1009df2ff97e13c395e718e7767bf2878cf281d8e7630d52"
+        self.assertEqual(merkle_root([leaf(row) for row in rows]), rejected)
+        self.assertNotEqual(rejected, EXPECTED_ROOT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cleantree/Invoke-JSONWisdomCleanTreeMerkle.ps1
+++ b/tools/cleantree/Invoke-JSONWisdomCleanTreeMerkle.ps1
@@ -1,0 +1,224 @@
+#requires -Version 7.2
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$InventoryCsv,
+    [Parameter(Mandatory)][string]$WorkspaceRoot,
+    [string]$OutputRoot = (Join-Path $PWD.Path "JSONWisdom-CleanTree-Receipts"),
+    [string]$PreviousInventoryCsv,
+    [switch]$EnableSecretContainerHmac
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-Sha256Bytes {
+    param([Parameter(Mandatory)][byte[]]$Bytes)
+    return [System.Security.Cryptography.SHA256]::HashData($Bytes)
+}
+
+function Get-Sha256Hex {
+    param([Parameter(Mandatory)][byte[]]$Bytes)
+    return [Convert]::ToHexString((Get-Sha256Bytes $Bytes)).ToLowerInvariant()
+}
+
+function Get-Utf8Bytes {
+    param([Parameter(Mandatory)][string]$Text)
+    return [System.Text.UTF8Encoding]::new($false).GetBytes($Text)
+}
+
+function Get-Utf8OrdinalSortKey {
+    param(
+        [Parameter(Mandatory)][string]$Repository,
+        [Parameter(Mandatory)][string]$RelativePath
+    )
+    # Hex encoding converts the exact UTF-8 byte sequence into an ASCII key.
+    # Sorting this key is stable across Windows/Linux cultures and preserves
+    # ordinal byte order, including uppercase/lowercase distinctions.
+    return [Convert]::ToHexString(
+        (Get-Utf8Bytes ($Repository + [char]0 + $RelativePath))
+    )
+}
+
+function Get-MerkleRoot {
+    param([Parameter(Mandatory)][byte[][]]$Leaves)
+    if ($Leaves.Count -eq 0) {
+        return Get-Sha256Hex (Get-Utf8Bytes "CLEANTREE_EMPTY_V1")
+    }
+    $level = [System.Collections.Generic.List[byte[]]]::new()
+    foreach ($leaf in $Leaves) { $level.Add($leaf) }
+    while ($level.Count -gt 1) {
+        $next = [System.Collections.Generic.List[byte[]]]::new()
+        for ($i = 0; $i -lt $level.Count; $i += 2) {
+            $left = $level[$i]
+            $right = if (($i + 1) -lt $level.Count) { $level[$i + 1] } else { $left }
+            $combined = [byte[]]::new(64)
+            [Array]::Copy($left, 0, $combined, 0, 32)
+            [Array]::Copy($right, 0, $combined, 32, 32)
+            $next.Add((Get-Sha256Bytes $combined))
+        }
+        $level = $next
+    }
+    return [Convert]::ToHexString($level[0]).ToLowerInvariant()
+}
+
+function Get-HardwareProfile {
+    $cpuName = "UNKNOWN"
+    $logicalProcessors = [Environment]::ProcessorCount
+    $gpuNames = @()
+    try {
+        $cpu = Get-CimInstance Win32_Processor | Select-Object -First 1
+        if ($cpu) {
+            $cpuName = [string]$cpu.Name
+            $logicalProcessors = [int]$cpu.NumberOfLogicalProcessors
+        }
+        $gpuNames = @(Get-CimInstance Win32_VideoController | ForEach-Object { [string]$_.Name })
+    } catch {
+        # Hardware discovery is informational and must not block inventory proof.
+    }
+    return [pscustomobject][ordered]@{
+        cpu_name = $cpuName
+        logical_processors = $logicalProcessors
+        ryzen_detected = ($cpuName -match "(?i)Ryzen")
+        recommended_parallel_corridors = [Math]::Max(1, [Math]::Min(8, $logicalProcessors))
+        gpu_names = $gpuNames
+        radeon_detected = [bool]($gpuNames -match "(?i)Radeon")
+        gpu_acceleration_used = $false
+        computation_mode = "DETERMINISTIC_CPU"
+    }
+}
+
+function Get-ReversePatchAction {
+    param([Parameter(Mandatory)][string]$Classification)
+    switch ($Classification) {
+        "SECRET" { return "ROTATE_IF_LIVE_AND_REMOVE_FROM_FUTURE_COMMITS_AFTER_HUMAN_CONFIRMATION" }
+        "PRIVATE_IP" { return "REVIEW_FOR_PRIVATE_IP_MIGRATION" }
+        "QUARANTINE" { return "ISOLATE_FOR_HUMAN_PRIVACY_REVIEW" }
+        "CONTROLLED" { return "VERIFY_PUBLIC_INTEROPERABILITY_MINIMUM" }
+        default { return "NO_CHANGE_PROPOSED" }
+    }
+}
+
+$inventoryFull = [IO.Path]::GetFullPath($InventoryCsv)
+$workspaceFull = [IO.Path]::GetFullPath($WorkspaceRoot)
+$outputFull = [IO.Path]::GetFullPath($OutputRoot)
+if (-not (Test-Path -LiteralPath $inventoryFull -PathType Leaf)) { throw "Inventory not found: $inventoryFull" }
+if (-not (Test-Path -LiteralPath $workspaceFull -PathType Container)) { throw "Workspace not found: $workspaceFull" }
+New-Item -ItemType Directory -Path $outputFull -Force | Out-Null
+
+$rows = @(Import-Csv -LiteralPath $inventoryFull)
+$rows = @(
+    $rows | Sort-Object @{
+        Expression = {
+            Get-Utf8OrdinalSortKey -Repository ([string]$_.repository) -RelativePath ([string]$_.relative_path)
+        }
+    }
+)
+$leafRecords = [System.Collections.Generic.List[object]]::new()
+$leafBytes = [System.Collections.Generic.List[byte[]]]::new()
+$reversePatch = [System.Collections.Generic.List[object]]::new()
+
+$hmacKey = $null
+if ($EnableSecretContainerHmac) {
+    $keyText = [Environment]::GetEnvironmentVariable("CLEANTREE_HMAC_KEY_B64")
+    if ([string]::IsNullOrWhiteSpace($keyText)) { throw "CLEANTREE_HMAC_KEY_B64 is required when HMAC is enabled." }
+    try { $hmacKey = [Convert]::FromBase64String($keyText) } catch { throw "CLEANTREE_HMAC_KEY_B64 is not valid Base64." }
+    if ($hmacKey.Length -lt 32) { throw "HMAC key must contain at least 32 bytes." }
+}
+
+foreach ($row in $rows) {
+    $fields = @(
+        "CLEANTREE_LEAF_V1", [string]$row.repository, [string]$row.commit_sha,
+        [string]$row.relative_path, [string]$row.bytes, ([string]$row.sha256).ToLowerInvariant(),
+        [string]$row.suggested_classification, [string]$row.rule_ids, [string]$row.content_scan_state
+    )
+    $canonical = $fields -join "`n"
+    $leafHashBytes = Get-Sha256Bytes (Get-Utf8Bytes $canonical)
+    $leafHash = [Convert]::ToHexString($leafHashBytes).ToLowerInvariant()
+    $leafBytes.Add($leafHashBytes)
+
+    $containerHmac = $null
+    if ($EnableSecretContainerHmac -and $row.suggested_classification -eq "SECRET") {
+        $repoName = ([string]$row.repository).Split("/")[-1]
+        $filePath = Join-Path (Join-Path $workspaceFull $repoName) (([string]$row.relative_path) -replace "/", [IO.Path]::DirectorySeparatorChar)
+        if (Test-Path -LiteralPath $filePath -PathType Leaf) {
+            $hmac = [System.Security.Cryptography.HMACSHA256]::new($hmacKey)
+            try {
+                $stream = [IO.File]::OpenRead($filePath)
+                try { $containerHmac = [Convert]::ToHexString($hmac.ComputeHash($stream)).ToLowerInvariant() }
+                finally { $stream.Dispose() }
+            } finally { $hmac.Dispose() }
+        }
+    }
+
+    $leafRecords.Add([pscustomobject][ordered]@{
+        repository = $row.repository
+        relative_path = $row.relative_path
+        leaf_sha256 = $leafHash
+        secret_container_hmac_sha256 = $containerHmac
+        raw_secret_recorded = $false
+    })
+    $reversePatch.Add([pscustomobject][ordered]@{
+        repository = $row.repository
+        relative_path = $row.relative_path
+        current_classification = $row.suggested_classification
+        proposed_action = Get-ReversePatchAction ([string]$row.suggested_classification)
+        patch_applied = $false
+        human_approval_required = $true
+    })
+}
+
+$merkleRoot = Get-MerkleRoot -Leaves @($leafBytes)
+$hardware = Get-HardwareProfile
+
+$delta = [ordered]@{ previous_inventory_supplied = $false; added = 0; removed = 0; changed = 0; unchanged = 0 }
+if ($PreviousInventoryCsv) {
+    $previousFull = [IO.Path]::GetFullPath($PreviousInventoryCsv)
+    if (-not (Test-Path -LiteralPath $previousFull -PathType Leaf)) { throw "Previous inventory not found: $previousFull" }
+    $delta.previous_inventory_supplied = $true
+    $old = @{}
+    foreach ($r in @(Import-Csv $previousFull)) { $old["$($r.repository)|$($r.relative_path)"] = [string]$r.sha256 }
+    $new = @{}
+    foreach ($r in $rows) { $new["$($r.repository)|$($r.relative_path)"] = [string]$r.sha256 }
+    foreach ($key in $new.Keys) {
+        if (-not $old.ContainsKey($key)) { $delta.added++ }
+        elseif ($old[$key] -ne $new[$key]) { $delta.changed++ }
+        else { $delta.unchanged++ }
+    }
+    foreach ($key in $old.Keys) { if (-not $new.ContainsKey($key)) { $delta.removed++ } }
+}
+
+$runId = "CLEANTREE_MERKLE_" + (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
+$leavesPath = Join-Path $outputFull "$runId.leaves.json"
+$reversePatchPath = Join-Path $outputFull "$runId.reverse-patch-plan.csv"
+$receiptPath = Join-Path $outputFull "$runId.receipt.json"
+
+$leafRecords | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $leavesPath -Encoding utf8
+$reversePatch | Export-Csv -LiteralPath $reversePatchPath -NoTypeInformation -Encoding utf8
+
+$receipt = [pscustomobject][ordered]@{
+    receipt_type = "SUPER_SECRET_SISTER_OS_CLEANTREE_MERKLE_V0_1"
+    run_id = $runId
+    inventory_source_sha256 = (Get-FileHash $inventoryFull -Algorithm SHA256).Hash.ToLowerInvariant()
+    leaf_count = $leafRecords.Count
+    merkle_algorithm = "BINARY_SHA256_DUPLICATE_ODD_V1"
+    merkle_root_sha256 = $merkleRoot
+    secret_container_hmac_enabled = [bool]$EnableSecretContainerHmac
+    secret_values_recorded = $false
+    hardware_profile = $hardware
+    radical_flywheel_delta = [pscustomobject]$delta
+    reverse_patch_plan = [IO.Path]::GetFileName($reversePatchPath)
+    reverse_patch_applied = $false
+    remote_mutation_performed = $false
+    deletion_performed = $false
+    authority_created = $false
+    next_transition = "FAMILY_HUMAN_REVIEWS_MERKLE_INVENTORY"
+}
+$receipt | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $receiptPath -Encoding utf8
+$receiptHash = (Get-FileHash $receiptPath -Algorithm SHA256).Hash.ToLowerInvariant()
+"$receiptHash  $([IO.Path]::GetFileName($receiptPath))" | Set-Content "$receiptPath.sha256" -Encoding ascii
+
+if ($null -ne $hmacKey) { [Array]::Clear($hmacKey, 0, $hmacKey.Length) }
+
+Write-Host "Merkle inventory complete: $merkleRoot"
+Write-Host "Receipt: $receiptPath"
+Write-Host "Reverse patch is a plan only; no patch was applied."

--- a/tools/cleantree/fixtures/synthetic-inventory.csv
+++ b/tools/cleantree/fixtures/synthetic-inventory.csv
@@ -1,0 +1,4 @@
+"repository","commit_sha","relative_path","bytes","sha256","suggested_classification","rule_ids","content_scan_state","matched_content_recorded","human_review_required"
+"jsonwisdom/SYNTHETIC","0000000000000000000000000000000000000000","README.md","12","aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","PUBLIC_CANDIDATE","","SCANNED","False","False"
+"jsonwisdom/SYNTHETIC","0000000000000000000000000000000000000000","internal/router.py","24","bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","PRIVATE_IP","PRIVATE_IP_PATH_MARKER","SCANNED","False","True"
+"jsonwisdom/SYNTHETIC","0000000000000000000000000000000000000000","credentials.env","32","cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","SECRET","SECRET_SENSITIVE_FILENAME","SCANNED","False","True"


### PR DESCRIPTION
## Outcome

Materializes the fail-closed CleanTree Merkle v0.2 patch candidate after the human-in-the-loop Windows fixture exposed culture-dependent ordering.

## Root cause

PowerShell's default file sorting placed `README.md` after lowercase paths. Leaf hashes were correct, but the changed order produced a different Merkle root.

## Changes

- Sorts repository/path keys by exact UTF-8 ordinal bytes encoded as hexadecimal.
- Adds the three-row synthetic fixture.
- Adds two cross-platform regression tests.
- Records the rejected v0.1 Windows root and expected v0.2 root.
- Adds an unsigned on-chain handoff candidate with all transaction fields null.
- Adds a GitHub verification receipt.

## Verification

```text
python -m unittest discover -s tests -v
2 tests / 2 pass
```

Expected root: `656020bb502588bf3cd0574a6890950ccec3c5ffd2f2e4551594c8d13e32677a`

Rejected v0.1 Windows root: `b5aff300e2fa84af1009df2ff97e13c395e718e7767bf2878cf281d8e7630d52`

## Boundaries

```text
WINDOWS_V0_2_RERUN   = NOT_RUN
REAL_INVENTORY       = NOT_RUN
CHAIN_SUBMISSION     = FALSE
WALLET_SIGNATURE     = HUMAN_ONLY
AUTHORITY_CREATED    = FALSE
```