### PR TITLE
Add classification-debt intercept safeguards

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -100,6 +100,45 @@ Required invariants:
 - EAS witnesses, but does not create global legitimacy;
 - ENS discovers, but does not create authority.
 
+## Classification-Debt Intercept Safeguards (Issue #453)
+
+The system SHALL apply the following safeguards whenever a classification-debt intercept is detected:
+
+1. **LABEL_PROVISIONAL**
+   - A classification derived from an observation MUST remain `PROVISIONAL` until source-bound, contradiction-aware validation is complete.
+   - Interface or connector failure MUST NOT be promoted into a capability, permission, role, or identity claim.
+
+2. **CLAIM_SOURCE_REQUIRED**
+   - No capability, permission, role, or identity MAY be inferred from an observation alone.
+   - Every classification MUST include an explicit, human-auditable `CLAIM_SOURCE` and evidence reference.
+
+3. **CONTRADICTION-DRIVEN_RECLASSIFICATION**
+   - A material contradiction SHALL trigger reclassification and replay through the Epistemic Stack validators.
+   - The prior label MUST remain append-only evidence and MUST be marked superseded by a new reclassification receipt; it MUST NOT be silently erased or mutated.
+
+### Human Appeal Path (Six Questions)
+
+The system SHALL provide a human appeal path that answers:
+
+1. Who labeled me?
+2. From what evidence?
+3. When?
+4. Under which rule?
+5. What changed because of it?
+6. How do I correct it?
+
+The answers and resulting reclassification MUST be preserved as replayable receipts. Neither classification nor reclassification creates authority.
+
+```json
+{
+  "label_provisional": true,
+  "claim_source_required": true,
+  "contradiction_reclassification": "REQUIRED",
+  "appeal_path": "MANDATORY",
+  "authority": false
+}
+```
+
 ## Operator Quick Rule
 
 ```text

--- a/docs/COMPUTERWISDOM_EPISTEMIC_STACK_V0_1.md
+++ b/docs/COMPUTERWISDOM_EPISTEMIC_STACK_V0_1.md
@@ -295,6 +295,43 @@ The next real proof boundary is not another concept. It is evidence-driven imple
 4. Validate admissions transitions.
 5. Only then consider runtime replay testing.
 
+## 13. Validator Requirements: Anti Observation-to-Capability Laundering
+
+Validators MUST enforce the following invariants:
+
+- **Observation != Capability**
+  No validator MAY treat an observation, interface failure, or connector state as evidence of capability, permission, role, or identity.
+
+- **Source-Bound Classification**
+  Every classification MUST include a `CLAIM_SOURCE` and stable evidence reference in a replayable receipt.
+
+- **Provisional-by-Default**
+  A classification remains `PROVISIONAL` until its source and evidence satisfy the applicable validator rules.
+
+- **Contradiction Priority**
+  A material contradiction MUST trigger replay through all applicable validators and emit a reclassification receipt.
+
+- **Append-Only Reclassification**
+  Reclassification MUST preserve the prior label and mark it superseded. Validators MUST NOT silently erase or mutate earlier evidence.
+
+- **Replay Determinism**
+  Identical evidence and validator versions MUST produce identical classification outputs. No validator MAY mutate evidence or create authority.
+
+- **Capability Isolation**
+  Validators MAY NOT infer capabilities from connector metadata, wallet activity, observation frequency, or a temporary interface failure.
+
+- **Appeal-Ready State**
+  Validators MUST emit structured receipts answering the six-question human appeal path defined in `CHARTER.md`.
+
+```json
+{
+  "validator_mode": "ANTI_OBSERVATION_TO_CAPABILITY_LAUNDERING",
+  "contradiction_reclassification": "REQUIRED",
+  "prior_labels": "APPEND_ONLY_SUPERSEDED",
+  "authority": false
+}
+```
+
 ## Final Lock Phrase
 
 **Data may move fast. Authority may not.**


### PR DESCRIPTION
## Summary

Adds a classification-debt intercept to the operating charter and Epistemic Stack.

The concrete failure pattern is:

- observed: wallet connector failure
- machine label: signer interface unavailable
- inherited conclusion: EAS dry run impossible
- contradiction: the signer already had established schemas and 74 Base attestations

## Changes

- makes observation-derived labels provisional
- requires a human-auditable claim source and evidence reference
- prohibits interface failure from becoming a capability or identity claim
- requires contradiction-driven reclassification
- preserves prior labels as append-only, superseded evidence
- adds the six-question human appeal path
- hardens validators against observation-to-capability laundering
- preserves replay determinism and `authority:false`

## Scope

Only these files are changed:

- `CHARTER.md`
- `docs/COMPUTERWISDOM_EPISTEMIC_STACK_V0_1.md`

Documentation/doctrine-only change. No runtime, signer, wallet, deployment, or authority mutation.

Closes #453