### PR TITLE
Lock Ziggy identity threshold ladder v0.1

### DIFF
--- a/projects/ziggy/DIRECTORY_MAP.md
+++ b/projects/ziggy/DIRECTORY_MAP.md
@@ -5,6 +5,8 @@ This tree defines boundaries before implementation.
 ```text
 projects/ziggy/
 ├── natural-language/
+├── identity/
+│   └── addresses/
 ├── ens/
 ├── voice/
 ├── imagination/
@@ -26,6 +28,7 @@ No directory creates authority merely by existing.
 ## Boundary meanings
 
 - `natural-language/` — human-readable commands become explicit intent records.
+- `identity/` — typed thresholds for activity, protocol role, control, identity binding, third-party attestation, and authority; address snapshots live under `identity/addresses/`.
 - `ens/` — ENS names, addresses, forward/reverse resolution results, and identity gaps.
 - `voice/` — voice input becomes reviewable text before any action is proposed.
 - `imagination/` — speculative/generated work stays outside preserved originals and protected release lanes.
@@ -35,9 +38,27 @@ No directory creates authority merely by existing.
 - `receipts/` — immutable-shaped records of what was proposed, verified, signed, merged, or tested.
 - `replay/` — deterministic reconstruction of the reasoning and promotion path.
 
+## Identity ladder
+
+`ACTIVITY → PROTOCOL_ROLE → CONTROL → IDENTITY_BINDING → AUTHORITY`
+
+Third-party attestation is tracked separately:
+
+`ATTESTATION ABOUT ADDRESS ≠ SIGNATURE BY ADDRESS`
+
+Authority is not the automatic next state after identity. It requires an explicit human or sealed-protocol grant within a defined scope.
+
 ## Non-collapse doctrine
 
 `NAME ≠ ADDRESS ≠ SIGNER_CONTROL ≠ GITHUB_IDENTITY ≠ RELEASE_AUTHORITY`
+
+`OBSERVED_EDGE ≠ OWNERSHIP`.
+
+`PROTOCOL_OWNERSHIP ≠ PRIVATE_KEY_CONTROL`.
+
+`CONTROL ≠ IDENTITY`.
+
+`IDENTITY ≠ AUTHORITY`.
 
 `VOICE ≠ COMMAND` until transcription is shown and confirmed.
 

--- a/projects/ziggy/identity/README.md
+++ b/projects/ziggy/identity/README.md
@@ -1,0 +1,74 @@
+# Ziggy Identity Threshold Layer
+
+This directory separates blockchain activity, protocol participation, address control, identity binding, third-party attestations, and authority.
+
+No layer silently promotes another.
+
+## Canonical ladder
+
+`ACTIVITY → PROTOCOL_ROLE → CONTROL → IDENTITY_BINDING → AUTHORITY`
+
+Third-party attestation is evidence **about** an address or identity relationship. It is tracked separately because:
+
+`ATTESTATION ABOUT ADDRESS ≠ SIGNATURE BY ADDRESS`
+
+## Thresholds
+
+### ACTIVITY
+
+Current meaning: observable transactions, transfers, logs, calls, or state changes involving an address.
+
+Activity proves only activity.
+
+### PROTOCOL_ROLE
+
+A protocol-role claim may be promoted only when protocol-specific evidence exists, for example:
+
+- Uniswap `Swap` event involving the address
+- explicit Universal Router / PoolManager interaction attributable to the address
+- liquidity-position mint or protocol state assigning a position to the address
+
+Token receipts alone do not cross this threshold.
+
+### CONTROL
+
+Control may be promoted only by cryptographic evidence attributable to the address itself:
+
+- valid `personal_sign` signature recoverable to the address
+- valid EIP-712 signature recoverable to the address
+- valid ERC-1271 signature when the address is a contract wallet
+
+A third-party attestation about the address is not proof that the address signed.
+
+### IDENTITY_BINDING
+
+Identity binding requires evidence connecting a cryptographically controlled address to a named identity such as `jaywisdom.eth`.
+
+A convenience label, social statement, token transfer, or screenshot is insufficient.
+
+### THIRD_PARTY_ATTESTATION
+
+Third-party attestations are recorded as their own evidence class.
+
+They may support an identity claim when the attester is independently trusted or verified, but they do not prove private-key control of the subject address and do not create authority by themselves.
+
+### AUTHORITY
+
+Authority is never inferred from activity, protocol role, ownership, control, identity, or attestation.
+
+Authority crosses only when an explicit human or sealed-protocol command grants it within the relevant scope.
+
+`authority_created=false` remains the default.
+
+## Non-collapse doctrine
+
+- observed edge ≠ ownership
+- protocol ownership ≠ private-key control
+- ownership ≠ control
+- control ≠ identity
+- identity ≠ authority
+- attestation about address ≠ signature by address
+- convenience label ≠ verified claim
+- Merkle commitment ≠ wallet identity
+
+See [`thresholds.v0.1.json`](./thresholds.v0.1.json) for the machine-readable rules and [`addresses/0xf18e616d5f315435f9a0c48eed52048d4051fb27.status.v0.1.json`](./addresses/0xf18e616d5f315435f9a0c48eed52048d4051fb27.status.v0.1.json) for the current bounded address snapshot.

--- a/projects/ziggy/identity/addresses/0xf18e616d5f315435f9a0c48eed52048d4051fb27.status.v0.1.json
+++ b/projects/ziggy/identity/addresses/0xf18e616d5f315435f9a0c48eed52048d4051fb27.status.v0.1.json
@@ -1,0 +1,103 @@
+{
+  "format": "ZIGGY_ADDRESS_STATUS_V0.1",
+  "repository": "jsonwisdom/COMPUTERWISDOM",
+  "snapshot_date": "2026-08-14",
+  "subject": {
+    "address": "0xF18E616d5F315435F9A0C48EeD52048d4051FB27",
+    "chain": "Base",
+    "convenience_label": "Jay's Uniswap",
+    "label_state": "USER_SUPPLIED_NOT_IDENTITY_PROOF"
+  },
+  "source_boundary": {
+    "status_source": "USER_SUPPLIED_CANONICAL_RECEIPT",
+    "independent_basescan_replay_in_this_commit": "NOT_PERFORMED",
+    "rule": "This file codifies the bounded state supplied for Ziggy. It does not promote a user label or reported activity into control, identity, protocol role, or authority."
+  },
+  "ladder": {
+    "activity": {
+      "status": "OBSERVED",
+      "reported_observations": [
+        "received DAI",
+        "received Zerocool token",
+        "transferred/interacted with JAYWISDOM contract 0x694ce46c64d9d1a5e9376a9febcf85ec05d72e9f",
+        "transferred/interacted with 0x829adfedbe565f9885a7ea6bc78912acaef055e2"
+      ],
+      "promotion_effect": "ACTIVITY_ONLY"
+    },
+    "protocol_role": {
+      "status": "NOT_YET_VERIFIED_FROM_BASESCAN",
+      "protocol": "Uniswap",
+      "crossing_evidence": [
+        "Swap event attributable to subject address",
+        "Universal Router interaction attributable to subject address",
+        "PoolManager interaction attributable to subject address",
+        "Uniswap liquidity position minted or protocol state assigned to subject address"
+      ]
+    },
+    "control": {
+      "status": "NOT_CRYPTOGRAPHICALLY_VERIFIED",
+      "crossing_evidence": [
+        "valid personal_sign signature recoverable to subject address",
+        "valid EIP-712 signature recoverable to subject address",
+        "valid ERC-1271 signature if subject address is a contract wallet"
+      ]
+    },
+    "identity_binding": {
+      "status": "NOT_VERIFIED",
+      "target_identity_if_claimed": "jaywisdom.eth",
+      "crossing_evidence": [
+        "verified signature from subject address explicitly binding it to jaywisdom.eth",
+        "mutually supported cryptographic binding"
+      ]
+    },
+    "third_party_attestation": {
+      "status": "NO_SUBJECT_BINDING_RECORDED_HERE",
+      "rule": "An attestation about the subject address is not a signature by the subject address and does not prove subject control."
+    },
+    "authority": {
+      "status": "NOT_CREATED",
+      "crossing_evidence": [
+        "explicit human authority grant within a defined scope",
+        "explicit sealed-protocol authority command within a defined scope"
+      ]
+    }
+  },
+  "distinct_nodes": {
+    "eas_creator_attester": {
+      "address": "0xC345B26094c63C69222Ee775189a3d3eaead5a84",
+      "relationship_to_subject": "DISTINCT_NO_IDENTITY_COLLAPSE",
+      "repository_evidence": "signal-core/eas/receipt-core-v0.4.eas.json"
+    },
+    "jaywisdom_contract": {
+      "address": "0x694ce46c64d9d1a5e9376a9febcf85ec05d72e9f",
+      "relationship_to_subject": "ACTIVITY_EDGE_ONLY_NOT_IDENTITY"
+    },
+    "other_address": {
+      "address": "0x829adfedbe565f9885a7ea6bc78912acaef055e2",
+      "relationship_to_subject": "ACTIVITY_EDGE_ONLY_NOT_IDENTITY"
+    }
+  },
+  "context_commitments_not_identity_proofs": [
+    {
+      "type": "MERKLE_ROOT_SHA256",
+      "value": "ff55a1fb6ef07adbeea057aed4997a617e16ae3c80c8d18ec673c3d14ca25a91",
+      "repository_evidence": "receipts/merkle/confucius_compute_wisdom_merkle_purpose_key_v1.json",
+      "relationship_to_subject": "NOT_ASSERTED"
+    },
+    {
+      "type": "EAS_RECEIPT_CORE_BUNDLE_ROOT_SHA256",
+      "value": "b3732b6b1c34075e60d85976c968f3d43d299e68b383bc604ed45bb3c1d45070",
+      "repository_evidence": "signal-core/eas/receipt-core-v0.4.eas.json",
+      "relationship_to_subject": "NOT_ASSERTED"
+    }
+  ],
+  "hard_rules": [
+    "OBSERVED_EDGE != OWNERSHIP",
+    "PROTOCOL_OWNERSHIP != PRIVATE_KEY_CONTROL",
+    "CONTROL != IDENTITY",
+    "IDENTITY != AUTHORITY",
+    "ATTESTATION_ABOUT_ADDRESS != SIGNATURE_BY_ADDRESS",
+    "ACTIVITY != AUTHORITY"
+  ],
+  "authority_created": false
+}

--- a/projects/ziggy/identity/thresholds.v0.1.json
+++ b/projects/ziggy/identity/thresholds.v0.1.json
@@ -1,0 +1,105 @@
+{
+  "format": "ZIGGY_IDENTITY_THRESHOLDS_V0.1",
+  "repository": "jsonwisdom/COMPUTERWISDOM",
+  "default_authority_created": false,
+  "ladder": [
+    "ACTIVITY",
+    "PROTOCOL_ROLE",
+    "CONTROL",
+    "IDENTITY_BINDING",
+    "AUTHORITY"
+  ],
+  "independent_evidence_class": "THIRD_PARTY_ATTESTATION",
+  "thresholds": {
+    "ACTIVITY": {
+      "crossing_evidence": [
+        "observable on-chain transaction involving address",
+        "observable transfer/log/call/state change involving address"
+      ],
+      "does_not_prove": [
+        "protocol role",
+        "ownership",
+        "control",
+        "identity",
+        "authority"
+      ]
+    },
+    "PROTOCOL_ROLE": {
+      "uniswap_examples": [
+        "Swap event attributable to address",
+        "Universal Router interaction attributable to address",
+        "PoolManager interaction attributable to address",
+        "liquidity position minted or protocol state assigned to address"
+      ],
+      "insufficient_evidence": [
+        "token receipt",
+        "token transfer",
+        "convenience label"
+      ]
+    },
+    "CONTROL": {
+      "crossing_evidence": [
+        "valid personal_sign signature recoverable to exact address",
+        "valid EIP-712 signature recoverable to exact address",
+        "valid ERC-1271 signature when subject address is a contract wallet"
+      ],
+      "insufficient_evidence": [
+        "third-party attestation about address",
+        "token ownership",
+        "token transfer",
+        "screenshot",
+        "social statement"
+      ]
+    },
+    "IDENTITY_BINDING": {
+      "crossing_evidence": [
+        "verified signature from controlled address that explicitly binds the address to the named identity",
+        "mutually supported cryptographic binding between controlled address and named identity"
+      ],
+      "supporting_but_not_control_evidence": [
+        "third-party attestation from independently verified or trusted attester"
+      ],
+      "insufficient_evidence": [
+        "human label",
+        "token activity",
+        "screenshot",
+        "unverified social claim"
+      ]
+    },
+    "THIRD_PARTY_ATTESTATION": {
+      "meaning": "an attester makes a claim about an address or identity relationship",
+      "hard_boundary": "ATTESTATION ABOUT ADDRESS != SIGNATURE BY ADDRESS",
+      "does_not_prove": [
+        "subject private-key control",
+        "authority"
+      ]
+    },
+    "AUTHORITY": {
+      "crossing_evidence": [
+        "explicit human authority grant within a defined scope",
+        "explicit sealed-protocol authority command within a defined scope"
+      ],
+      "insufficient_evidence": [
+        "activity",
+        "protocol role",
+        "protocol ownership",
+        "address control",
+        "identity binding",
+        "third-party attestation",
+        "Merkle root"
+      ],
+      "default": "NOT_CREATED"
+    }
+  },
+  "non_collapse_rules": [
+    "OBSERVED_EDGE != OWNERSHIP",
+    "PROTOCOL_OWNERSHIP != PRIVATE_KEY_CONTROL",
+    "OWNERSHIP != CONTROL",
+    "CONTROL != IDENTITY",
+    "IDENTITY != AUTHORITY",
+    "ATTESTATION_ABOUT_ADDRESS != SIGNATURE_BY_ADDRESS",
+    "CONVENIENCE_LABEL != VERIFIED_CLAIM",
+    "MERKLE_COMMITMENT != WALLET_IDENTITY"
+  ],
+  "authority_created": false
+}


### PR DESCRIPTION
## Purpose

Codify Ziggy's address-evidence ladder so activity, protocol participation, control, identity binding, third-party attestation, and authority cannot silently collapse into one another.

## Adds

- `projects/ziggy/identity/README.md`
- `projects/ziggy/identity/thresholds.v0.1.json`
- `projects/ziggy/identity/addresses/0xf18e616d5f315435f9a0c48eed52048d4051fb27.status.v0.1.json`
- updates `projects/ziggy/DIRECTORY_MAP.md` to add the new `identity/` layer

## Canonical ladder

`ACTIVITY → PROTOCOL_ROLE → CONTROL → IDENTITY_BINDING → AUTHORITY`

Third-party attestation remains an independent evidence class:

`ATTESTATION ABOUT ADDRESS ≠ SIGNATURE BY ADDRESS`

## 0xF18E snapshot

The supplied status is preserved without promotion:

- activity: `OBSERVED`
- Uniswap protocol role: `NOT_YET_VERIFIED_FROM_BASESCAN`
- control: `NOT_CRYPTOGRAPHICALLY_VERIFIED`
- identity binding: `NOT_VERIFIED`
- authority: `NOT_CREATED`

The convenience label `Jay's Uniswap` is preserved as `USER_SUPPLIED_NOT_IDENTITY_PROOF`.

The commit does not independently replay BaseScan; it codifies the bounded receipt supplied for Ziggy and explicitly records that boundary.

## Important contradiction resolved

The supplied table listed third-party attestation as an AUTHORITY crossing event, while the rest of the receipt correctly states `attestation ≠ authority`.

This PR locks the stronger rule:

- third-party attestation may support an identity claim
- it does not prove subject private-key control
- it does not create authority
- authority requires an explicit human or sealed-protocol grant within a defined scope

## Merkle boundary

Known COMPUTERWISDOM commitments are referenced only as context:

- `ff55a1fb6ef07adbeea057aed4997a617e16ae3c80c8d18ec673c3d14ca25a91`
- `b3732b6b1c34075e60d85976c968f3d43d299e68b383bc604ed45bb3c1d45070`

Both record `relationship_to_subject = NOT_ASSERTED`.

`authority_created=false`