### PR TITLE
Mission control migration engine v0.2

### DIFF
--- a/missions/_SCAFFOLD_v0.2/README.md
+++ b/missions/_SCAFFOLD_v0.2/README.md
@@ -1,0 +1,102 @@
+# COMPUTERWISDOM Mission Migration v0.2
+
+v0.2 performs provenance-preserving **copies** from reviewed source commits into the canonical mission scaffold. It does not create institutional, legal, operational, or epistemic authority.
+
+## Required sequence
+
+```text
+v0.1 DISCOVERY
+  -> CLASSIFICATION
+  -> INDEX
+  -> VALIDATION
+  -> ARTIFACT-LEVEL REVIEW
+  -> SCAFFOLD
+  -> v0.2 PLAN
+  -> EXPLICIT MIGRATION AUTHORIZATION
+  -> COPY
+  -> HASH VERIFICATION
+  -> PROVENANCE RECEIPT
+```
+
+## Reviewed artifact contract
+
+A migration-eligible row must have:
+
+```text
+MIGRATION_STATUS = REVIEWED
+REVIEW_REQUIRED = FALSE
+CLASSIFICATION_AMBIGUOUS = FALSE
+AUTHORITY_CREATED = FALSE
+MISSION_ID = explicit
+ARTIFACT_ID = explicit filesystem-safe id
+SOURCE_SHA = immutable commit
+SOURCE_PATHS = explicit non-empty selectors
+DESTINATION_SUBDIR = explicit approved scaffold class
+```
+
+A branch containing multiple artifacts must be represented by multiple artifact rows. The branch itself is not the migration unit.
+
+## Plan-only default
+
+```powershell
+.\tools\mission_control\migrate_v0_2.ps1
+```
+
+This writes `missions/_MIGRATION_PLAN_v0.2.json` and copies nothing.
+
+## Execution gate
+
+Execution requires all three conditions:
+
+1. The reviewed index explicitly has `MIGRATION_AUTHORIZED = true`.
+2. The runtime environment has `CW_MIGRATION_AUTHORIZED=TRUE`.
+3. The operator invokes the explicit execution path.
+
+```powershell
+$env:CW_MIGRATION_AUTHORIZED='TRUE'
+.\tools\mission_control\migrate_v0_2.ps1 -Execute
+```
+
+If any gate is missing, execution fails closed.
+
+## Destination behavior
+
+Files are copied beneath:
+
+```text
+missions/<MISSION_ID>/<DESTINATION_SUBDIR>/<ARTIFACT_ID>/<original-source-path>
+```
+
+This preserves original source-path identity and prevents unrelated artifacts from silently overwriting each other. Existing destination files with different bytes cause a hard failure.
+
+## Receipts
+
+Successful copies write:
+
+```text
+missions/<MISSION_ID>/receipts/migration-v0.2/<ARTIFACT_ID>.provenance.json
+```
+
+The receipt binds the original branch, immutable source SHA, explicit selectors, destination, file hashes, and copy event.
+
+It always records:
+
+```text
+EVENT = COPY_HASH_VERIFIED
+AUTHORITY_CREATED = FALSE
+AUTHORITY_GRANT = null
+ORIGINAL_BRANCH_DELETED = FALSE
+```
+
+## Invariants
+
+```text
+COPY != AUTHORITY
+PROVENANCE_RECEIPT != AUTHORITY_GRANT
+HANDOFF != EVIDENCE
+BRANCH != ARTIFACT
+MIGRATION != PROMOTION
+ORIGINAL_BRANCHES remain untouched
+```
+
+Branch archival/deletion, corpus admission, authority establishment, and mission promotion are separate future operations and are intentionally outside v0.2.

--- a/tools/mission_control/migrate_v0_2.ps1
+++ b/tools/mission_control/migrate_v0_2.ps1
@@ -1,0 +1,31 @@
+param(
+    [switch]$Execute
+)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host 'MISSION_CONTROL MIGRATION v0.2'
+Write-Host 'COPY != AUTHORITY'
+Write-Host 'PROVENANCE_RECEIPT != AUTHORITY_GRANT'
+Write-Host ''
+
+if (-not $Execute) {
+    python tools/mission_control/migrate_v0_2.py
+    exit $LASTEXITCODE
+}
+
+if ($env:CW_MIGRATION_AUTHORIZED -ne 'TRUE') {
+    Write-Error 'Execution denied: set CW_MIGRATION_AUTHORIZED=TRUE only after reviewing the migration plan and explicitly authorizing migration.'
+    exit 2
+}
+
+python tools/mission_control/migrate_v0_2.py --execute
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+python tools/mission_control/validate_migration_v0_2.py
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host ''
+Write-Host 'COPY_HASH_VERIFIED = TRUE'
+Write-Host 'AUTHORITY_CREATED = FALSE'
+Write-Host 'ORIGINAL_BRANCHES_DELETED = FALSE'

--- a/tools/mission_control/migrate_v0_2.py
+++ b/tools/mission_control/migrate_v0_2.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+
+ROOT = Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip())
+INDEX = ROOT / "missions" / "_MISSION_INDEX.json"
+PLAN = ROOT / "missions" / "_MIGRATION_PLAN_v0.2.json"
+ALLOWED_DESTINATION_SUBDIRS = {
+    "control/state", "control/handoffs", "sources", "corpus/raw",
+    "receipts", "manifests", "analysis", "schemas", "tests"
+}
+SAFE_ID = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def git_text(*args):
+    return subprocess.check_output(["git", *args], cwd=ROOT, text=True, errors="replace").strip()
+
+
+def git_ok(*args):
+    return subprocess.run(["git", *args], cwd=ROOT, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def validate_row(e):
+    errors = []
+    if e.get("MIGRATION_STATUS") != "REVIEWED":
+        errors.append("MIGRATION_STATUS must be REVIEWED")
+    if e.get("REVIEW_REQUIRED") is not False:
+        errors.append("REVIEW_REQUIRED must be false")
+    if e.get("AUTHORITY_CREATED") is not False:
+        errors.append("AUTHORITY_CREATED must remain false")
+    if e.get("MISSION_ID") in (None, "", "UNKNOWN"):
+        errors.append("MISSION_ID must be explicit")
+    if e.get("CLASSIFICATION_AMBIGUOUS") is True:
+        errors.append("CLASSIFICATION_AMBIGUOUS must be false")
+    artifact_id = e.get("ARTIFACT_ID")
+    if not artifact_id or artifact_id == "UNSPLIT_BRANCH_TIP" or not SAFE_ID.fullmatch(artifact_id):
+        errors.append("ARTIFACT_ID must be explicit and filesystem-safe")
+    if not isinstance(e.get("SOURCE_PATHS"), list) or not e.get("SOURCE_PATHS"):
+        errors.append("SOURCE_PATHS must be a non-empty explicit list")
+    if e.get("DESTINATION_SUBDIR") not in ALLOWED_DESTINATION_SUBDIRS:
+        errors.append("DESTINATION_SUBDIR is not approved")
+    expected = f"missions/{e.get('MISSION_ID')}/"
+    if e.get("CANONICAL_DESTINATION") != expected:
+        errors.append(f"CANONICAL_DESTINATION must equal {expected}")
+    sha = e.get("SOURCE_SHA")
+    if not sha or not git_ok("cat-file", "-e", f"{sha}^{{commit}}"):
+        errors.append("SOURCE_SHA is not a resolvable commit")
+    for p in e.get("SOURCE_PATHS", []):
+        pp = PurePosixPath(p)
+        if p in ("", ".") or pp.is_absolute() or ".." in pp.parts:
+            errors.append(f"unsafe SOURCE_PATH: {p}")
+        elif sha and not git_ok("cat-file", "-e", f"{sha}:{p}"):
+            errors.append(f"SOURCE_PATH not found at SOURCE_SHA: {p}")
+    return errors
+
+
+def reviewed_rows(doc):
+    rows = []
+    blocked = []
+    for e in doc.get("entries", []):
+        if e.get("MIGRATION_STATUS") != "REVIEWED":
+            continue
+        errors = validate_row(e)
+        if errors:
+            blocked.append({"DISCOVERY_ID": e.get("DISCOVERY_ID"), "ARTIFACT_ID": e.get("ARTIFACT_ID"), "errors": errors})
+        else:
+            rows.append(e)
+    return rows, blocked
+
+
+def write_plan(doc, rows, blocked):
+    plan = {
+        "PLAN_VERSION": "0.2",
+        "GENERATED_AT_UTC": datetime.now(timezone.utc).isoformat(),
+        "INDEX_REGISTRY_VERSION": doc.get("REGISTRY_VERSION"),
+        "INDEX_MIGRATION_AUTHORIZED": doc.get("MIGRATION_AUTHORIZED"),
+        "AUTHORITY_CREATED": False,
+        "eligible_count": len(rows),
+        "blocked_count": len(blocked),
+        "eligible": [
+            {
+                "DISCOVERY_ID": e["DISCOVERY_ID"],
+                "ARTIFACT_ID": e["ARTIFACT_ID"],
+                "MISSION_ID": e["MISSION_ID"],
+                "BRANCH": e["BRANCH"],
+                "SOURCE_SHA": e["SOURCE_SHA"],
+                "SOURCE_PATHS": e["SOURCE_PATHS"],
+                "DESTINATION": f"{e['CANONICAL_DESTINATION']}{e['DESTINATION_SUBDIR']}/{e['ARTIFACT_ID']}/",
+            }
+            for e in rows
+        ],
+        "blocked": blocked,
+    }
+    PLAN.write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+    return plan
+
+
+def safe_members(tf):
+    members = []
+    for m in tf.getmembers():
+        p = PurePosixPath(m.name)
+        if p.is_absolute() or ".." in p.parts:
+            raise RuntimeError(f"unsafe archive member: {m.name}")
+        if not (m.isdir() or m.isfile()):
+            raise RuntimeError(f"unsupported archive member type: {m.name}")
+        members.append(m)
+    return members
+
+
+def stage_row(e, stage_root):
+    artifact_stage = stage_root / e["ARTIFACT_ID"]
+    artifact_stage.mkdir(parents=True, exist_ok=True)
+    cmd = ["git", "archive", "--format=tar", e["SOURCE_SHA"], "--", *e["SOURCE_PATHS"]]
+    archive_bytes = subprocess.check_output(cmd, cwd=ROOT)
+    tf = tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:")
+    members = safe_members(tf)
+    files = []
+    for m in members:
+        target = artifact_stage / Path(*PurePosixPath(m.name).parts)
+        if m.isdir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        src = tf.extractfile(m)
+        if src is None:
+            raise RuntimeError(f"could not extract {m.name}")
+        with src, open(target, "wb") as out:
+            shutil.copyfileobj(src, out)
+        files.append({"source_member": m.name, "sha256": sha256_file(target), "size": target.stat().st_size})
+    return artifact_stage, files
+
+
+def destination_root(e):
+    return ROOT / e["CANONICAL_DESTINATION"] / e["DESTINATION_SUBDIR"] / e["ARTIFACT_ID"]
+
+
+def preflight_destination(stage, dest):
+    for src in stage.rglob("*"):
+        if not src.is_file():
+            continue
+        rel = src.relative_to(stage)
+        target = dest / rel
+        if target.exists() and (not target.is_file() or sha256_file(target) != sha256_file(src)):
+            raise RuntimeError(f"destination collision with different content: {target}")
+
+
+def copy_stage(stage, dest):
+    for src in stage.rglob("*"):
+        rel = src.relative_to(stage)
+        target = dest / rel
+        if src.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        elif not target.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, target)
+
+
+def write_receipt(e, files):
+    receipt_dir = ROOT / e["CANONICAL_DESTINATION"] / "receipts" / "migration-v0.2"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    receipt_path = receipt_dir / f"{e['ARTIFACT_ID']}.provenance.json"
+    receipt = {
+        "RECEIPT_VERSION": "0.2",
+        "EVENT": "COPY_HASH_VERIFIED",
+        "COPIED_AT_UTC": datetime.now(timezone.utc).isoformat(),
+        "DISCOVERY_ID": e["DISCOVERY_ID"],
+        "ARTIFACT_ID": e["ARTIFACT_ID"],
+        "MISSION_ID": e["MISSION_ID"],
+        "ORIGINAL_BRANCH": e["BRANCH"],
+        "SOURCE_SHA": e["SOURCE_SHA"],
+        "SOURCE_PATHS": e["SOURCE_PATHS"],
+        "DESTINATION_SUBDIR": e["DESTINATION_SUBDIR"],
+        "DESTINATION_ROOT": str(destination_root(e).relative_to(ROOT)).replace(os.sep, "/"),
+        "FILES": files,
+        "AUTHORITY_CREATED": False,
+        "AUTHORITY_GRANT": None,
+        "ORIGINAL_BRANCH_DELETED": False,
+    }
+    data = json.dumps(receipt, indent=2) + "\n"
+    if receipt_path.exists() and receipt_path.read_text(encoding="utf-8") != data:
+        raise RuntimeError(f"receipt already exists with different content: {receipt_path}")
+    receipt_path.write_text(data, encoding="utf-8")
+    return receipt_path
+
+
+def execute(rows):
+    completed = []
+    with tempfile.TemporaryDirectory(prefix="cw-migrate-v0-2-") as td:
+        stage_root = Path(td)
+        staged = []
+        for e in rows:
+            stage, files = stage_row(e, stage_root)
+            dest = destination_root(e)
+            preflight_destination(stage, dest)
+            staged.append((e, stage, files, dest))
+        for e, stage, files, dest in staged:
+            copy_stage(stage, dest)
+            receipt = write_receipt(e, files)
+            completed.append({"ARTIFACT_ID": e["ARTIFACT_ID"], "destination": str(dest.relative_to(ROOT)), "receipt": str(receipt.relative_to(ROOT))})
+    return completed
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Plan or execute provenance-preserving mission copies.")
+    ap.add_argument("--execute", action="store_true", help="Execute eligible reviewed copies. Default is plan-only.")
+    args = ap.parse_args()
+
+    doc = json.loads(INDEX.read_text(encoding="utf-8"))
+    rows, blocked = reviewed_rows(doc)
+    plan = write_plan(doc, rows, blocked)
+    print(f"Plan: eligible={plan['eligible_count']} blocked={plan['blocked_count']} -> {PLAN}")
+
+    if blocked:
+        print("Fail-closed: at least one REVIEWED row is invalid.")
+        raise SystemExit(2)
+    if not args.execute:
+        print("PLAN_ONLY: no files copied; no authority created.")
+        return
+
+    gates = {
+        "INDEX_MIGRATION_AUTHORIZED": doc.get("MIGRATION_AUTHORIZED") is True,
+        "ENV_CW_MIGRATION_AUTHORIZED": os.environ.get("CW_MIGRATION_AUTHORIZED") == "TRUE",
+        "EXECUTE_FLAG": args.execute,
+    }
+    failed = [k for k, v in gates.items() if not v]
+    if failed:
+        raise SystemExit("Execution denied; unsatisfied gates: " + ", ".join(failed))
+    if not rows:
+        raise SystemExit("Execution denied; zero reviewed migration rows")
+
+    completed = execute(rows)
+    print(f"COPIED_HASH_VERIFIED={len(completed)}")
+    print("AUTHORITY_CREATED=FALSE")
+    print("ORIGINAL_BRANCHES_DELETED=FALSE")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/mission_control/migrate_v0_2.py
+++ b/tools/mission_control/migrate_v0_2.py
@@ -22,10 +22,6 @@ ALLOWED_DESTINATION_SUBDIRS = {
 SAFE_ID = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
-def git_text(*args):
-    return subprocess.check_output(["git", *args], cwd=ROOT, text=True, errors="replace").strip()
-
-
 def git_ok(*args):
     return subprocess.run(["git", *args], cwd=ROOT, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
 
@@ -50,35 +46,72 @@ def validate_row(e):
         errors.append("MISSION_ID must be explicit")
     if e.get("CLASSIFICATION_AMBIGUOUS") is True:
         errors.append("CLASSIFICATION_AMBIGUOUS must be false")
+
     artifact_id = e.get("ARTIFACT_ID")
     if not artifact_id or artifact_id == "UNSPLIT_BRANCH_TIP" or not SAFE_ID.fullmatch(artifact_id):
         errors.append("ARTIFACT_ID must be explicit and filesystem-safe")
-    if not isinstance(e.get("SOURCE_PATHS"), list) or not e.get("SOURCE_PATHS"):
+
+    source_paths = e.get("SOURCE_PATHS")
+    if not isinstance(source_paths, list) or not source_paths:
         errors.append("SOURCE_PATHS must be a non-empty explicit list")
+        source_paths = []
+
     if e.get("DESTINATION_SUBDIR") not in ALLOWED_DESTINATION_SUBDIRS:
         errors.append("DESTINATION_SUBDIR is not approved")
+
     expected = f"missions/{e.get('MISSION_ID')}/"
     if e.get("CANONICAL_DESTINATION") != expected:
         errors.append(f"CANONICAL_DESTINATION must equal {expected}")
+
     sha = e.get("SOURCE_SHA")
     if not sha or not git_ok("cat-file", "-e", f"{sha}^{{commit}}"):
         errors.append("SOURCE_SHA is not a resolvable commit")
-    for p in e.get("SOURCE_PATHS", []):
+
+    normalized = []
+    for p in source_paths:
+        if not isinstance(p, str):
+            errors.append(f"SOURCE_PATH must be a string: {p!r}")
+            continue
         pp = PurePosixPath(p)
         if p in ("", ".") or pp.is_absolute() or ".." in pp.parts:
             errors.append(f"unsafe SOURCE_PATH: {p}")
-        elif sha and not git_ok("cat-file", "-e", f"{sha}:{p}"):
-            errors.append(f"SOURCE_PATH not found at SOURCE_SHA: {p}")
+            continue
+        norm = pp.as_posix().rstrip("/")
+        normalized.append(norm)
+        if sha and not git_ok("cat-file", "-e", f"{sha}:{norm}"):
+            errors.append(f"SOURCE_PATH not found at SOURCE_SHA: {norm}")
+
+    if len(normalized) != len(set(normalized)):
+        errors.append("SOURCE_PATHS contains duplicates")
+    for i, a in enumerate(normalized):
+        ap = PurePosixPath(a)
+        for b in normalized[i + 1:]:
+            bp = PurePosixPath(b)
+            if ap in bp.parents or bp in ap.parents:
+                errors.append(f"SOURCE_PATHS overlap: {a} <-> {b}")
+
     return errors
+
+
+def destination_string(e):
+    return f"{e['CANONICAL_DESTINATION']}{e['DESTINATION_SUBDIR']}/{e['ARTIFACT_ID']}/"
 
 
 def reviewed_rows(doc):
     rows = []
     blocked = []
+    destinations = {}
     for e in doc.get("entries", []):
         if e.get("MIGRATION_STATUS") != "REVIEWED":
             continue
         errors = validate_row(e)
+        if not errors:
+            dest = destination_string(e)
+            prior = destinations.get(dest)
+            if prior is not None:
+                errors.append(f"destination collides with {prior}")
+            else:
+                destinations[dest] = f"{e.get('DISCOVERY_ID')}::{e.get('ARTIFACT_ID')}"
         if errors:
             blocked.append({"DISCOVERY_ID": e.get("DISCOVERY_ID"), "ARTIFACT_ID": e.get("ARTIFACT_ID"), "errors": errors})
         else:
@@ -103,7 +136,7 @@ def write_plan(doc, rows, blocked):
                 "BRANCH": e["BRANCH"],
                 "SOURCE_SHA": e["SOURCE_SHA"],
                 "SOURCE_PATHS": e["SOURCE_PATHS"],
-                "DESTINATION": f"{e['CANONICAL_DESTINATION']}{e['DESTINATION_SUBDIR']}/{e['ARTIFACT_ID']}/",
+                "DESTINATION": destination_string(e),
             }
             for e in rows
         ],
@@ -126,25 +159,27 @@ def safe_members(tf):
 
 
 def stage_row(e, stage_root):
-    artifact_stage = stage_root / e["ARTIFACT_ID"]
-    artifact_stage.mkdir(parents=True, exist_ok=True)
+    stage_name = f"{e['DISCOVERY_ID'][:12]}-{e['ARTIFACT_ID']}"
+    artifact_stage = stage_root / stage_name
+    artifact_stage.mkdir(parents=True, exist_ok=False)
     cmd = ["git", "archive", "--format=tar", e["SOURCE_SHA"], "--", *e["SOURCE_PATHS"]]
     archive_bytes = subprocess.check_output(cmd, cwd=ROOT)
-    tf = tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:")
-    members = safe_members(tf)
-    files = []
-    for m in members:
-        target = artifact_stage / Path(*PurePosixPath(m.name).parts)
-        if m.isdir():
-            target.mkdir(parents=True, exist_ok=True)
-            continue
-        target.parent.mkdir(parents=True, exist_ok=True)
-        src = tf.extractfile(m)
-        if src is None:
-            raise RuntimeError(f"could not extract {m.name}")
-        with src, open(target, "wb") as out:
-            shutil.copyfileobj(src, out)
-        files.append({"source_member": m.name, "sha256": sha256_file(target), "size": target.stat().st_size})
+    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:") as tf:
+        members = safe_members(tf)
+        files = []
+        for m in members:
+            target = artifact_stage / Path(*PurePosixPath(m.name).parts)
+            if m.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            src = tf.extractfile(m)
+            if src is None:
+                raise RuntimeError(f"could not extract {m.name}")
+            with src, open(target, "wb") as out:
+                shutil.copyfileobj(src, out)
+            files.append({"source_member": m.name, "sha256": sha256_file(target), "size": target.stat().st_size})
+    files.sort(key=lambda x: x["source_member"])
     return artifact_stage, files
 
 
@@ -173,14 +208,10 @@ def copy_stage(stage, dest):
             shutil.copy2(src, target)
 
 
-def write_receipt(e, files):
-    receipt_dir = ROOT / e["CANONICAL_DESTINATION"] / "receipts" / "migration-v0.2"
-    receipt_dir.mkdir(parents=True, exist_ok=True)
-    receipt_path = receipt_dir / f"{e['ARTIFACT_ID']}.provenance.json"
-    receipt = {
+def receipt_stable_fields(e, files):
+    return {
         "RECEIPT_VERSION": "0.2",
         "EVENT": "COPY_HASH_VERIFIED",
-        "COPIED_AT_UTC": datetime.now(timezone.utc).isoformat(),
         "DISCOVERY_ID": e["DISCOVERY_ID"],
         "ARTIFACT_ID": e["ARTIFACT_ID"],
         "MISSION_ID": e["MISSION_ID"],
@@ -194,10 +225,23 @@ def write_receipt(e, files):
         "AUTHORITY_GRANT": None,
         "ORIGINAL_BRANCH_DELETED": False,
     }
-    data = json.dumps(receipt, indent=2) + "\n"
-    if receipt_path.exists() and receipt_path.read_text(encoding="utf-8") != data:
-        raise RuntimeError(f"receipt already exists with different content: {receipt_path}")
-    receipt_path.write_text(data, encoding="utf-8")
+
+
+def write_receipt(e, files):
+    receipt_dir = ROOT / e["CANONICAL_DESTINATION"] / "receipts" / "migration-v0.2"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    receipt_path = receipt_dir / f"{e['ARTIFACT_ID']}.provenance.json"
+    stable = receipt_stable_fields(e, files)
+
+    if receipt_path.exists():
+        existing = json.loads(receipt_path.read_text(encoding="utf-8"))
+        existing_stable = {k: existing.get(k) for k in stable}
+        if existing_stable != stable:
+            raise RuntimeError(f"receipt already exists with different provenance: {receipt_path}")
+        return receipt_path
+
+    receipt = {"COPIED_AT_UTC": datetime.now(timezone.utc).isoformat(), **stable}
+    receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
     return receipt_path
 
 

--- a/tools/mission_control/migrate_v0_2.py
+++ b/tools/mission_control/migrate_v0_2.py
@@ -208,6 +208,18 @@ def copy_stage(stage, dest):
             shutil.copy2(src, target)
 
 
+def verify_destination(stage, dest):
+    for src in stage.rglob("*"):
+        if not src.is_file():
+            continue
+        rel = src.relative_to(stage)
+        target = dest / rel
+        if not target.is_file():
+            raise RuntimeError(f"destination verification missing file: {target}")
+        if sha256_file(target) != sha256_file(src):
+            raise RuntimeError(f"destination verification hash mismatch: {target}")
+
+
 def receipt_stable_fields(e, files):
     return {
         "RECEIPT_VERSION": "0.2",
@@ -257,6 +269,7 @@ def execute(rows):
             staged.append((e, stage, files, dest))
         for e, stage, files, dest in staged:
             copy_stage(stage, dest)
+            verify_destination(stage, dest)
             receipt = write_receipt(e, files)
             completed.append({"ARTIFACT_ID": e["ARTIFACT_ID"], "destination": str(dest.relative_to(ROOT)), "receipt": str(receipt.relative_to(ROOT))})
     return completed

--- a/tools/mission_control/validate_migration_v0_2.py
+++ b/tools/mission_control/validate_migration_v0_2.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+import subprocess
+from pathlib import Path, PurePosixPath
+
+ROOT = Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip())
+RECEIPT_GLOB = "missions/*/receipts/migration-v0.2/*.provenance.json"
+
+
+def sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def git_blob(sha, path):
+    return subprocess.check_output(["git", "show", f"{sha}:{path}"], cwd=ROOT)
+
+
+def main():
+    receipts = sorted(ROOT.glob(RECEIPT_GLOB))
+    errors = []
+    checked_files = 0
+
+    for receipt_path in receipts:
+        r = json.loads(receipt_path.read_text(encoding="utf-8"))
+        label = str(receipt_path.relative_to(ROOT))
+        if r.get("EVENT") != "COPY_HASH_VERIFIED":
+            errors.append(f"{label}: unexpected EVENT")
+        if r.get("AUTHORITY_CREATED") is not False or r.get("AUTHORITY_GRANT") is not None:
+            errors.append(f"{label}: provenance receipt must not grant authority")
+        if r.get("ORIGINAL_BRANCH_DELETED") is not False:
+            errors.append(f"{label}: original branch deletion recorded")
+
+        sha = r.get("SOURCE_SHA")
+        dest_root = ROOT / r.get("DESTINATION_ROOT", "")
+        if not dest_root.resolve().is_relative_to(ROOT.resolve()):
+            errors.append(f"{label}: destination escapes repository root")
+            continue
+
+        for f in r.get("FILES", []):
+            member = f.get("source_member")
+            expected = f.get("sha256")
+            pp = PurePosixPath(member or "")
+            if not member or pp.is_absolute() or ".." in pp.parts:
+                errors.append(f"{label}: unsafe source_member {member}")
+                continue
+            dest = dest_root / Path(*pp.parts)
+            if not dest.is_file():
+                errors.append(f"{label}: missing destination file {dest.relative_to(ROOT)}")
+                continue
+            dest_hash = sha256_file(dest)
+            if dest_hash != expected:
+                errors.append(f"{label}: destination hash mismatch {dest.relative_to(ROOT)}")
+            try:
+                source_hash = sha256_bytes(git_blob(sha, member))
+            except subprocess.CalledProcessError:
+                errors.append(f"{label}: source blob not resolvable {sha}:{member}")
+                continue
+            if source_hash != expected:
+                errors.append(f"{label}: source hash mismatch {sha}:{member}")
+            checked_files += 1
+
+    print(f"receipts={len(receipts)} files_checked={checked_files} errors={len(errors)}")
+    for e in errors:
+        print(f"ERROR {e}")
+    if not receipts:
+        print("NO_MIGRATION_RECEIPTS_FOUND")
+    raise SystemExit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

Adds the executable migration layer as a stacked follow-up to scaffold PR #449.

- plan-only by default
- reviewed artifact rows only
- explicit `ARTIFACT_ID`, `SOURCE_PATHS`, and `DESTINATION_SUBDIR` required
- rejects overlapping source selectors and destination collisions
- stages bytes from immutable `SOURCE_SHA` using `git archive`
- rejects symlink/special archive members and unsafe paths
- preserves original source paths beneath artifact-scoped destination roots
- preflights existing destination hashes before writes
- verifies destination hashes after copy before writing a receipt
- idempotently reuses an existing matching provenance receipt
- adds independent migration receipt verifier
- adds Windows PowerShell runner

## Three-key execution gate

```text
ROW: MIGRATION_STATUS = REVIEWED
INDEX: MIGRATION_AUTHORIZED = TRUE
RUNTIME: CW_MIGRATION_AUTHORIZED = TRUE + --execute
```

Default invocation only emits `missions/_MIGRATION_PLAN_v0.2.json`.

## Authority boundary

```text
COPY != AUTHORITY
PROVENANCE_RECEIPT != AUTHORITY_GRANT
MIGRATION != PROMOTION
AUTHORITY_CREATED = FALSE
ORIGINAL_BRANCHES_DELETED = FALSE
```

The engine does not mutate registry rows to claim authority, does not delete/archive source branches, and does not admit copied material into a corpus merely by copying it.

## Stack

Base: `agent/mission-control-scaffold-v0-1` (PR #449)
Head: `agent/mission-control-migration-v0-2`

This PR should remain stacked/draft until the v0.1 registry has been generated and manually reviewed in an actual COMPUTERWISDOM checkout.