### PR TITLE
Ziggy: Platteville School Board Watch v0.1

### DIFF
--- a/projects/ziggy/replay/PLATTEVILLE_SCHOOL_BOARD_WATCH_v0.1.md
+++ b/projects/ziggy/replay/PLATTEVILLE_SCHOOL_BOARD_WATCH_v0.1.md
@@ -1,0 +1,50 @@
+# PLATTEVILLE — An Actual School Board Meeting
+
+## Ziggy Watch v0.1
+
+### Mission
+Watch public Platteville School District Board of Education records for new agendas, packets, minutes, regular/committee meeting video, budgets, school-safety items, police/CRO relationships, technology, and student-policy material.
+
+### Evidence rail
+
+`CLAIM → DOCUMENT → MONEY → AUTHORITY → VOTE → RESULT → REPLAY`
+
+### Non-collapse rules
+
+- `PROPOSED ≠ APPROVED ≠ SPENT`
+- `AGENDA ≠ MOTION ≠ VOTE ≠ MINUTES`
+- `DISCUSSION ≠ AUTHORIZATION`
+- `POLICE PRESENCE ≠ FORCE POLICY`
+- Do **not** promote a “shock glove” claim into Platteville’s record unless an actual Platteville source establishes it.
+
+### Episode triggers
+
+1. **THE AGENDA** — What are they actually voting on?
+2. **FOLLOW THE DOLLAR** — Who requested it, which fund, what vote, what receipt?
+3. **SCHOOL SAFETY** — What policy, training, equipment, authority, and limits exist?
+4. **PUBLIC COMMENT** — What question was asked, and was it answered?
+5. **THE VOTE** — Motion, second, vote, minutes, result.
+6. **REPLAY** — They said it. Did they write it down? Did they vote? Did they spend it? Show me.
+
+### Watch output
+For every new material item capture:
+
+`MEETING | SOURCE_TYPE | AGENDA_ITEM | CLAIM | DOLLARS | AUTHORITY/POLICY | MOTION/VOTE | GAP | EPISODE_CANDIDATE`
+
+Only notify on a new source or material change. Preserve uncertainty and contradictory records instead of resolving them by narrative.
+
+### Source classes
+- Platteville School District Board of Education public pages
+- official agenda/packet/minutes system
+- official district board-meeting video channel
+- linked public budget, policy, safety, and committee records
+
+### State
+
+```text
+WATCH                = ACTIVE
+PUBLIC_RECORD_ONLY   = TRUE
+SOURCE_MUTATED       = FALSE
+AUTHORITY_CREATED    = FALSE
+MERGE_STATE          = UNMERGED_PENDING_HUMAN_REVIEW
+```


### PR DESCRIPTION
Adds an evidence-only replay/watch lane for public Platteville School District Board of Education material.

Core rail:
`CLAIM → DOCUMENT → MONEY → AUTHORITY → VOTE → RESULT → REPLAY`

Guardrail: no Platteville “shock glove” claim is promoted unless an actual Platteville source establishes it.

State remains `AUTHORITY_CREATED=FALSE` and unmerged pending human review.