### PR TITLE
Add Sentinel Arena v0.1 evidence-adjudication runtime

### DIFF
--- a/.github/workflows/validate-auditor-contracts.yml
+++ b/.github/workflows/validate-auditor-contracts.yml
@@ -6,6 +6,7 @@ on:
       - 'knowledge-management/contracts/**'
       - 'knowledge-management/fixtures/**'
       - 'knowledge-management/tests/**'
+      - 'knowledge-management/arena/**'
       - '.github/workflows/validate-auditor-contracts.yml'
   workflow_dispatch:
 
@@ -29,3 +30,6 @@ jobs:
 
       - name: Validate contracts and fixtures
         run: node knowledge-management/tests/validate-contracts.mjs
+
+      - name: Test Sentinel Arena runtime
+        run: python3 knowledge-management/tests/test_arena.py

--- a/knowledge-management/arena/README.md
+++ b/knowledge-management/arena/README.md
@@ -1,0 +1,77 @@
+# Sentinel Arena v0.1
+
+Status: EXPERIMENTAL / NON-AUTHORITATIVE  
+Authority: false  
+Remediation: disabled by contract
+
+The Sentinel Arena is a replayable evidence-adjudication surface for COMPUTERWISDOM. It allows two or more instruments to submit competing hypotheses against a shared evidence set, calibrates those hypotheses from the evidence actually referenced, preserves dissent, and emits a non-authoritative **State of Reality** report for Orchestrator review.
+
+It is not a governor, deployment agent, or automatic remediation system.
+
+## Constitutional boundary
+
+```text
+Sentinel / Arena: observe -> question -> investigate -> answer -> calibrate -> report -> escalate
+Orchestrator: decide
+Builders / Scalers / Perfectors: act
+```
+
+The Arena MUST keep:
+
+```text
+authority: false
+remediation_applied: false
+```
+
+A successful Arena run is a finding, not permission to act.
+
+## Why an Arena
+
+The Arena makes institutional disagreement explicit and machine-replayable instead of collapsing it into one narrative. A round contains one falsifiable question, at least two competing instruments/hypotheses, a shared evidence set, declared confidence from each instrument, reliability and severity on each evidence item, support/contradiction edges linking evidence to hypotheses, and a decision policy for evidence coverage, disagreement, and escalation.
+
+Declared confidence is retained for audit, but the runtime does not treat confidence as evidence. It computes a separate calibrated confidence from weighted support, weighted contradiction, and evidence coverage.
+
+## Runtime
+
+```bash
+python3 knowledge-management/arena/arena.py \
+  knowledge-management/fixtures/valid/arena-round-minimal.json
+```
+
+Write the report:
+
+```bash
+python3 knowledge-management/arena/arena.py \
+  knowledge-management/fixtures/valid/arena-round-minimal.json \
+  --output /tmp/state-of-reality.json
+```
+
+The runtime uses only the Python standard library.
+
+## Status rules
+
+- `insufficient_evidence`: no hypothesis has the configured minimum relevant evidence coverage.
+- `contested`: the top two calibrated scores remain within the configured disagreement threshold.
+- `resolved`: one hypothesis leads beyond the disagreement threshold. This is still non-authoritative.
+- `escalate`: evidence at or above the configured severity threshold is present and must be routed to the Orchestrator.
+
+Unknown remains a valid outcome. A contested round intentionally returns no winning instrument.
+
+## Proportionate skepticism
+
+The Arena does not enforce equal-and-opposite skepticism. Evidence is weighted by its declared reliability and by whether it supports or contradicts a hypothesis. A weak contrarian claim therefore does not receive artificial parity with a strongly evidenced claim, while dissenting hypotheses remain visible in the report.
+
+## Replay properties
+
+A round is deterministic except for `generated_at`. Given the same round JSON, the same scoring and status result is produced. Reports preserve declared vs calibrated confidence, support and contradiction weights, evidence coverage, missing evidence references, dissenting hypotheses, critical evidence IDs, recommended next actions, and escalation state.
+
+## Contracts
+
+- `knowledge-management/contracts/arena/ArenaRound.v0.1.0.json`
+- `knowledge-management/contracts/arena/ArenaReport.v0.1.0.json`
+
+The repository contract validator compiles both schemas. Arena fixtures are included in the auditor-contract validation lane.
+
+## Non-goals for v0.1
+
+The Arena does not autonomously ingest private systems, call external models, change production state, grant authority, or execute recommendations. Future adapters may generate questions or evidence candidates, but those adapters must still emit replayable round records and remain inside the same authority boundary.

--- a/knowledge-management/arena/arena.py
+++ b/knowledge-management/arena/arena.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Deterministic Sentinel Arena evaluator.
+
+The Arena adjudicates competing instrument hypotheses against referenced evidence.
+It never grants authority and never applies remediation. Output is a replayable
+State of Reality record suitable for Orchestrator review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SEVERITY_RANK = {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+
+
+class ArenaError(ValueError):
+    """Raised when an Arena round violates runtime invariants."""
+
+
+@dataclass(frozen=True)
+class InstrumentScore:
+    instrument_id: str
+    hypothesis: str
+    declared_confidence: float
+    calibrated_confidence: float
+    support_weight: float
+    contradiction_weight: float
+    evidence_count: int
+    missing_evidence_refs: tuple[str, ...]
+
+
+def _bounded_number(value: Any, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ArenaError(f"{name} must be a number between 0 and 1")
+    value = float(value)
+    if math.isnan(value) or value < 0.0 or value > 1.0:
+        raise ArenaError(f"{name} must be a number between 0 and 1")
+    return value
+
+
+def _require_round_invariants(round_data: dict[str, Any]) -> None:
+    if round_data.get("authority") is not False:
+        raise ArenaError("Arena rounds must set authority=false")
+    if round_data.get("remediation_applied") not in (None, False):
+        raise ArenaError("Arena cannot silently remediate; remediation_applied must be false")
+
+    instruments = round_data.get("instruments")
+    if not isinstance(instruments, list) or len(instruments) < 2:
+        raise ArenaError("Arena requires at least two competing instruments")
+
+    evidence = round_data.get("evidence")
+    if not isinstance(evidence, list):
+        raise ArenaError("evidence must be an array")
+
+    instrument_ids = [item.get("id") for item in instruments if isinstance(item, dict)]
+    if len(instrument_ids) != len(instruments) or any(not item for item in instrument_ids):
+        raise ArenaError("every instrument requires a non-empty id")
+    if len(set(instrument_ids)) != len(instrument_ids):
+        raise ArenaError("instrument ids must be unique")
+
+    evidence_ids = [item.get("id") for item in evidence if isinstance(item, dict)]
+    if len(evidence_ids) != len(evidence) or any(not item for item in evidence_ids):
+        raise ArenaError("every evidence item requires a non-empty id")
+    if len(set(evidence_ids)) != len(evidence_ids):
+        raise ArenaError("evidence ids must be unique")
+
+    known_instruments = set(instrument_ids)
+    for item in evidence:
+        for field in ("supports", "contradicts"):
+            refs = item.get(field, [])
+            if not isinstance(refs, list):
+                raise ArenaError(f"evidence.{field} must be an array")
+            unknown = sorted(set(refs) - known_instruments)
+            if unknown:
+                raise ArenaError(
+                    f"evidence {item['id']} references unknown instruments in {field}: {unknown}"
+                )
+
+
+def _score_instrument(
+    instrument: dict[str, Any],
+    evidence_by_id: dict[str, dict[str, Any]],
+    minimum_evidence_items: int,
+) -> InstrumentScore:
+    instrument_id = instrument["id"]
+    declared = _bounded_number(instrument.get("confidence", 0.0), f"{instrument_id}.confidence")
+    requested_refs = instrument.get("evidence_refs", [])
+    if not isinstance(requested_refs, list):
+        raise ArenaError(f"{instrument_id}.evidence_refs must be an array")
+
+    missing = tuple(sorted(ref for ref in requested_refs if ref not in evidence_by_id))
+    usable = [evidence_by_id[ref] for ref in requested_refs if ref in evidence_by_id]
+
+    support_weight = 0.0
+    contradiction_weight = 0.0
+    relevant_count = 0
+    for item in usable:
+        reliability = _bounded_number(item.get("reliability", 0.5), f"{item['id']}.reliability")
+        if instrument_id in item.get("supports", []):
+            support_weight += reliability
+            relevant_count += 1
+        if instrument_id in item.get("contradicts", []):
+            contradiction_weight += reliability
+            relevant_count += 1
+
+    total_weight = support_weight + contradiction_weight
+    if total_weight == 0:
+        evidence_ratio = 0.0
+    else:
+        evidence_ratio = support_weight / total_weight
+
+    coverage = min(1.0, relevant_count / max(1, minimum_evidence_items))
+    calibrated = round(evidence_ratio * coverage, 6)
+
+    return InstrumentScore(
+        instrument_id=instrument_id,
+        hypothesis=str(instrument.get("hypothesis", "")),
+        declared_confidence=declared,
+        calibrated_confidence=calibrated,
+        support_weight=round(support_weight, 6),
+        contradiction_weight=round(contradiction_weight, 6),
+        evidence_count=relevant_count,
+        missing_evidence_refs=missing,
+    )
+
+
+def evaluate_round(round_data: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate one Arena round and return a non-authoritative report."""
+    _require_round_invariants(round_data)
+
+    policy = round_data.get("decision_policy", {})
+    minimum_evidence_items = int(policy.get("minimum_evidence_items", 2))
+    disagreement_threshold = _bounded_number(
+        policy.get("disagreement_threshold", 0.15), "decision_policy.disagreement_threshold"
+    )
+    escalation_threshold = SEVERITY_RANK.get(
+        str(policy.get("escalation_severity", "critical")), SEVERITY_RANK["critical"]
+    )
+
+    evidence_by_id = {item["id"]: item for item in round_data["evidence"]}
+    scores = [
+        _score_instrument(instrument, evidence_by_id, minimum_evidence_items)
+        for instrument in round_data["instruments"]
+    ]
+    scores.sort(key=lambda item: (-item.calibrated_confidence, item.instrument_id))
+
+    top = scores[0]
+    runner_up = scores[1]
+    margin = round(top.calibrated_confidence - runner_up.calibrated_confidence, 6)
+    max_relevant_evidence = max((score.evidence_count for score in scores), default=0)
+
+    critical_evidence = [
+        item["id"]
+        for item in round_data["evidence"]
+        if SEVERITY_RANK.get(str(item.get("severity", "info")), 0) >= escalation_threshold
+    ]
+
+    missing_refs = sorted({ref for score in scores for ref in score.missing_evidence_refs})
+    if max_relevant_evidence < minimum_evidence_items:
+        status = "insufficient_evidence"
+    elif margin <= disagreement_threshold:
+        status = "contested"
+    else:
+        status = "resolved"
+
+    escalate = bool(critical_evidence)
+    if escalate:
+        status = "escalate"
+
+    if status == "insufficient_evidence":
+        state = "Available evidence is insufficient to prefer a hypothesis. Unknown remains valid."
+    elif status == "contested":
+        state = (
+            f"Evidence remains contested: {top.instrument_id} leads {runner_up.instrument_id} "
+            f"by {margin:.3f}, within the disagreement threshold."
+        )
+    elif status == "escalate":
+        state = (
+            f"Critical evidence requires Orchestrator review. Current evidence leader: "
+            f"{top.instrument_id} at calibrated confidence {top.calibrated_confidence:.3f}."
+        )
+    else:
+        state = (
+            f"Current evidence favors {top.instrument_id} at calibrated confidence "
+            f"{top.calibrated_confidence:.3f}; this is a finding, not authority."
+        )
+
+    recommended_actions: list[str] = []
+    if missing_refs:
+        recommended_actions.append("Acquire or repair missing evidence references before promotion.")
+    if status in {"insufficient_evidence", "contested"}:
+        recommended_actions.append("Run another falsification round with evidence targeted at the leading hypotheses.")
+    if escalate:
+        recommended_actions.append("Route critical evidence to the Orchestrator; do not auto-remediate.")
+    if not recommended_actions:
+        recommended_actions.append("Preserve the report and seek independent replay before acting on it.")
+
+    return {
+        "contract_version": "v0.1",
+        "arena_id": round_data.get("arena_id"),
+        "round_id": round_data.get("round_id"),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_by": "COMPUTERWISDOM Sentinel Arena v0.1",
+        "authority": False,
+        "remediation_applied": False,
+        "question": round_data.get("question"),
+        "status": status,
+        "state_of_reality": state,
+        "winning_instrument": top.instrument_id if status in {"resolved", "escalate"} else None,
+        "confidence": top.calibrated_confidence,
+        "confidence_margin": margin,
+        "critical_evidence": critical_evidence,
+        "missing_evidence_refs": missing_refs,
+        "scores": [
+            {
+                "instrument_id": score.instrument_id,
+                "hypothesis": score.hypothesis,
+                "declared_confidence": score.declared_confidence,
+                "calibrated_confidence": score.calibrated_confidence,
+                "support_weight": score.support_weight,
+                "contradiction_weight": score.contradiction_weight,
+                "evidence_count": score.evidence_count,
+                "missing_evidence_refs": list(score.missing_evidence_refs),
+            }
+            for score in scores
+        ],
+        "dissent": [
+            {
+                "instrument_id": score.instrument_id,
+                "hypothesis": score.hypothesis,
+                "calibrated_confidence": score.calibrated_confidence,
+            }
+            for score in scores[1:]
+        ],
+        "recommended_actions": recommended_actions,
+        "escalate": escalate,
+    }
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate a COMPUTERWISDOM Sentinel Arena round")
+    parser.add_argument("input", type=Path, help="Arena round JSON file")
+    parser.add_argument("--output", "-o", type=Path, help="Write report JSON to this path")
+    parser.add_argument("--compact", action="store_true", help="Emit compact JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    try:
+        round_data = json.loads(args.input.read_text(encoding="utf-8"))
+        report = evaluate_round(round_data)
+    except (OSError, json.JSONDecodeError, ArenaError, TypeError, ValueError) as exc:
+        print(f"arena: {exc}", file=sys.stderr)
+        return 2
+
+    if args.compact:
+        payload = json.dumps(report, sort_keys=True, separators=(",", ":")) + "\n"
+    else:
+        payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
+
+    if args.output:
+        args.output.write_text(payload, encoding="utf-8")
+    else:
+        sys.stdout.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/knowledge-management/arena/arena.py
+++ b/knowledge-management/arena/arena.py
@@ -103,11 +103,13 @@ def _score_instrument(
     relevant_count = 0
     for item in usable:
         reliability = _bounded_number(item.get("reliability", 0.5), f"{item['id']}.reliability")
-        if instrument_id in item.get("supports", []):
+        supports = instrument_id in item.get("supports", [])
+        contradicts = instrument_id in item.get("contradicts", [])
+        if supports:
             support_weight += reliability
-            relevant_count += 1
-        if instrument_id in item.get("contradicts", []):
+        if contradicts:
             contradiction_weight += reliability
+        if supports or contradicts:
             relevant_count += 1
 
     total_weight = support_weight + contradiction_weight
@@ -137,12 +139,15 @@ def evaluate_round(round_data: dict[str, Any]) -> dict[str, Any]:
 
     policy = round_data.get("decision_policy", {})
     minimum_evidence_items = int(policy.get("minimum_evidence_items", 2))
+    if minimum_evidence_items < 1:
+        raise ArenaError("decision_policy.minimum_evidence_items must be at least 1")
     disagreement_threshold = _bounded_number(
         policy.get("disagreement_threshold", 0.15), "decision_policy.disagreement_threshold"
     )
-    escalation_threshold = SEVERITY_RANK.get(
-        str(policy.get("escalation_severity", "critical")), SEVERITY_RANK["critical"]
-    )
+    escalation_severity = str(policy.get("escalation_severity", "critical"))
+    if escalation_severity not in SEVERITY_RANK:
+        raise ArenaError(f"unknown escalation severity: {escalation_severity}")
+    escalation_threshold = SEVERITY_RANK[escalation_severity]
 
     evidence_by_id = {item["id"]: item for item in round_data["evidence"]}
     scores = [

--- a/knowledge-management/contracts/arena/ArenaReport.v0.1.0.json
+++ b/knowledge-management/contracts/arena/ArenaReport.v0.1.0.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jsonwisdom.example/contracts/arena/ArenaReport.v0.1.0.json",
+  "title": "COMPUTERWISDOM Sentinel Arena State of Reality Report v0.1.0",
+  "type": "object",
+  "required": [
+    "contract_version",
+    "arena_id",
+    "round_id",
+    "generated_at",
+    "generated_by",
+    "authority",
+    "remediation_applied",
+    "question",
+    "status",
+    "state_of_reality",
+    "confidence",
+    "confidence_margin",
+    "critical_evidence",
+    "missing_evidence_refs",
+    "scores",
+    "dissent",
+    "recommended_actions",
+    "escalate"
+  ],
+  "properties": {
+    "contract_version": { "const": "v0.1" },
+    "arena_id": { "type": ["string", "null"] },
+    "round_id": { "type": ["string", "null"] },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "generated_by": { "const": "COMPUTERWISDOM Sentinel Arena v0.1" },
+    "authority": { "const": false },
+    "remediation_applied": { "const": false },
+    "question": { "type": ["string", "null"] },
+    "status": { "enum": ["resolved", "contested", "insufficient_evidence", "escalate"] },
+    "state_of_reality": { "type": "string", "minLength": 1 },
+    "winning_instrument": { "type": ["string", "null"] },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+    "confidence_margin": { "type": "number", "minimum": 0, "maximum": 1 },
+    "critical_evidence": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string" }
+    },
+    "missing_evidence_refs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string" }
+    },
+    "scores": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "required": [
+          "instrument_id",
+          "hypothesis",
+          "declared_confidence",
+          "calibrated_confidence",
+          "support_weight",
+          "contradiction_weight",
+          "evidence_count",
+          "missing_evidence_refs"
+        ],
+        "properties": {
+          "instrument_id": { "type": "string" },
+          "hypothesis": { "type": "string" },
+          "declared_confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+          "calibrated_confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+          "support_weight": { "type": "number", "minimum": 0 },
+          "contradiction_weight": { "type": "number", "minimum": 0 },
+          "evidence_count": { "type": "integer", "minimum": 0 },
+          "missing_evidence_refs": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "dissent": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["instrument_id", "hypothesis", "calibrated_confidence"],
+        "properties": {
+          "instrument_id": { "type": "string" },
+          "hypothesis": { "type": "string" },
+          "calibrated_confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "recommended_actions": { "type": "array", "items": { "type": "string" } },
+    "escalate": { "type": "boolean" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "enum": ["contested", "insufficient_evidence"] } } },
+      "then": { "properties": { "winning_instrument": { "type": "null" } } }
+    },
+    {
+      "if": { "properties": { "status": { "const": "escalate" } } },
+      "then": { "properties": { "escalate": { "const": true } } }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/knowledge-management/contracts/arena/ArenaRound.v0.1.0.json
+++ b/knowledge-management/contracts/arena/ArenaRound.v0.1.0.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jsonwisdom.example/contracts/arena/ArenaRound.v0.1.0.json",
+  "title": "COMPUTERWISDOM Sentinel Arena Round v0.1.0",
+  "type": "object",
+  "required": [
+    "contract_version",
+    "arena_id",
+    "round_id",
+    "authority",
+    "remediation_applied",
+    "question",
+    "decision_policy",
+    "instruments",
+    "evidence"
+  ],
+  "properties": {
+    "contract_version": { "const": "v0.1" },
+    "arena_id": { "type": "string", "minLength": 1 },
+    "round_id": { "type": "string", "minLength": 1 },
+    "authority": { "const": false },
+    "remediation_applied": { "const": false },
+    "question": { "type": "string", "minLength": 1 },
+    "decision_policy": {
+      "type": "object",
+      "required": ["minimum_evidence_items", "disagreement_threshold", "escalation_severity"],
+      "properties": {
+        "minimum_evidence_items": { "type": "integer", "minimum": 1 },
+        "disagreement_threshold": { "type": "number", "minimum": 0, "maximum": 1 },
+        "escalation_severity": { "enum": ["info", "low", "medium", "high", "critical"] }
+      },
+      "additionalProperties": false
+    },
+    "instruments": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "required": ["id", "role", "hypothesis", "confidence", "evidence_refs"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "role": { "type": "string", "minLength": 1 },
+          "hypothesis": { "type": "string", "minLength": 1 },
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+          "evidence_refs": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "kind",
+          "source",
+          "claim",
+          "reliability",
+          "severity",
+          "supports",
+          "contradicts"
+        ],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "kind": {
+            "enum": ["telemetry", "repository", "incident", "feedback", "research", "decision", "other"]
+          },
+          "source": { "type": "string", "minLength": 1 },
+          "claim": { "type": "string", "minLength": 1 },
+          "reliability": { "type": "number", "minimum": 0, "maximum": 1 },
+          "severity": { "enum": ["info", "low", "medium", "high", "critical"] },
+          "supports": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "contradicts": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/knowledge-management/fixtures/invalid/arena-round-claiming-authority.json
+++ b/knowledge-management/fixtures/invalid/arena-round-claiming-authority.json
@@ -1,0 +1,30 @@
+{
+  "contract_version": "v0.1",
+  "arena_id": "sentinel-arena",
+  "round_id": "invalid-authority",
+  "authority": true,
+  "remediation_applied": false,
+  "question": "Can the Arena grant itself authority?",
+  "decision_policy": {
+    "minimum_evidence_items": 1,
+    "disagreement_threshold": 0.15,
+    "escalation_severity": "critical"
+  },
+  "instruments": [
+    {
+      "id": "yes",
+      "role": "proponent",
+      "hypothesis": "The Arena may self-authorize.",
+      "confidence": 1,
+      "evidence_refs": []
+    },
+    {
+      "id": "no",
+      "role": "challenger",
+      "hypothesis": "The Arena cannot self-authorize.",
+      "confidence": 1,
+      "evidence_refs": []
+    }
+  ],
+  "evidence": []
+}

--- a/knowledge-management/fixtures/valid/arena-round-minimal.json
+++ b/knowledge-management/fixtures/valid/arena-round-minimal.json
@@ -1,0 +1,61 @@
+{
+  "contract_version": "v0.1",
+  "arena_id": "sentinel-arena",
+  "round_id": "round-001",
+  "authority": false,
+  "remediation_applied": false,
+  "question": "Is the reported growth signal durable or attribution drift?",
+  "decision_policy": {
+    "minimum_evidence_items": 2,
+    "disagreement_threshold": 0.15,
+    "escalation_severity": "critical"
+  },
+  "instruments": [
+    {
+      "id": "growth-durable",
+      "role": "proponent",
+      "hypothesis": "The growth signal is durable.",
+      "confidence": 0.82,
+      "evidence_refs": ["cohort-30d", "attribution-audit", "retention-curve"]
+    },
+    {
+      "id": "growth-drift",
+      "role": "challenger",
+      "hypothesis": "The growth signal is mostly attribution drift.",
+      "confidence": 0.74,
+      "evidence_refs": ["cohort-30d", "attribution-audit", "retention-curve"]
+    }
+  ],
+  "evidence": [
+    {
+      "id": "cohort-30d",
+      "kind": "telemetry",
+      "source": "analytics/cohorts/30d",
+      "claim": "Thirty-day retained users increased after the launch cohort.",
+      "reliability": 0.85,
+      "severity": "medium",
+      "supports": ["growth-durable"],
+      "contradicts": ["growth-drift"]
+    },
+    {
+      "id": "attribution-audit",
+      "kind": "research",
+      "source": "audit/attribution-v3",
+      "claim": "A channel mapping change explains part of the top-line increase.",
+      "reliability": 0.95,
+      "severity": "high",
+      "supports": ["growth-drift"],
+      "contradicts": ["growth-durable"]
+    },
+    {
+      "id": "retention-curve",
+      "kind": "telemetry",
+      "source": "analytics/retention/curve",
+      "claim": "Retention improvement persists after attribution normalization.",
+      "reliability": 0.8,
+      "severity": "medium",
+      "supports": ["growth-durable"],
+      "contradicts": []
+    }
+  ]
+}

--- a/knowledge-management/tests/test_arena.py
+++ b/knowledge-management/tests/test_arena.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+ARENA_PATH = ROOT / "knowledge-management" / "arena" / "arena.py"
+FIXTURE = ROOT / "knowledge-management" / "fixtures" / "valid" / "arena-round-minimal.json"
+
+spec = importlib.util.spec_from_file_location("computerwisdom_arena", ARENA_PATH)
+arena = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = arena
+assert spec.loader is not None
+spec.loader.exec_module(arena)
+
+
+class SentinelArenaTests(unittest.TestCase):
+    def load_fixture(self):
+        return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    def test_valid_round_is_contested_and_non_authoritative(self):
+        report = arena.evaluate_round(self.load_fixture())
+        self.assertEqual(report["status"], "contested")
+        self.assertIsNone(report["winning_instrument"])
+        self.assertFalse(report["authority"])
+        self.assertFalse(report["remediation_applied"])
+        self.assertFalse(report["escalate"])
+        self.assertGreaterEqual(len(report["scores"]), 2)
+
+    def test_declared_confidence_does_not_override_evidence(self):
+        round_data = self.load_fixture()
+        round_data["instruments"][0]["confidence"] = 0.01
+        round_data["instruments"][1]["confidence"] = 0.99
+        report = arena.evaluate_round(round_data)
+        scores = {row["instrument_id"]: row for row in report["scores"]}
+        self.assertGreater(
+            scores["growth-durable"]["calibrated_confidence"],
+            scores["growth-drift"]["calibrated_confidence"],
+        )
+
+    def test_arena_cannot_claim_authority(self):
+        round_data = self.load_fixture()
+        round_data["authority"] = True
+        with self.assertRaises(arena.ArenaError):
+            arena.evaluate_round(round_data)
+
+    def test_critical_evidence_escalates_without_remediation(self):
+        round_data = self.load_fixture()
+        round_data["evidence"][0]["severity"] = "critical"
+        report = arena.evaluate_round(round_data)
+        self.assertEqual(report["status"], "escalate")
+        self.assertTrue(report["escalate"])
+        self.assertFalse(report["remediation_applied"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/knowledge-management/tests/validate-contracts.mjs
+++ b/knowledge-management/tests/validate-contracts.mjs
@@ -70,13 +70,16 @@ const schemaByFixture = {
   'minimal-repository-evidence.json': 'https://jsonwisdom.example/contracts/JSONWisdom-Repository-Evidence.v0.1.0.json',
   'missing-authority.json': 'https://jsonwisdom.example/contracts/JSONWisdom-Repository-Evidence.v0.1.0.json',
   'trinity-confidence-without-evidence.json': 'https://jsonwisdom.example/contracts/JSONWisdom-Trinity-Classification.v0.1.0.json',
-  'auditor-claiming-authority.json': 'https://jsonwisdom.example/contracts/auditor/AuditorEvidenceBase.v0.1.0.json'
+  'auditor-claiming-authority.json': 'https://jsonwisdom.example/contracts/auditor/AuditorEvidenceBase.v0.1.0.json',
+  'arena-round-minimal.json': 'https://jsonwisdom.example/contracts/arena/ArenaRound.v0.1.0.json',
+  'arena-round-claiming-authority.json': 'https://jsonwisdom.example/contracts/arena/ArenaRound.v0.1.0.json'
 };
 
 const expectedInvalidReason = {
   'missing-authority.json': { type: 'keyword', value: 'required' },
   'trinity-confidence-without-evidence.json': { type: 'keyword', value: 'minItems' },
-  'auditor-claiming-authority.json': { type: 'authority-separation' }
+  'auditor-claiming-authority.json': { type: 'authority-separation' },
+  'arena-round-claiming-authority.json': { type: 'authority-separation' }
 };
 
 function authoritySeparationViolation(data, relativeFilename) {


### PR DESCRIPTION
## What changed

- Adds a deterministic Sentinel Arena runtime for competing hypotheses and shared evidence.
- Adds `ArenaRound` and `ArenaReport` JSON contracts.
- Preserves dissent, missing evidence, calibrated confidence, and critical-evidence escalation.
- Enforces `authority: false` and `remediation_applied: false` at both schema and runtime boundaries.
- Adds valid/invalid fixtures and four Python runtime tests.
- Wires Arena files into the existing auditor-contract validation workflow.

## Why

COMPUTERWISDOM already treats missing evidence as non-confidence and authority as false by default. The Arena turns that doctrine into a replayable challenge surface: instruments may disagree, evidence is weighted proportionately, and the result is a non-authoritative State of Reality report for Orchestrator review.

## Validation

- `python3 knowledge-management/tests/test_arena.py` — 4 tests pass locally.
- Sample round produces `contested`, preserves dissent, and does not select a winner.
- Existing contract-validation workflow now compiles the Arena contracts and validates Arena fixtures.

## Boundary

The Arena reports and escalates. It does not grant authority, change production state, or silently remediate.