### PR TITLE
Add Minnesota PublicProof Round 001

### DIFF
--- a/fixtures/publicproof/MN_2026_PRIORITY_MATRIX_001.json
+++ b/fixtures/publicproof/MN_2026_PRIORITY_MATRIX_001.json
@@ -1,0 +1,51 @@
+{
+  "mode": "MINNESOTA_MATH_MATRIX_PUBLIC_POSTS_PRIORITY_PEGGYPROOFPLAYER1",
+  "purpose": "VERIFICATION_PRIORITY_ONLY",
+  "budget_per_participant": 100,
+  "player": {
+    "id": "PEGGYPLAYER1",
+    "role": "case_label_only",
+    "candidate_preference_scored": false,
+    "party_preference_scored": false,
+    "guilt_scored_by_public_vote": false
+  },
+  "quadratic_rule": {
+    "allocation_symbol": "q_j",
+    "claim_cost": "q_j^2",
+    "ballot_cost": "sum(q_j^2)",
+    "constraint": "sum(q_j^2) <= 100"
+  },
+  "claims": [
+    {"id": "CLAIMED_STING", "status": "HOLD"},
+    {"id": "NO_ID_ACTIVE_VOTER", "status": "VERIFIED"},
+    {"id": "8_PERSON_VOUCHING", "status": "VERIFIED"},
+    {"id": "VOUCH_PROVES_CITIZENSHIP", "status": "FALSE"},
+    {"id": "IMPERSONATION_OCCURRED", "status": "VIDEO_NEEDED"},
+    {"id": "ILLEGAL_BALLOT_CAST", "status": "NOT_PROVEN"},
+    {"id": "PEGGY_INVOLVEMENT", "status": "NOT_ESTABLISHED"}
+  ],
+  "ballots": [],
+  "public_post_protocol": {
+    "accepted_action": "ALLOCATE_VERIFICATION_PRIORITY",
+    "not_accepted_actions": [
+      "VOTE_CANDIDATE",
+      "VOTE_PARTY",
+      "VOTE_GUILTY",
+      "VOTE_TRUE_FALSE",
+      "CHANGE_ELECTION_RESULT"
+    ],
+    "minimum_receipt_fields": [
+      "participant_id",
+      "allocations"
+    ],
+    "anti_brigading_note": "A public tally is an attention signal only. Identity/Sybil controls are a separate unresolved layer and must not be inferred from account count.",
+    "evidence_separation": "Priority votes select what to investigate next; only replayable evidence may change a claim status."
+  },
+  "seed_state": {
+    "synthetic_ballots_added": 0,
+    "public_ballots_recorded": 0,
+    "priority_winner": null,
+    "reason": "No public participation has been recorded. Do not fabricate a crowd signal."
+  },
+  "authority_created": false
+}

--- a/fixtures/publicproof/MN_2026_ROUND_001.json
+++ b/fixtures/publicproof/MN_2026_ROUND_001.json
@@ -1,0 +1,105 @@
+{
+  "game": "QUANTUM_PUBLIC_PROOF_PRIORITY_PERFECT_PRESS",
+  "round_id": "MN_2026_ROUND_001",
+  "title": "Polling-Place Sting",
+  "player": {
+    "id": "PEGGYPLAYER1",
+    "name": "Peggy Flanagan",
+    "role": "case_label_only",
+    "party_changes_score": false,
+    "involvement_in_claimed_sting": "NOT_ESTABLISHED"
+  },
+  "election_context": {
+    "election_date": "2026-08-11",
+    "office": "U.S. Senator",
+    "party": "Democratic-Farmer-Labor",
+    "results_status": "UNOFFICIAL_PENDING_STATE_CANVASS",
+    "state_canvass_date": "2026-08-18",
+    "precincts_reporting_percent": 100,
+    "flanagan_votes": 411541,
+    "flanagan_percent": 59.02
+  },
+  "scoring": {
+    "primary_government_record": 100,
+    "full_original_video": 80,
+    "independent_corroboration": 60,
+    "complete_contextual_quote": 40,
+    "campaign_party_assertion": 10,
+    "cropped_viral_clip": 0,
+    "unsupported_accusation": -50,
+    "proven_fabrication": -100
+  },
+  "claims": [
+    {
+      "id": "CLAIMED_STING",
+      "status": "HOLD",
+      "reason": "Original full video has not been supplied to this fixture."
+    },
+    {
+      "id": "NO_ID_ACTIVE_VOTER",
+      "status": "VERIFIED",
+      "reason": "Minnesota Secretary of State states that a current and active registered voter does not need to bring identification."
+    },
+    {
+      "id": "8_PERSON_VOUCHING",
+      "status": "VERIFIED",
+      "reason": "Minnesota law permits an ordinary registered precinct voter to sign up to eight proof-of-residence oaths on an election day."
+    },
+    {
+      "id": "VOUCH_PROVES_CITIZENSHIP",
+      "status": "FALSE",
+      "reason": "The voucher oath described in section 201.061 attests to precinct residence; voter eligibility, including citizenship, is a separate legal requirement."
+    },
+    {
+      "id": "IMPERSONATION_OCCURRED",
+      "status": "VIDEO_NEEDED",
+      "reason": "The claimed interaction requires the complete original recording and sufficient context for independent replay."
+    },
+    {
+      "id": "ILLEGAL_BALLOT_CAST",
+      "status": "NOT_PROVEN",
+      "reason": "No evidence in this fixture establishes that an illegal ballot was actually cast or counted."
+    },
+    {
+      "id": "PEGGY_INVOLVEMENT",
+      "status": "NOT_ESTABLISHED",
+      "reason": "No evidence in this fixture connects Peggy Flanagan to the claimed polling-place conduct."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "MN_SOS_ID_RULE",
+      "type": "primary_government_record",
+      "points": 100,
+      "supports": ["NO_ID_ACTIVE_VOTER"],
+      "url": "https://www.sos.mn.gov/elections-voting/election-day-voting/do-i-need-to-bring-id/"
+    },
+    {
+      "id": "MN_STATUTE_201_061",
+      "type": "primary_government_record",
+      "points": 100,
+      "supports": ["8_PERSON_VOUCHING", "VOUCH_PROVES_CITIZENSHIP"],
+      "url": "https://www.revisor.mn.gov/statutes/?id=201.061"
+    },
+    {
+      "id": "MN_SOS_2026_PRIMARY_RESULTS",
+      "type": "primary_government_record",
+      "points": 100,
+      "supports": ["ELECTION_CONTEXT"],
+      "url": "https://electionresults.sos.mn.gov/Results/Index?ErsElectionId=200&electionDate=08%2F11%2F2026+00%3A00%3A00&officeInElectionIdList=-1&officeInElectionIdList=38485&scenario=USSenate"
+    }
+  ],
+  "missing_receipts": [
+    "full_original_video",
+    "video_metadata_or_chain_of_custody",
+    "independent_corroboration_of_claimed_impersonation",
+    "evidence_of_any_illegal_ballot_being_cast_or_counted",
+    "evidence_connecting_peggy_flanagan_to_the_claimed_event"
+  ],
+  "public_verdict": {
+    "rule": "Winning a claim requires replayable evidence; unresolved claims remain unresolved.",
+    "guilt_inference_allowed": false,
+    "party_based_scoring_allowed": false,
+    "authority_created": false
+  }
+}

--- a/tools/publicproof/README.md
+++ b/tools/publicproof/README.md
@@ -1,0 +1,72 @@
+# PublicProof — Minnesota Round 001
+
+**Mode:** `QUANTUM_PUBLIC_PROOF_PRIORITY_PERFECT_PRESS`
+
+PublicProof is a nonpartisan, replayable evidence game for viral political claims. A player name is a case label, not an accusation. Party, office, popularity, and virality do not change evidence scores.
+
+> PARTY != PROOF  
+> VIRALITY != PROOF  
+> OFFICE != PROOF  
+> ACCUSATION != PROOF  
+> REPLAYABLE_EVIDENCE -> SCORE
+
+## Player 1
+
+`PEGGYPLAYER1` is the first Minnesota case because the August 11, 2026 unofficial statewide results show Peggy Flanagan leading the DFL U.S. Senate primary with 411,541 votes (59.02%), with 100% of precincts reporting. Minnesota's results site expressly states that state and federal results remain unofficial until the State Canvassing Board certifies them on August 18, 2026.
+
+The satirical wrapper `Flanagan Shenanigans` is presentation only. It creates **zero evidentiary weight** and is not a claim of misconduct.
+
+## Cards
+
+Every round may contain:
+
+- Claim Card
+- Source Card
+- Law Card
+- Video Receipt
+- Counterevidence
+- Public Verdict
+
+## Evidence weights
+
+| Evidence type | Points |
+|---|---:|
+| Primary government record | +100 |
+| Full original video | +80 |
+| Independent corroboration | +60 |
+| Complete contextual quote | +40 |
+| Campaign/party assertion | +10 |
+| Cropped viral clip | 0 |
+| Unsupported accusation | -50 |
+| Proven fabrication | -100 |
+
+Weights grade evidence objects, not people or parties.
+
+## Round 001 — polling-place sting
+
+Initial claim states:
+
+- `CLAIMED_STING = HOLD`
+- `NO_ID_ACTIVE_VOTER = VERIFIED`
+- `8_PERSON_VOUCHING = VERIFIED`
+- `VOUCH_PROVES_CITIZENSHIP = FALSE`
+- `IMPERSONATION_OCCURRED = VIDEO_NEEDED`
+- `ILLEGAL_BALLOT_CAST = NOT_PROVEN`
+- `PEGGY_INVOLVEMENT = NOT_ESTABLISHED`
+
+The fixture in `fixtures/publicproof/MN_2026_ROUND_001.json` carries the replayable claim/evidence state. `publicproof.py` computes evidence totals and rejects party-based scoring fields.
+
+## Primary sources
+
+- Minnesota Secretary of State — 2026 U.S. Senate primary results: https://electionresults.sos.mn.gov/Results/Index?ErsElectionId=200&electionDate=08%2F11%2F2026+00%3A00%3A00&officeInElectionIdList=-1&officeInElectionIdList=38485&scenario=USSenate
+- Minnesota Secretary of State — current/active voters do not need ID at sign-in: https://www.sos.mn.gov/elections-voting/election-day-voting/do-i-need-to-bring-id/
+- Minnesota Secretary of State — Election Day registration/vouching: https://www.sos.mn.gov/elections-voting/register-to-vote/register-on-election-day/
+- Minnesota Statutes §201.061 subd. 3 — registered precinct voter may vouch for residence for up to eight voters: https://www.revisor.mn.gov/statutes/?id=201.061
+
+## Guardrails
+
+1. A claim does not become true because a source exists; the source must actually support it.
+2. Vouching under §201.061 is evidence of **residence**, not a substitute for legal voter eligibility or citizenship.
+3. `VIDEO_NEEDED` means the claimed event is not scored as established until the original evidence can be replayed.
+4. `NOT_PROVEN` and `NOT_ESTABLISHED` must never be rendered as guilt.
+5. Any candidate, campaign, election official, journalist, activist, or citizen is evaluated by the same evidence weights.

--- a/tools/publicproof/README.md
+++ b/tools/publicproof/README.md
@@ -56,12 +56,54 @@ Initial claim states:
 
 The fixture in `fixtures/publicproof/MN_2026_ROUND_001.json` carries the replayable claim/evidence state. `publicproof.py` computes evidence totals and rejects party-based scoring fields.
 
+## MinnesotaMathMatrix — quadratic verification priority
+
+`quadratic_priority.py` adds a separate public-attention mechanism inspired by quadratic voting. It **does not conduct an election and does not vote on truth, guilt, candidate preference, party preference, or official outcomes**.
+
+Each participant receives a fixed budget of 100 proof-credits. If a participant allocates `q_j` verification-priority votes to claim `j`, the cost is:
+
+```text
+cost_j = q_j^2
+ballot_cost = sum(q_j^2)
+ballot_cost <= 100
+```
+
+Examples:
+
+| Priority votes on one claim | Credit cost |
+|---:|---:|
+| 1 | 1 |
+| 2 | 4 |
+| 3 | 9 |
+| 5 | 25 |
+| 8 | 64 |
+| 10 | 100 |
+
+The purpose is narrow: **which unresolved claim should receive verification effort next?** A quadratic tally is an attention signal only. It cannot change `VERIFIED`, `FALSE`, `HOLD`, `VIDEO_NEEDED`, `NOT_PROVEN`, or `NOT_ESTABLISHED`; only replayable evidence may change those states.
+
+The initial matrix is `fixtures/publicproof/MN_2026_PRIORITY_MATRIX_001.json`. It begins with zero ballots so the repository never fabricates a public preference signal.
+
+### Public-post receipt shape
+
+```json
+{
+  "participant_id": "PUBLIC_HASH_OR_PSEUDONYM",
+  "allocations": {
+    "IMPERSONATION_OCCURRED": 5,
+    "ILLEGAL_BALLOT_CAST": 3
+  }
+}
+```
+
+That sample costs `5^2 + 3^2 = 34` credits. Participant identity and Sybil resistance are separate governance problems; account count must never be treated automatically as unique-human count.
+
 ## Primary sources
 
 - Minnesota Secretary of State — 2026 U.S. Senate primary results: https://electionresults.sos.mn.gov/Results/Index?ErsElectionId=200&electionDate=08%2F11%2F2026+00%3A00%3A00&officeInElectionIdList=-1&officeInElectionIdList=38485&scenario=USSenate
 - Minnesota Secretary of State — current/active voters do not need ID at sign-in: https://www.sos.mn.gov/elections-voting/election-day-voting/do-i-need-to-bring-id/
 - Minnesota Secretary of State — Election Day registration/vouching: https://www.sos.mn.gov/elections-voting/register-to-vote/register-on-election-day/
 - Minnesota Statutes §201.061 subd. 3 — registered precinct voter may vouch for residence for up to eight voters: https://www.revisor.mn.gov/statutes/?id=201.061
+- Lalley & Weyl, “Quadratic Voting: How Mechanism Design Can Radicalize Democracy,” AEA Papers and Proceedings 108 (2018), pp. 33–37: https://doi.org/10.1257/pandp.20181002
 
 ## Guardrails
 
@@ -70,3 +112,5 @@ The fixture in `fixtures/publicproof/MN_2026_ROUND_001.json` carries the replaya
 3. `VIDEO_NEEDED` means the claimed event is not scored as established until the original evidence can be replayed.
 4. `NOT_PROVEN` and `NOT_ESTABLISHED` must never be rendered as guilt.
 5. Any candidate, campaign, election official, journalist, activist, or citizen is evaluated by the same evidence weights.
+6. Quadratic priority selects **verification attention**, not candidate support or a factual verdict.
+7. Public-post tallies create no governmental, electoral, legal, or evidentiary authority.

--- a/tools/publicproof/publicproof.py
+++ b/tools/publicproof/publicproof.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Deterministic evidence scorer for PublicProof fixtures."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+WEIGHTS = {
+    "primary_government_record": 100,
+    "full_original_video": 80,
+    "independent_corroboration": 60,
+    "complete_contextual_quote": 40,
+    "campaign_party_assertion": 10,
+    "cropped_viral_clip": 0,
+    "unsupported_accusation": -50,
+    "proven_fabrication": -100,
+}
+
+ALLOWED_STATUS = {
+    "VERIFIED",
+    "FALSE",
+    "HOLD",
+    "VIDEO_NEEDED",
+    "NOT_PROVEN",
+    "NOT_ESTABLISHED",
+}
+
+FORBIDDEN_SCORE_FIELDS = {"party", "political_party", "office", "candidate_identity"}
+
+
+def validate(doc: dict) -> None:
+    scoring = doc.get("scoring", {})
+    bad = FORBIDDEN_SCORE_FIELDS.intersection(scoring)
+    if bad:
+        raise ValueError(f"forbidden identity-based scoring fields: {sorted(bad)}")
+
+    for claim in doc.get("claims", []):
+        status = claim.get("status")
+        if status not in ALLOWED_STATUS:
+            raise ValueError(f"invalid claim status {status!r}: {claim.get('id')}")
+
+    for item in doc.get("evidence", []):
+        kind = item.get("type")
+        if kind not in WEIGHTS:
+            raise ValueError(f"unknown evidence type {kind!r}: {item.get('id')}")
+        if item.get("points") != WEIGHTS[kind]:
+            raise ValueError(
+                f"noncanonical points for {item.get('id')}: "
+                f"expected {WEIGHTS[kind]}, got {item.get('points')}"
+            )
+
+
+def score(doc: dict) -> dict:
+    validate(doc)
+    evidence = doc.get("evidence", [])
+    total = sum(item["points"] for item in evidence)
+    return {
+        "game": doc.get("game"),
+        "round_id": doc.get("round_id"),
+        "evidence_count": len(evidence),
+        "evidence_score": total,
+        "claim_states": {c["id"]: c["status"] for c in doc.get("claims", [])},
+        "party_scoring": False,
+        "authority_created": False,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: publicproof.py <fixture.json>", file=sys.stderr)
+        return 2
+    path = Path(sys.argv[1])
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    print(json.dumps(score(doc), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/publicproof/quadratic_priority.py
+++ b/tools/publicproof/quadratic_priority.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Quadratic priority allocator for PublicProof.
+
+This module does NOT vote on candidate preference, guilt, truth, or election outcomes.
+It allocates a fixed public attention budget across claims that participants want
+independently verified next.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+DEFAULT_BUDGET = 100
+FORBIDDEN_DIMENSIONS = {
+    "candidate_preference",
+    "candidate_score",
+    "party_preference",
+    "party_score",
+    "guilt",
+    "truth_vote",
+    "election_vote",
+}
+
+
+def ballot_cost(allocations: dict[str, int]) -> int:
+    """Quadratic cost: sum(q_j^2) across claim-priority allocations."""
+    return sum(q * q for q in allocations.values())
+
+
+def validate_ballot(ballot: dict, allowed_claims: set[str], budget: int) -> None:
+    forbidden = FORBIDDEN_DIMENSIONS.intersection(ballot)
+    if forbidden:
+        raise ValueError(f"forbidden political/verdict dimensions: {sorted(forbidden)}")
+
+    allocations = ballot.get("allocations", {})
+    if not isinstance(allocations, dict):
+        raise ValueError("allocations must be an object mapping claim_id -> nonnegative integer")
+
+    for claim_id, q in allocations.items():
+        if claim_id not in allowed_claims:
+            raise ValueError(f"unknown claim_id: {claim_id}")
+        if isinstance(q, bool) or not isinstance(q, int) or q < 0:
+            raise ValueError(f"allocation for {claim_id} must be a nonnegative integer")
+
+    cost = ballot_cost(allocations)
+    if cost > budget:
+        raise ValueError(f"ballot exceeds budget: cost={cost}, budget={budget}")
+
+
+def aggregate(doc: dict) -> dict:
+    if doc.get("purpose") != "VERIFICATION_PRIORITY_ONLY":
+        raise ValueError("purpose must be VERIFICATION_PRIORITY_ONLY")
+
+    budget = doc.get("budget_per_participant", DEFAULT_BUDGET)
+    if isinstance(budget, bool) or not isinstance(budget, int) or budget <= 0:
+        raise ValueError("budget_per_participant must be a positive integer")
+
+    claims = doc.get("claims", [])
+    allowed_claims = {c["id"] for c in claims}
+    status_by_claim = {c["id"]: c.get("status") for c in claims}
+    totals: dict[str, int] = defaultdict(int)
+    costs: dict[str, int] = {}
+
+    ballots = doc.get("ballots", [])
+    seen_participants: set[str] = set()
+    for ballot in ballots:
+        participant = ballot.get("participant_id")
+        if not participant or not isinstance(participant, str):
+            raise ValueError("each ballot requires participant_id")
+        if participant in seen_participants:
+            raise ValueError(f"duplicate participant_id: {participant}")
+        seen_participants.add(participant)
+
+        validate_ballot(ballot, allowed_claims, budget)
+        allocations = ballot.get("allocations", {})
+        costs[participant] = ballot_cost(allocations)
+        for claim_id, q in allocations.items():
+            totals[claim_id] += q
+
+    matrix = [
+        {
+            "claim_id": claim_id,
+            "evidence_status": status_by_claim[claim_id],
+            "priority_votes": totals.get(claim_id, 0),
+        }
+        for claim_id in sorted(allowed_claims)
+    ]
+    matrix.sort(key=lambda row: (-row["priority_votes"], row["claim_id"]))
+
+    return {
+        "mode": doc.get("mode"),
+        "purpose": "VERIFICATION_PRIORITY_ONLY",
+        "budget_per_participant": budget,
+        "participants": len(ballots),
+        "ballot_costs": costs,
+        "priority_matrix": matrix,
+        "changes_evidence_status": False,
+        "changes_candidate_score": False,
+        "changes_election_result": False,
+        "authority_created": False,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: quadratic_priority.py <matrix.json>", file=sys.stderr)
+        return 2
+    path = Path(sys.argv[1])
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    print(json.dumps(aggregate(doc), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

Adds a nonpartisan PublicProof prototype for replaying viral political claims as evidence-scored fixtures, plus a quadratic **verification-priority** layer for public participation.

- Adds `tools/publicproof/README.md` with evidence rules, neutrality guardrails, and MinnesotaMathMatrix documentation.
- Adds `tools/publicproof/publicproof.py`, a deterministic evidence scorer that rejects identity/party-based scoring fields.
- Adds `fixtures/publicproof/MN_2026_ROUND_001.json` for the Minnesota polling-place sting claim set.
- Adds `tools/publicproof/quadratic_priority.py`, a fixed-budget quadratic allocator for deciding which claim should receive verification effort next.
- Adds `fixtures/publicproof/MN_2026_PRIORITY_MATRIX_001.json`, initialized with zero ballots so no crowd signal is fabricated.

## Quadratic priority rule

Each participant receives 100 proof-credits. Allocating `q_j` priority votes to claim `j` costs `q_j^2`, with `sum(q_j^2) <= 100`.

The quadratic layer is **not** an election, candidate ranking, party preference system, truth vote, guilt vote, or legal/factual verdict. It only produces an attention signal for which claim should be independently investigated next. Evidence statuses can change only through replayable evidence.

## Round 001 safeguards

- Government records support only the claims they actually establish.
- `IMPERSONATION_OCCURRED` remains `VIDEO_NEEDED`.
- `ILLEGAL_BALLOT_CAST` remains `NOT_PROVEN`.
- `PEGGY_INVOLVEMENT` remains `NOT_ESTABLISHED`.
- Peggy Flanagan's candidate/party identity creates no positive or negative score.
- The 2026 DFL U.S. Senate result is recorded as unofficial pending the August 18 State Canvassing Board certification.
- Account count is not automatically treated as unique-human count; Sybil resistance remains a separate governance layer.

## Primary sources

- Minnesota Secretary of State 2026 primary results.
- Minnesota Secretary of State voter ID guidance.
- Minnesota Secretary of State Election Day registration/vouching guidance.
- Minnesota Statutes §201.061 subd. 3.
- Lalley & Weyl, “Quadratic Voting: How Mechanism Design Can Radicalize Democracy,” AEA Papers and Proceedings 108 (2018).

## Validation

- `quadratic_priority.py` syntax parse: PASS.
- Zero-ballot matrix: PASS; participants=0 and all claim priorities remain 0.
- Example allocation `5^2 + 3^2`: PASS at cost 34.
- Over-budget allocation `11^2`: correctly rejected at cost 121 > 100.
- Forbidden `guilt` ballot dimension: correctly rejected.
- Quadratic priority changes evidence status: FALSE.
- Quadratic priority changes candidate score: FALSE.
- Quadratic priority changes election result: FALSE.

`authority_created=false`; this PR does not assert guilt, create election authority, or certify election results.