### PR TITLE
Materialize Personal Memory Constitution v1 stack

### DIFF
--- a/missions/personal-memory/CONSTITUTION.md
+++ b/missions/personal-memory/CONSTITUTION.md
@@ -1,0 +1,58 @@
+# CONSTITUTION FOR PERSONAL MEMORY v1.0
+
+Status: **FROZEN**
+
+Checkpoint identifier: `PERSONAL-MEMORY-CONSTITUTION-v1.0 | NO-MUTATION | NO-EPISTEMIC-LAUNDERING | NO-AUTHORITY-LAUNDERING`
+
+> The checkpoint identifier is a canonical label, not a cryptographic digest unless its exact bytes are hashed.
+
+## 1. Canonical Object
+
+`m = <id, tau, c, p, [t_s,t_e), A, s, conf>`
+
+- `id`: immutable identity
+- `tau`: immutable epistemic type
+- `c`: content or content-addressed reference
+- `p`: provenance DAG + derivation edges
+- `[t_s,t_e)`: validity interval
+- `A`: authority scope set
+- `s`: lifecycle state
+- `conf`: confidence metadata
+
+## 2. Governing Predicate
+
+`USABLE(m,t) = VALID(m) AND CURRENT(m,t) AND AUTHORIZED(m)`
+
+Existence grants nothing. Only `USABLE` objects may participate in reasoning or action.
+
+`BELIEF(t) = { m | USABLE(m,t) }`
+
+## 3. Constitutional Invariants
+
+### I1 — No Silent Mutation
+
+`tau(m,t') = tau(m,t_creation)`
+
+Type never changes. Stronger claims require a new object with new provenance.
+
+### I2 — No Epistemic Laundering
+
+`INFERRED` can never become `OBSERVED` by relabeling. `USER_ASSERTED` can never become `OBSERVED` without a new external evidence object.
+
+### I3 — No Authority Laundering
+
+`A_child subseteq intersection(A_dependency)`
+
+No derived object may broaden permissions of its evidence base.
+
+## 4. Lifecycle
+
+Append-first. Correction, supersession, invalidation, revalidation, revocation, and forgetting are represented by new events rather than silent mutation.
+
+## 5. Core Principle
+
+`NO SILENT MUTATION + NO EPISTEMIC LAUNDERING + NO AUTHORITY LAUNDERING`
+
+All lower policies may evolve only beneath these three laws.
+
+`AUTHORITY_CREATED = FALSE`

--- a/missions/personal-memory/PMEM-IMPL-001.md
+++ b/missions/personal-memory/PMEM-IMPL-001.md
@@ -1,0 +1,31 @@
+# PMEM-IMPL-001 — Memory Object Implementation Contract
+
+Parent: `PERSONAL-MEMORY-CONSTITUTION-v1.0`  
+Class: IMPLEMENTATION  
+Constitution mutation: FALSE
+
+## Canonical stored object
+
+Fields: `id`, `type`, `content_ref`, `provenance{sources,dependencies,derivation}`, `validity{start,end}`, `authority{reason,action,export}`, `lifecycle`, `confidence{value,assessed_at}`.
+
+Immutable after CREATE: `id`, `type`, `content_ref`, provenance, original creation record. Changed claims create new objects.
+
+## Derivation gate
+
+For child `x`: `A_x subseteq intersection(A_dependencies)` and derived children are `INFERRED` unless an independent external evidence source establishes another type.
+
+`DERIVATION != OBSERVATION`  
+`SUMMARY != OBSERVATION`  
+`REPETITION != CONFIRMATION`
+
+## Append-first events
+
+`CREATE | CORRECT | SUPERSEDE | INVALIDATE | FORGET | REVALIDATE`
+
+FORGET revokes/destroys protected material where controllable, creates a minimal tombstone, traverses transitive dependencies, invalidates affected descendants and reasoning caches, and prevents descendants from entering future USABLE sets.
+
+Before reasoning: `USABLE = VALID AND CURRENT AND AUTHORIZED`. Any failed term means `OBJECT_USABLE=FALSE`.
+
+Core: `OBJECT + DERIVATION GATE + APPEND-FIRST EVENTS + FORGET CASCADE`.
+
+`AUTHORITY_CREATED = FALSE`

--- a/missions/personal-memory/PMEM-IMPL-002.md
+++ b/missions/personal-memory/PMEM-IMPL-002.md
@@ -1,0 +1,21 @@
+# PMEM-IMPL-002 — Receipt + Event Ledger Schema
+
+Depends on: `PMEM-IMPL-001`
+
+Every attempted state-changing operation produces exactly one immutable receipt, including SUCCESS, FAILURE, and REJECTION. Absence of a receipt means no recognized ledger effect.
+
+Canonical receipt binds: `receipt_id`, `event_id`, `operation`, `target_ids`, `attempted_at`, `actor`, `authority_basis`, `dependencies`, `pre_state_ref`, `request_ref`, `result`, `reason_codes`, `post_state_ref`, `receipt_hash`.
+
+The event ledger is append-only. Events cannot be edited, reordered, or deleted; corrections create new events.
+
+Admission requires: `I1 AND I2 AND I3 AND POLICY_001 AND AUTHORIZED`. Failure means `EXECUTION=FALSE`, `RESULT=REJECTED`, and receipt required. A rejected request cannot be reinterpreted into another successful operation.
+
+Admitted state changes bind canonical pre/post state hashes. FORGET receipts preserve the revocation fact but must not retain forgotten content or sufficient material to reconstruct it.
+
+Cascade descendants receive their own linked receipts via `caused_by`.
+
+Replay must explain WHAT happened, WHEN, TO WHICH object, BY WHOM, UNDER WHAT authority, WHICH rule admitted/rejected it, and WHAT state resulted.
+
+Core invariant: **NO STATE CHANGE WITHOUT RECEIPT**.
+
+`AUTHORITY_CREATED = FALSE`

--- a/missions/personal-memory/PMEM-IMPL-003.md
+++ b/missions/personal-memory/PMEM-IMPL-003.md
@@ -1,0 +1,25 @@
+# PMEM-IMPL-003 — Evidence Graph Query + Replay Contract
+
+Depends on: `001..002`
+
+A query may reason only from objects satisfying `USABLE(m,t)=VALID AND CURRENT AND AUTHORIZED`.
+
+`STORED != RETRIEVABLE`  
+`MATCHED != USABLE`  
+`USABLE != EXPORTABLE`
+
+Pipeline: `QUERY -> INDEX MATCH -> GRAPH EXPANSION -> VALIDITY FILTER -> CURRENT FILTER -> AUTHORITY FILTER -> TYPE PRESERVATION -> RESULT SET`. Filtering occurs before reasoning.
+
+Historical replay evaluates the ledger and graph as they existed at the requested `as_of` time. Future corrections do not rewrite historical replay.
+
+Reasoning outputs retain provenance links to materially supporting objects. Derived results remain `INFERRED` unless independent external evidence establishes another type.
+
+Contradictory usable objects coexist. Allowed result states include `SUPPORTED`, `CONTRADICTED`, `DISPUTED`, `INSUFFICIENT_EVIDENCE`, `UNKNOWN`.
+
+Confidence is metadata, not type, validity, truth, or authority.
+
+Consequential queries produce receipts with candidate/usable counts, exclusions, evidence ids, result hash, and exact policy stack. Unknown authorization fails closed.
+
+Core invariant: **NO REASONING FROM NON-USABLE MEMORY**.
+
+`AUTHORITY_CREATED = FALSE`

--- a/missions/personal-memory/PMEM-IMPL-004.md
+++ b/missions/personal-memory/PMEM-IMPL-004.md
@@ -1,0 +1,25 @@
+# PMEM-IMPL-004 — Authorization + Scope Contract
+
+Depends on: `001..003`
+
+Authority is explicit, scoped, revocable, and purpose-bound. `AUTHORITY != IDENTITY`.
+
+Canonical grants bind subject, object scope, independent permissions (`READ`, `REASON`, `EXPORT`, `ACT`, `DELEGATE`), purpose, validity interval, delegation flag, issuer, and status.
+
+`AUTHORIZED(o) = GRANT_EXISTS AND SCOPE_MATCH AND PURPOSE_MATCH AND TIME_VALID AND NOT_REVOKED`. Unknown terms evaluate FALSE.
+
+Permissions are independent: `READ != REASON != EXPORT != ACT != DELEGATE`.
+
+For derived object `x`: `A_x subseteq A_creator intersection intersection(A_dependencies)`.
+
+Purpose expansion requires a new authorization event. Delegation is prohibited unless explicitly granted and can only narrow authority.
+
+Revocation immediately blocks future operations while preserving historical receipts.
+
+EXPORT and ACT require explicit gates beyond REASON; destination, purpose, dependent scopes, and revocation state are checked fail-closed.
+
+All GRANT/NARROW/DELEGATE/REVOKE/EXPORT_ATTEMPT/ACTION_ATTEMPT events produce receipts.
+
+Core invariant: **NO AUTHORITY BY IMPLICATION**.
+
+`AUTHORITY_CREATED = FALSE`

--- a/missions/personal-memory/PMEM-IMPL-005.md
+++ b/missions/personal-memory/PMEM-IMPL-005.md
@@ -1,0 +1,25 @@
+# PMEM-IMPL-005 — Integrity + Trust Anchor Contract
+
+Depends on: `001..004`
+
+`HASH(x) != TRUTH(x)` and `HASH(x) != AUTHORITY(x)`.
+
+Anything hashed must first be transformed into deterministic canonical bytes with declared serialization format/version, encoding, normalization rules, and hash algorithm.
+
+`CID(x)=SHA256(CANONICAL(x))` from actual bytes. Receipt hashes exclude the `receipt_hash` field itself.
+
+Ledger events chain `previous_receipt_hash`; edits, reorder, insertion, and deletion become detectable as hash/sequence/chain failures.
+
+Checkpoints commit to ledger prefixes but are not external trust anchors by default. External anchor states are distinct: `REQUESTED`, `SUBMITTED`, `CONFIRMED`; CONFIRMED requires independently retrievable proof.
+
+`SIGNATURE != IDENTITY` without a separately established binding, and `IDENTITY != AUTHORITY`.
+
+Verification states: `UNVERIFIED | VERIFIED_LOCAL | VERIFIED_EXTERNAL | FAILED`. Missing canonical bytes means `HASH_RECOMPUTED=FALSE` and `INTEGRITY_VERIFIED=FALSE`.
+
+After FORGET, a surviving digest is not retained content: `DIGEST != CONTENT`.
+
+No aggregate PASS may hide failed subchecks. Cryptographic inconsistency sets `INTEGRITY=FAILED` and forbids silent repair.
+
+Core: **NO CRYPTOGRAPHIC CLAIM WITHOUT BYTE-LEVEL VERIFICATION**.
+
+`AUTHORITY_CREATED = FALSE`

--- a/missions/personal-memory/PMEM-IMPL-006.md
+++ b/missions/personal-memory/PMEM-IMPL-006.md
@@ -1,0 +1,25 @@
+# PMEM-IMPL-006 — Temporal Validity + Revalidation Contract
+
+Depends on: `001..005`
+
+`STORED(m) != CURRENT(m,t)`.
+
+Temporal metadata includes `observed_at`, `valid_from`, `valid_until`, `revalidate_after`, `last_verified_at`, and `temporal_class: STATIC|SLOW|VOLATILE|EVENT`.
+
+`CONFIDENCE(m,t) != VALID(m,t)`. Confidence may decay without changing type; validity may expire despite previously high confidence.
+
+Decay policies are versioned and may change only confidence metadata. Type immutability remains absolute.
+
+Revalidation requires actual supporting evidence and creates new evidence/state assertions. `REVALIDATE != REFRESH TIMESTAMP`.
+
+At/after expiration: `CURRENT=FALSE`, `USABLE=FALSE` unless independently supported. Historical replay remains available when authorized.
+
+Volatile claims require explicit freshness constraints. For current-state queries, `STALE -> EXCLUDE` and `UNKNOWN_FRESHNESS -> FAIL_CLOSED`.
+
+New contradictions do not erase old evidence.
+
+Material time claims distinguish `EVENT_TIME`, `OBSERVATION_TIME`, `INGEST_TIME`, `LEDGER_TIME`; they are not silently treated as equal.
+
+Core: **OLD != CURRENT; REVALIDATION != TIMESTAMP REFRESH; DECAY NEVER CHANGES TYPE**.
+
+`AUTHORITY_CREATED = FALSE`

--- a/missions/personal-memory/PMEM-IMPL-007.md
+++ b/missions/personal-memory/PMEM-IMPL-007.md
@@ -1,0 +1,23 @@
+# PMEM-IMPL-007 — Actor Identity + Authentication Contract
+
+Depends on: `001..006`
+
+`LABEL != IDENTITY` and `AUTHENTICATED != AUTHORIZED`.
+
+Canonical actors have immutable `actor_id`, actor type (`USER|MODEL|SYSTEM|TOOL|SERVICE`), display label, bindings, and status. Display-label changes are append-first metadata events.
+
+Identity bindings are independent objects with `binding_id`, `actor_id`, method (`ACCOUNT|KEY|DEVICE|CREDENTIAL|USER_ASSERTION`), evidence reference, validity, and verification state.
+
+Authentication flow: `binding presented -> binding verified -> actor resolved -> receipt`. Ambiguous resolution fails closed as `ACTOR=UNKNOWN`, `AUTHENTICATED=FALSE`.
+
+Display names, email text, signature blocks, self-description, and model-generated claims cannot alone establish verified identity; they may produce USER_ASSERTED evidence only.
+
+Binding revocation blocks future authentication through that binding while preserving historical receipts. Credential rotation does not automatically create a new actor.
+
+Model/tool identity should include provider, identifier, version, and execution/session identifier where available.
+
+All BIND/VERIFY/AUTHENTICATE/REJECT/REVOKE/RESOLVE operations produce receipts.
+
+Core: **SIGNATURE != IDENTITY WITHOUT BINDING; AUTHENTICATION != AUTHORIZATION**.
+
+`AUTHORITY_CREATED = FALSE`

--- a/missions/personal-memory/PMEM-IMPL-008.md
+++ b/missions/personal-memory/PMEM-IMPL-008.md
@@ -1,0 +1,23 @@
+# PMEM-IMPL-008 — Custody + Retention + Replication Contract
+
+Depends on: `001..007`
+
+`POSSESSION != AUTHORITY` and `MEMORY != COPY`.
+
+Each materialized copy is attributable by `copy_id`, `memory_id`, `content_ref`, storage class (`PRIMARY|REPLICA|CACHE|BACKUP|EXPORT`), custodian, retention policy, encryption state, and status.
+
+Persistent reproduction creates a ledger event: `CREATE_COPY|REPLICATE|CACHE|BACKUP|EXPORT|RESTORE|DESTROY_COPY`. Unregistered persistent copies are violations.
+
+Retention requires explicit scope, purpose, deadline, and disposition. Conflicts surface as `DISPUTED_POLICY`; they are not silently resolved.
+
+FORGET must locate known primary copies, replicas, caches, indexes, backups, and controllable exports; revoke access; destroy where controllable; invalidate descendants/indexes; and issue per-copy receipts.
+
+Uncontrolled external copies remain `DESTRUCTION_CONFIRMED=FALSE`: `LOCAL FORGET != GLOBAL ERASURE`.
+
+Backup restore must replay revocation ledger/tombstones before admission. Caches inherit source authority/retention. Searchable derived index material cannot preserve forgotten protected content.
+
+`ENCRYPTED != FORGOTTEN`; key deletion is not proven byte destruction unless explicit cryptographic-erasure semantics are verified.
+
+Core: **BACKUP RESTORE != REVOCATION ROLLBACK**.
+
+`AUTHORITY_CREATED = FALSE`

--- a/missions/personal-memory/PMEM-IMPL-009.md
+++ b/missions/personal-memory/PMEM-IMPL-009.md
@@ -1,0 +1,25 @@
+# PMEM-IMPL-009 — Disclosure + Composition Safety Contract
+
+Depends on: `001..008`
+
+`AUTHORIZED TO REASON != AUTHORIZED TO DISCLOSE`.
+
+Individually permitted fragments may compose into an unauthorized inference: `SAFE(m1) AND SAFE(m2)` does not imply `SAFE(m1 + m2)`.
+
+Canonical disclosure requests bind actor, destination, purpose, requested fields, evidence ids, derived claims, and request time.
+
+Disclosure gate: `USABLE AND EXPORT_AUTHORIZED AND PURPOSE_MATCH AND DESTINATION_AUTHORIZED AND COMPOSITION_SAFE AND MINIMIZED`; unknown => FALSE.
+
+Any synthesis is a derived object, so its authority is independently evaluated and may only narrow from creator and dependencies.
+
+Composition requires derived-claim analysis before disclosure. Data minimization permits `OMIT|REDACT|GENERALIZE|AGGREGATE|PSEUDONYMIZE`; narrowing transformations may not fabricate evidence.
+
+Authorization is destination-bound. Forwarding is a new disclosure event.
+
+Side channels count as disclosure: prompts, tool arguments, URLs, logs, telemetry, files, email, API calls, and model context sent externally.
+
+Disclosure receipts bind sources, derived claims, requested/released/withheld fields, transformations, authority basis, result, and output hash.
+
+Core: **AUTHORIZED PARTS != AUTHORIZED COMPOSITION; DISCLOSE ONLY THE MINIMUM AUTHORIZED RESULT**.
+
+`AUTHORITY_CREATED = FALSE`

--- a/missions/personal-memory/PMEM-IMPL-010.md
+++ b/missions/personal-memory/PMEM-IMPL-010.md
@@ -1,0 +1,23 @@
+# PMEM-IMPL-010 — Policy Versioning + Migration Contract
+
+Depends on: `001..009`
+
+`CURRENT POLICY != HISTORICAL POLICY`.
+
+Every consequential operation binds exact policy identifiers, versions, and content references used at execution. Replay evaluates the policy stack recorded for that event, not today's policy.
+
+Canonical policy objects bind `policy_id`, name, semantic version, content hash/reference, effective interval, parent references, and status (`DRAFT|ACTIVE|SUPERSEDED|RETIRED`). Activated policy bytes are immutable.
+
+New policies may change future behavior but may not rewrite historical outcomes. `REEVALUATE != REWRITE`.
+
+Migration requires source/target versions, migration rule, affected objects, authority basis, result, and receipt. Migration creates derived state; it does not edit original representation.
+
+Candidate policies must pass I1/I2/I3. Lower layers cannot amend the constitution through versioning.
+
+Policy conflicts resolve by constitution, explicit precedence, narrower authority, then fail-closed. If deterministic resolution is impossible: `POLICY_STATE=DISPUTED_POLICY`, `EXECUTION=FALSE`.
+
+Retirement blocks future use while preserving historical replay. Re-evaluation records original result/stack and new evaluation/stack separately.
+
+Core: **POLICY UPDATE != HISTORY REWRITE; MIGRATION != MUTATION; LOWER POLICY != CONSTITUTIONAL AMENDMENT**.
+
+`AUTHORITY_CREATED = FALSE`

--- a/missions/personal-memory/fixtures/PMEM-OP-001.json
+++ b/missions/personal-memory/fixtures/PMEM-OP-001.json
@@ -1,0 +1,42 @@
+{
+  "operation_id": "PMEM-OP-001",
+  "mode": "SPECIFICATION_TRACE",
+  "policy_stack": [
+    "PERSONAL-MEMORY-CONSTITUTION-v1.0",
+    "PMEM-IMPL-001",
+    "PMEM-IMPL-002",
+    "PMEM-IMPL-003",
+    "PMEM-IMPL-004",
+    "PMEM-IMPL-005",
+    "PMEM-IMPL-006",
+    "PMEM-IMPL-007",
+    "PMEM-IMPL-008",
+    "PMEM-IMPL-009",
+    "PMEM-IMPL-010"
+  ],
+  "input": {
+    "type": "USER_ASSERTED",
+    "content": "Project Alpha deadline is 2026-09-01",
+    "authority": {
+      "reason": ["PROJECT_PLANNING"],
+      "export": [],
+      "action": []
+    }
+  },
+  "expected_trace": [
+    {"step": "CREATE", "expected": "ADMITTED", "type": "USER_ASSERTED"},
+    {"step": "REASON", "expected": "ADMITTED", "derived_type": "INFERRED"},
+    {"step": "EXPORT", "expected": "REJECTED", "reason": "EXPORT_NOT_AUTHORIZED"},
+    {"step": "REVOKE_REASON", "expected": "ADMITTED"},
+    {"step": "CURRENT_QUERY", "expected": "EXCLUDED_NON_USABLE"},
+    {"step": "HISTORICAL_REPLAY", "expected": "PRE_REVOKE_USABLE_POST_REVOKE_NOT_USABLE"}
+  ],
+  "spec_conformance": "PASS",
+  "runtime_executed": false,
+  "ledger_events_created": false,
+  "receipt_bytes_created": false,
+  "hashes_recomputed": false,
+  "crypto_integrity_verified": false,
+  "external_anchor": null,
+  "authority_created": false
+}

--- a/missions/personal-memory/fixtures/REPLAY.md
+++ b/missions/personal-memory/fixtures/REPLAY.md
@@ -1,0 +1,27 @@
+# PMEM-OP-001 — Synthetic Replay Record
+
+Mode: `SPECIFICATION_TRACE`  
+Runtime claim: NONE  
+Authority created: FALSE
+
+## Expected trace
+
+1. CREATE `USER_ASSERTED` deadline with REASON-only project-planning scope -> ADMITTED.
+2. REASON query passes VALID/CURRENT/AUTHORIZED -> conclusion must explicitly attribute USER_ASSERTED source; derived result remains INFERRED.
+3. EXPORT attempt -> REJECTED because EXPORT permission is absent. No reinterpretation into another successful operation.
+4. REVOKE reasoning grant -> ADMITTED; future reasoning prohibited; historical receipts preserved.
+5. Current query after revocation -> MATCHED may remain true, but USABLE=false and reasoning from object prohibited.
+6. Historical replay before revocation -> usable under then-recorded policy/authority; replay after revocation -> not usable. No history rewrite.
+
+## Precision lock
+
+`PMEM-OP-001: SPEC_CONFORMANCE=PASS`
+
+`SPECIFICATION != EXECUTION != BYTE-LEVEL VERIFICATION`
+
+- Specification: rule-level PASS against frozen `v1.0 -> 010`.
+- Execution: none claimed by this fixture.
+- Byte-level verification: none claimed by this fixture.
+- No synthetic receipt bytes, runtime ledger events, cryptographic integrity claim, external anchor, or authority are created by this document.
+
+No laundering path is observed in the synthetic specification trace.

--- a/validation/pmem-stack-validation.md
+++ b/validation/pmem-stack-validation.md
@@ -1,0 +1,51 @@
+# PMEM Stack Validation Record
+
+Target: `missions/personal-memory/`  
+Validation class: **STATIC SPECIFICATION VALIDATION**
+
+## Scope
+
+This record validates the materialized documents for internal policy consistency only. It is not a runtime execution receipt and does not claim byte-level PMEM ledger verification.
+
+## Required artifacts
+
+- `CONSTITUTION.md`
+- `PMEM-IMPL-001.md` through `PMEM-IMPL-010.md`
+- `fixtures/PMEM-OP-001.json`
+- `fixtures/REPLAY.md`
+
+## Invariant review
+
+- I1 No Silent Mutation: preserved by immutable identity/type commitments, append-first lifecycle/events, versioned policies, and non-rewriting replay.
+- I2 No Epistemic Laundering: preserved by immutable epistemic type, provenance retention, contradiction preservation, hash/truth separation, and specification/execution separation.
+- I3 No Authority Laundering: preserved by fail-closed authority intersections, explicit purpose/destination permissions, authentication/authorization separation, custody separation, and composition checks.
+
+## Boundary review
+
+- Retrieval laundering: blocked by USABLE gate.
+- Scope/purpose laundering: blocked by explicit capability grants.
+- Integrity laundering: blocked by `HASH != TRUTH` and byte-level verification requirement.
+- Temporal laundering: blocked by freshness/expiration/revalidation rules.
+- Identity laundering: blocked by binding + authentication separation.
+- Custody laundering / revocation rollback: blocked across caches/backups/replicas/restores.
+- Composition/inference leakage: blocked at final disclosure boundary.
+- Retroactive policy laundering: blocked by per-event policy-stack binding.
+
+## PMEM-OP-001
+
+`SPEC_CONFORMANCE=PASS`
+
+Explicitly not claimed:
+
+`RUNTIME_EXECUTED=FALSE`  
+`LEDGER_EVENTS_CREATED=FALSE`  
+`RECEIPT_BYTES_CREATED=FALSE`  
+`CRYPTO_INTEGRITY_VERIFIED=FALSE`  
+`EXTERNAL_ANCHOR=NONE`  
+`AUTHORITY_CREATED=FALSE`
+
+## Result
+
+`STATIC_STACK_VALIDATION=PASS`
+
+This PASS means the materialized specification is internally consistent with the frozen constitutional invariants. It does not establish deployment, runtime enforcement, cryptographic verification, external authority, or institutional adoption.


### PR DESCRIPTION
## What changed

Materializes the frozen Personal Memory constitutional stack as documentation/specification artifacts only.

Added:
- `missions/personal-memory/CONSTITUTION.md` — frozen v1.0 constitution
- `missions/personal-memory/PMEM-IMPL-001.md` through `PMEM-IMPL-010.md`
- `missions/personal-memory/fixtures/PMEM-OP-001.json`
- `missions/personal-memory/fixtures/REPLAY.md`
- `validation/pmem-stack-validation.md`

## Constitutional boundary

```text
I1 = NO SILENT MUTATION
I2 = NO EPISTEMIC LAUNDERING
I3 = NO AUTHORITY LAUNDERING
```

The implementation policies remain subordinate to `PERSONAL-MEMORY-CONSTITUTION-v1.0`. No lower policy amends the constitution.

## Validation

GitHub compare from base `e471c4dc9ed6a10831be2d46e90b33d217f4b216` to head `1cf70e8d37b358a5950cbc0fc6d7477129e3760f` shows:

```text
STATUS        = ahead
COMMITS       = 1
FILES_ADDED   = 14
FILES_DELETED = 0
```

`PMEM-OP-001.json` is materialized as `SPECIFICATION_TRACE` with the locked boundary:

```text
SPEC_CONFORMANCE          = PASS
RUNTIME_EXECUTED          = FALSE
LEDGER_EVENTS_CREATED     = FALSE
RECEIPT_BYTES_CREATED     = FALSE
HASHES_RECOMPUTED         = FALSE
CRYPTO_INTEGRITY_VERIFIED = FALSE
EXTERNAL_ANCHOR           = NONE
AUTHORITY_CREATED         = FALSE
```

## Precision boundary

```text
SPECIFICATION != EXECUTION != BYTE-LEVEL VERIFICATION
HASH != TRUTH
SIGNATURE != AUTHORITY
POSSESSION != AUTHORITY
```

This PR materializes and statically validates the design stack. It does not claim a PMEM runtime, cryptographic ledger verification, external anchoring, deployment, institutional adoption, or authority creation.
