### PR TITLE
Correct Ziggy iPhone wallet signing docs

### DIFF
--- a/projects/ziggy/README.md
+++ b/projects/ziggy/README.md
@@ -48,12 +48,22 @@ Live GitHub Pages signer:
 
 The signer is deliberately bounded:
 
-- connects an injected EVM wallet
+- connects an injected EIP-1193 wallet provider
 - requires Base Sepolia (`84532`) before signing
 - uses `personal_sign` over an explicit Ziggy release message
 - binds the BoxD payload hash, source commit, repository, operator label, network target, timestamp, and `authority_created=false`
 - creates a downloadable JSON signature receipt
 - does **not** call `eth_sendTransaction`, submit EAS, spend gas, or claim an attestation UID / transaction hash
+
+### iPhone / Coinbase product boundary
+
+Do **not** treat the Coinbase trading app as the Base app wallet explorer. A screen showing **Spot / Futures / Stocks / Portfolio / Orders** is the trading product, not proof of an injected EVM provider.
+
+For the current verified iPhone path and official Coinbase/Base references, read:
+
+**[WALLET_SIGNING_IOS.md](./WALLET_SIGNING_IOS.md)**
+
+If the signer reports `No injected EVM wallet provider found`, the correct state is `SIGNATURE_NOT_CREATED`. Do not promote that into a wallet, chain, or attestation failure.
 
 A wallet signature is a separate state from an on-chain attestation:
 

--- a/projects/ziggy/README.md
+++ b/projects/ziggy/README.md
@@ -33,12 +33,31 @@ Every edge requires provenance and a permission state. Missing edges remain unkn
 ## Release identity
 
 - **Operator:** `jaywisdom.eth`
+- **Repository / system identity:** `jsonwisdom/COMPUTERWISDOM`
 - **Preservation layer:** `BoxD`
 - **Intelligence label:** `100th Intelligence`
 - **Source commit:** `5aa886746ec08adcbbbad2c5f758b64324066d66`
 - **BoxD release payload SHA-256:** `ad22599ef68bca96af1328ed0ab60cc0ff488af21db1139db954098400146447`
 - **Release manifest:** `projects/ziggy/ziggy-release-v0.1.json`
 - **On-chain status:** signature required / not submitted
+
+### COMPUTERWISDOM boundary
+
+GitHub is the host and transport for this public release. It does not replace the repository/system identity.
+
+`COMPUTERWISDOM` must remain explicit in Ziggy receipts, signer messages, manifests, and replay paths as:
+
+`repository = jsonwisdom/COMPUTERWISDOM`
+
+User-supplied signer claim:
+
+`0x73ad550dcb47d254a5b3c335ae39d8999c42ff12`
+
+Current verification state:
+
+`USER_SUPPLIED_UNVERIFIED`
+
+The address must not be promoted to verified operator control merely because it was supplied in conversation. Verification requires an actual wallet signature from that address over the bounded Ziggy release message. See `computerwisdom-signer-binding-v0.1.json`.
 
 ## Human signature gate
 

--- a/projects/ziggy/WALLET_SIGNING_IOS.md
+++ b/projects/ziggy/WALLET_SIGNING_IOS.md
@@ -1,0 +1,55 @@
+# Ziggy v0.1 — iPhone Wallet Signing Guide
+
+Verified against official Coinbase / Base documentation on 2026-08-14.
+
+## First: identify the app
+
+The **Coinbase trading app** and the **Base app** are different products.
+
+If the screen shows market/trading navigation such as **Spot**, **Futures**, **Stocks**, **Portfolio**, or **Orders**, do not treat that screen as the Base app explorer. Coinbase documents that a Coinbase primary balance cannot be used to access dapps.
+
+Official source:
+- https://help.coinbase.com/en/dapps/getting-started/comparing-coinbase-wallets
+- https://help.coinbase.com/en/wallet/getting-started/what-is-coinbase-wallet
+
+## Current Base app route on iPhone
+
+Coinbase's current Base help says to connect to an app through the **Base app explorer**:
+
+1. Open the **Base app** on the iPhone.
+2. Open **Apps / app explorer**.
+3. Manually enter the Ziggy signer URL in the explorer address field:
+   `https://jsonwisdom.github.io/COMPUTERWISDOM/projects/ziggy/sign-v0.1.html`
+4. Load the page.
+5. Tap **1 — CONNECT WALLET**.
+6. Continue only if the page reports a wallet provider and the wallet/account shown is the one the human intends to use.
+
+Official source:
+- https://help.coinbase.com/en-gb/wallet/other-topics/mobile-app-sign-in-discontinued
+
+## Base Sepolia
+
+Ziggy v0.1 targets **Base Sepolia**, chain ID **84532**. Base's network documentation lists 84532 as the Base Sepolia chain ID.
+
+Official source:
+- https://docs.base.org/base-chain/quickstart/connecting-to-base
+
+## Important compatibility boundary
+
+The Ziggy v0.1 signer currently uses an injected **EIP-1193** provider (`window.ethereum`) and `personal_sign`.
+
+Therefore:
+
+- Opening the page in ChatGPT's in-app browser or ordinary Safari may show `No injected EVM wallet provider found`.
+- The Coinbase trading screen is **not evidence** that an injected provider exists.
+- Do not invent a tap path through a changing Coinbase UI.
+- Do not claim compatibility until the actual Base app explorer loads the page and exposes the wallet provider.
+- If the Base app explorer does not expose an injected provider, stop at `SIGNATURE_NOT_CREATED`; that is a client-compatibility gap, not a blockchain failure.
+
+## State doctrine
+
+`PUBLISHED ≠ PRESERVED ≠ SIGNED ≠ ATTESTED`
+
+A wallet connection is not a signature. A signature is not a transaction. A transaction is not an attestation until independently verified.
+
+`authority_created=false`

--- a/projects/ziggy/WALLET_SIGNING_IOS.md
+++ b/projects/ziggy/WALLET_SIGNING_IOS.md
@@ -12,6 +12,24 @@ Official source:
 - https://help.coinbase.com/en/dapps/getting-started/comparing-coinbase-wallets
 - https://help.coinbase.com/en/wallet/getting-started/what-is-coinbase-wallet
 
+## COMPUTERWISDOM identity must remain explicit
+
+GitHub is only the host/transport for this public page. Ziggy's repository/system identity is:
+
+`jsonwisdom/COMPUTERWISDOM`
+
+That exact repository string is part of the signing boundary and must remain visible in receipts and replay.
+
+User-supplied signer claim:
+
+`0x73ad550dcb47d254a5b3c335ae39d8999c42ff12`
+
+Current state:
+
+`USER_SUPPLIED_UNVERIFIED`
+
+Do not treat that address as verified ownership until the connected wallet actually signs the Ziggy release message from the same address. A mismatch must remain a mismatch; it must not be silently substituted.
+
 ## Current Base app route on iPhone
 
 Coinbase's current Base help says to connect to an app through the **Base app explorer**:
@@ -23,6 +41,7 @@ Coinbase's current Base help says to connect to an app through the **Base app ex
 4. Load the page.
 5. Tap **1 — CONNECT WALLET**.
 6. Continue only if the page reports a wallet provider and the wallet/account shown is the one the human intends to use.
+7. Before signing, compare the connected wallet address with the user-supplied claim above. If it differs, stop and preserve the gap.
 
 Official source:
 - https://help.coinbase.com/en-gb/wallet/other-topics/mobile-app-sign-in-discontinued
@@ -50,6 +69,6 @@ Therefore:
 
 `PUBLISHED ≠ PRESERVED ≠ SIGNED ≠ ATTESTED`
 
-A wallet connection is not a signature. A signature is not a transaction. A transaction is not an attestation until independently verified.
+A wallet connection is not a signature. A supplied address is not proof of wallet control. A signature is not a transaction. A transaction is not an attestation until independently verified.
 
 `authority_created=false`

--- a/projects/ziggy/computerwisdom-signer-binding-v0.1.json
+++ b/projects/ziggy/computerwisdom-signer-binding-v0.1.json
@@ -1,0 +1,20 @@
+{
+  "format": "ZIGGY_COMPUTERWISDOM_SIGNER_BINDING_V0.1",
+  "system_identity": "COMPUTERWISDOM",
+  "repository": "jsonwisdom/COMPUTERWISDOM",
+  "hosting_transport": "GitHub Pages",
+  "release": "Ziggy v0.1",
+  "operator_label": "jaywisdom.eth",
+  "claimed_signer_address": "0x73ad550dcb47d254a5b3c335ae39d8999c42ff12",
+  "claimed_signer_state": "USER_SUPPLIED_UNVERIFIED",
+  "verification_rule": "Promote the claimed signer address only after an actual wallet signature from the same address over the bounded Ziggy release message is independently verified.",
+  "mismatch_rule": "If the connected or recovered signer address differs, preserve the mismatch and do not silently substitute identities.",
+  "artifact_payload_sha256": "ad22599ef68bca96af1328ed0ab60cc0ff488af21db1139db954098400146447",
+  "source_commit_sha1": "5aa886746ec08adcbbbad2c5f758b64324066d66",
+  "target_network": "Base Sepolia",
+  "chain_id": 84532,
+  "signature_state": "NOT_CREATED",
+  "attestation_uid": null,
+  "transaction_hash": null,
+  "authority_created": false
+}


### PR DESCRIPTION
## Why

The prior mobile guidance collapsed the Coinbase trading app, legacy Coinbase Wallet naming, and the current Base app explorer into one path. A real iPhone screenshot exposed that mismatch.

## What changed

- adds `projects/ziggy/WALLET_SIGNING_IOS.md`
- updates the Ziggy README with an explicit Coinbase-product boundary
- records the current Base app explorer route from official Coinbase help
- records Base Sepolia chain ID `84532` from official Base documentation
- states that the current Ziggy signer still requires an injected EIP-1193 provider
- treats `No injected EVM wallet provider found` as `SIGNATURE_NOT_CREATED`, not as a chain failure

## No speculative code

This PR does not add Coinbase SDK integration, WalletConnect, a transaction path, or an EAS call. It documents the verified boundary before changing signing architecture.

`PUBLISHED ≠ PRESERVED ≠ SIGNED ≠ ATTESTED`

`authority_created=false`