### PR TITLE
Grant County: add Jay Screw Math verification contract

### DIFF
--- a/schemas/grant-county/jay_screw_tooth.v0_1.schema.json
+++ b/schemas/grant-county/jay_screw_tooth.v0_1.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jsonwisdom.example/schemas/grant-county/jay_screw_tooth.v0_1.schema.json",
+  "title": "Grant County Jay Screw Tooth v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "tooth_id",
+    "district",
+    "artifact_sha256",
+    "page",
+    "source_line",
+    "raw_amount",
+    "normalized_amount",
+    "verification",
+    "locked",
+    "reusable",
+    "authority_created"
+  ],
+  "properties": {
+    "tooth_id": {
+      "type": "string",
+      "pattern": "^J-GC-[0-9]{4,}$"
+    },
+    "district": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_sha256": {
+      "type": ["string", "null"],
+      "pattern": "^[a-fA-F0-9]{64}$"
+    },
+    "page": {
+      "type": ["integer", "null"],
+      "minimum": 1
+    },
+    "source_line": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "raw_amount": {
+      "type": ["number", "null"]
+    },
+    "normalized_amount": {
+      "type": ["number", "null"]
+    },
+    "verification": {
+      "type": "string",
+      "enum": ["HOLD", "LOCKED"]
+    },
+    "locked": {
+      "type": "boolean"
+    },
+    "reusable": {
+      "type": "boolean"
+    },
+    "authority_created": {
+      "const": false
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "verification": {"const": "HOLD"}
+        },
+        "required": ["verification"]
+      },
+      "then": {
+        "properties": {
+          "locked": {"const": false},
+          "reusable": {"const": false}
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "verification": {"const": "LOCKED"}
+        },
+        "required": ["verification"]
+      },
+      "then": {
+        "properties": {
+          "artifact_sha256": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"},
+          "page": {"type": "integer", "minimum": 1},
+          "source_line": {"type": "string", "minLength": 1},
+          "raw_amount": {"type": "number"},
+          "normalized_amount": {"type": "number"},
+          "locked": {"const": true},
+          "reusable": {"const": true}
+        }
+      }
+    }
+  ]
+}

--- a/schemas/grant-county/jay_screw_tooth.v0_1.schema.json
+++ b/schemas/grant-county/jay_screw_tooth.v0_1.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://jsonwisdom.example/schemas/grant-county/jay_screw_tooth.v0_1.schema.json",
   "title": "Grant County Jay Screw Tooth v0.1",
   "type": "object",
   "additionalProperties": false,

--- a/specs/grant-county/JAY_SCREW_MATH_V0_1.md
+++ b/specs/grant-county/JAY_SCREW_MATH_V0_1.md
@@ -1,0 +1,73 @@
+# Jason’s Grant County — Jay Screw Math v0.1
+
+**Status:** CONSTITUTIONAL SPEC / NO BUDGET TOOTH PROMOTED  
+**Authority created:** false
+
+## Governing mechanic
+
+`J = VERIFIED_TOOTH`
+
+`WORK → RECEIPT → LOCK → REUSE → COMPOUND ↺`
+
+`J_(n+1) = J_n + 1` only when `tooth_(n+1)` verifies.
+
+Never increment `J` from a plausible, parsed, summarized, or inferred value.
+
+## Grant County descent chain
+
+`PDF → BYTE CERTIFICATE → BUDGET LINE → SOURCE LOCATOR → NORMALIZED AMOUNT → VERIFIED METRIC → DISTRICT COMPARISON → PUBLIC EXPLANATION`
+
+Every completed stage becomes one locked tooth. Until the exact PDF bytes, byte certificate, and source locator are present, the tooth remains `OPEN` and contributes zero verified progress.
+
+## Tooth contract
+
+```json
+{
+  "tooth_id": "J-GC-0001",
+  "district": "Platteville",
+  "artifact_sha256": null,
+  "page": null,
+  "source_line": null,
+  "raw_amount": null,
+  "normalized_amount": null,
+  "verification": "HOLD",
+  "locked": false,
+  "reusable": false,
+  "authority_created": false
+}
+```
+
+## Promotion rule
+
+- `OPEN`: `verification=HOLD`, `locked=false`, `reusable=false`, `progress=0`.
+- `LOCKED`: every mandatory evidence slot verifies, `locked=true`, `reusable=true`, `progress=+1`.
+
+A locked tooth may be reused in per-student math, admin ratio, instruction ratio, SPED analysis, year-over-year change, district comparison, public dashboards, and AI explanation without re-inventing the underlying number.
+
+## Reverse Screw traceability
+
+`CLAIM ↑ DERIVED_METRIC ↑ NORMALIZED_LINE ↑ RAW_LINE ↑ PAGE ↑ CERTIFIED_PDF`
+
+Every public claim must traverse backward to certified source bytes.
+
+## Constitutional equation
+
+`PUBLIC_CLAIM = f(J_1, J_2, …, J_n)` subject to `VERIFIED(J_i)=TRUE` for every dependency.
+
+`10 VERIFIED TEETH + 1 UNKNOWN ≠ 11 VERIFIED TEETH`
+
+**UNKNOWN DOES NOT AVERAGE OUT.**
+
+If one required tooth is `FALSE` or `UNKNOWN`, every dependent calculation `HOLD`s.
+
+## System placement
+
+- **SCREW MATH** — progress only from verified teeth.
+- **GIRLMATH** — mandatory evidence cannot be compensated.
+- **BOX D** — preserves the original artifact.
+- **BITBOT** — verifies exact bytes.
+- **AI** — explains verified structure; does not create authority.
+
+## Current state
+
+The Grant County school-budget substrate now has a governing verification mechanic, but this record promotes no budget tooth. Artifact hashes, pages, source lines, amounts, and district metrics remain `HOLD` until independently verified from source bytes.


### PR DESCRIPTION
## Purpose
Apply Jay Screw Math to the Grant County school-budget substrate without promoting any unverified budget number.

## Adds
- `specs/grant-county/JAY_SCREW_MATH_V0_1.md` — governing Reverse Screw / verified-tooth contract.
- `schemas/grant-county/jay_screw_tooth.v0_1.schema.json` — machine-readable tooth gate.

## Core invariant
`J_(n+1) = J_n + 1` only when the next tooth verifies.

Unknown or missing mandatory evidence cannot be averaged away. A dependent calculation remains `HOLD` whenever a required tooth is not verified.

## Initial state
`J-GC-0001` is an example HOLD tooth for Platteville. No PDF hash, page, source line, amount, metric, or public claim is promoted by this PR.

`authority_created=false`