### PR TITLE
Add Aunt Rann ReceiptOS history regression v0.1

### DIFF
--- a/tests/receiptos_history_vectors_v0_1/AUNT_RANN_SAME_ENDPOINT_DIFFERENT_HISTORY_V0_1.json
+++ b/tests/receiptos_history_vectors_v0_1/AUNT_RANN_SAME_ENDPOINT_DIFFERENT_HISTORY_V0_1.json
@@ -1,0 +1,104 @@
+{
+  "format": "RECEIPTOS_HISTORY_REGRESSION_V0.1",
+  "fixture_id": "AUNT_RANN_SAME_ENDPOINT_DIFFERENT_HISTORY_V0_1",
+  "classification": "SYNTHETIC_REGRESSION",
+  "lesson_surface": "FAMILY_EDUCATIONAL_SIMULATION",
+  "purpose": "Prove that identical final state hashes do not imply identical event-history hashes.",
+  "canonicalization": {
+    "encoding": "UTF-8",
+    "json": "sort_keys=true,separators=(',',':'),ensure_ascii=false",
+    "hash": "SHA-256"
+  },
+  "initial_state": {
+    "consent": "HOLD",
+    "content": "Meet me by the pink tree.",
+    "delivered": false
+  },
+  "initial_state_hash": "sha256:30cc29ff65e9f94595a0c1c0e35ad4e58692d1dea4c4ed4badf83719435cfdd9",
+  "paths": {
+    "PATH_A": {
+      "description": "No route interaction occurred.",
+      "event_count": 0,
+      "event_history": [],
+      "path_hash": "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "event_history_hash": "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "final_state": {
+        "consent": "HOLD",
+        "content": "Meet me by the pink tree.",
+        "delivered": false
+      },
+      "state_hash": "sha256:30cc29ff65e9f94595a0c1c0e35ad4e58692d1dea4c4ed4badf83719435cfdd9",
+      "replay_result": "PATH_RECONSTRUCTED"
+    },
+    "PATH_B": {
+      "description": "A route was requested, consent was checked, and the route was blocked.",
+      "event_count": 3,
+      "event_history": [
+        "ROUTE_REQUESTED",
+        "CONSENT_CHECKED",
+        "ROUTE_BLOCKED"
+      ],
+      "path_hash": "sha256:ba6ab657988d965d2bbba0096a7ce94cbf843c09bf3d2e9c540eda1f9448fa7e",
+      "event_history_hash": "sha256:ba6ab657988d965d2bbba0096a7ce94cbf843c09bf3d2e9c540eda1f9448fa7e",
+      "final_state": {
+        "consent": "HOLD",
+        "content": "Meet me by the pink tree.",
+        "delivered": false
+      },
+      "state_hash": "sha256:30cc29ff65e9f94595a0c1c0e35ad4e58692d1dea4c4ed4badf83719435cfdd9",
+      "replay_result": "PATH_RECONSTRUCTED"
+    }
+  },
+  "comparison": {
+    "state_hash_equal": true,
+    "path_hash_equal": false,
+    "event_history_hash_equal": false,
+    "replay_result": "MULTIPLE_PATHS_DISTINGUISHED",
+    "canonical_law": "STATE_HASH_EQUAL != HISTORY_HASH_EQUAL"
+  },
+  "replay_objects": {
+    "PATH_A": {
+      "initial_state_hash": "sha256:30cc29ff65e9f94595a0c1c0e35ad4e58692d1dea4c4ed4badf83719435cfdd9",
+      "final_state_hash": "sha256:30cc29ff65e9f94595a0c1c0e35ad4e58692d1dea4c4ed4badf83719435cfdd9",
+      "event_count": 0,
+      "event_history_hash": "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "replay_result": "PATH_RECONSTRUCTED",
+      "authority_created": false
+    },
+    "PATH_B": {
+      "initial_state_hash": "sha256:30cc29ff65e9f94595a0c1c0e35ad4e58692d1dea4c4ed4badf83719435cfdd9",
+      "final_state_hash": "sha256:30cc29ff65e9f94595a0c1c0e35ad4e58692d1dea4c4ed4badf83719435cfdd9",
+      "event_count": 3,
+      "event_history_hash": "sha256:ba6ab657988d965d2bbba0096a7ce94cbf843c09bf3d2e9c540eda1f9448fa7e",
+      "replay_result": "PATH_RECONSTRUCTED",
+      "authority_created": false
+    }
+  },
+  "three_wisdom_girls": {
+    "WITNESS": {
+      "question": "What state do we actually see?",
+      "observation": "DELIVERED = FALSE",
+      "cannot_infer": "WHY"
+    },
+    "CHALLENGER": {
+      "question": "Show me the receipts. What path produced this state?",
+      "function": "DISTINGUISH_EVENT_HISTORY"
+    },
+    "GATEKEEPER": {
+      "blocked_promotion": "DELIVERED_FALSE -> NOBODY_TRIED",
+      "allowed_classifications": [
+        "UNIQUE_PATH_PROVEN",
+        "MULTIPLE_PATHS_REMAIN",
+        "INSUFFICIENT_HISTORY"
+      ]
+    }
+  },
+  "laws": [
+    "ENDPOINT != HISTORY",
+    "STATE_ROOT != EVENT_ROOT",
+    "OBSERVED_RESULT != PROVEN_CAUSE",
+    "NO_VISIBLE_STATE_CHANGE != NO_INTERACTION"
+  ],
+  "child_sentence": "Two roads can end at the same house.",
+  "authority_created": false
+}

--- a/tests/receiptos_history_vectors_v0_1/README.md
+++ b/tests/receiptos_history_vectors_v0_1/README.md
@@ -1,0 +1,73 @@
+# ReceiptOS History Regression V0.1
+
+This fixture family tests a foundational ReceiptOS rule:
+
+`SAME ENDPOINT != SAME HISTORY`
+
+A state commitment answers **what state exists now**. A path commitment answers **what event history produced or preceded that state**. ReceiptOS must never infer the second from the first.
+
+## Canonical hashing
+
+```text
+STATE_HASH = SHA256(canonical(FINAL_STATE))
+PATH_HASH  = SHA256(canonical(EVENT_HISTORY))
+```
+
+Canonical JSON for this vector is UTF-8 JSON with sorted object keys, compact separators `,` and `:`, and `ensure_ascii=false`.
+
+## Fixture
+
+`AUNT_RANN_SAME_ENDPOINT_DIFFERENT_HISTORY_V0_1.json`
+
+Both paths end at:
+
+```json
+{"consent":"HOLD","content":"Meet me by the pink tree.","delivered":false}
+```
+
+Path A has no events.
+
+Path B records:
+
+```text
+ROUTE_REQUESTED
+CONSENT_CHECKED
+ROUTE_BLOCKED
+```
+
+Expected result:
+
+```text
+PATH_A.STATE_HASH == PATH_B.STATE_HASH  -> TRUE
+PATH_A.PATH_HASH  == PATH_B.PATH_HASH   -> FALSE
+```
+
+Exact commitments:
+
+```text
+STATE_HASH = sha256:30cc29ff65e9f94595a0c1c0e35ad4e58692d1dea4c4ed4badf83719435cfdd9
+PATH_A     = sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+PATH_B     = sha256:ba6ab657988d965d2bbba0096a7ce94cbf843c09bf3d2e9c540eda1f9448fa7e
+```
+
+## Regression law
+
+- `STATE_HASH_EQUAL != HISTORY_HASH_EQUAL`
+- `ENDPOINT != HISTORY`
+- `STATE_ROOT != EVENT_ROOT`
+- `OBSERVED_RESULT != PROVEN_CAUSE`
+- `NO_VISIBLE_STATE_CHANGE != NO_INTERACTION`
+
+The unsupported promotion `DELIVERED_FALSE -> NOBODY_TRIED` must remain blocked.
+
+## Three Wisdom Girls surface
+
+- **Witness** — reports the visible state and does not infer cause.
+- **Challenger** — requests the event receipts and reconstructs the path.
+- **Gatekeeper** — blocks causal claims that the available history does not support.
+
+Child sentence: **Two roads can end at the same house.**
+
+This is a synthetic regression fixture. It creates no family, wallet, institutional, or protocol authority.
+
+`authority_created=false`

--- a/tests/test_receiptos_history_hash_separation_v0_1.py
+++ b/tests/test_receiptos_history_hash_separation_v0_1.py
@@ -1,0 +1,93 @@
+import hashlib
+import json
+from pathlib import Path
+
+
+FIXTURE = (
+    Path(__file__).parent
+    / "receiptos_history_vectors_v0_1"
+    / "AUNT_RANN_SAME_ENDPOINT_DIFFERENT_HISTORY_V0_1.json"
+)
+
+
+def canonical_json(value):
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def sha256_commitment(value):
+    payload = canonical_json(value).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def load_fixture():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_fixture_hashes_recompute_exactly():
+    fixture = load_fixture()
+    assert fixture["initial_state_hash"] == sha256_commitment(fixture["initial_state"])
+
+    for path in fixture["paths"].values():
+        assert path["event_count"] == len(path["event_history"])
+        assert path["state_hash"] == sha256_commitment(path["final_state"])
+        expected_history_hash = sha256_commitment(path["event_history"])
+        assert path["path_hash"] == expected_history_hash
+        assert path["event_history_hash"] == expected_history_hash
+
+
+def test_same_endpoint_does_not_collapse_history():
+    fixture = load_fixture()
+    path_a = fixture["paths"]["PATH_A"]
+    path_b = fixture["paths"]["PATH_B"]
+
+    assert path_a["final_state"] == path_b["final_state"]
+    assert path_a["state_hash"] == path_b["state_hash"]
+    assert path_a["path_hash"] != path_b["path_hash"]
+    assert fixture["comparison"]["state_hash_equal"] is True
+    assert fixture["comparison"]["path_hash_equal"] is False
+    assert fixture["comparison"]["event_history_hash_equal"] is False
+    assert fixture["comparison"]["replay_result"] == "MULTIPLE_PATHS_DISTINGUISHED"
+
+
+def test_path_a_is_canonical_empty_history():
+    fixture = load_fixture()
+    path_a = fixture["paths"]["PATH_A"]
+
+    assert path_a["event_count"] == 0
+    assert path_a["event_history"] == []
+    assert path_a["path_hash"] == (
+        "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    )
+
+
+def test_path_b_preserves_three_distinct_events():
+    fixture = load_fixture()
+    path_b = fixture["paths"]["PATH_B"]
+
+    assert path_b["event_count"] == 3
+    assert path_b["event_history"] == [
+        "ROUTE_REQUESTED",
+        "CONSENT_CHECKED",
+        "ROUTE_BLOCKED",
+    ]
+
+
+def test_gatekeeper_blocks_unsupported_causal_promotion():
+    fixture = load_fixture()
+    gatekeeper = fixture["three_wisdom_girls"]["GATEKEEPER"]
+
+    assert gatekeeper["blocked_promotion"] == "DELIVERED_FALSE -> NOBODY_TRIED"
+    assert "OBSERVED_RESULT != PROVEN_CAUSE" in fixture["laws"]
+
+
+def test_authority_remains_false():
+    fixture = load_fixture()
+
+    assert fixture["authority_created"] is False
+    assert fixture["replay_objects"]["PATH_A"]["authority_created"] is False
+    assert fixture["replay_objects"]["PATH_B"]["authority_created"] is False


### PR DESCRIPTION
## Purpose

Add a foundational ReceiptOS regression proving that identical final states do not imply identical causal histories.

## Fixture

`AUNT_RANN_SAME_ENDPOINT_DIFFERENT_HISTORY_V0_1`

Two synthetic paths share the same initial and final durable state:

`{"consent":"HOLD","content":"Meet me by the pink tree.","delivered":false}`

But their event histories differ:

- Path A: `[]`
- Path B: `ROUTE_REQUESTED → CONSENT_CHECKED → ROUTE_BLOCKED`

## Canonical commitments

- state hash: `sha256:30cc29ff65e9f94595a0c1c0e35ad4e58692d1dea4c4ed4badf83719435cfdd9`
- Path A / `H([])`: `sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945`
- Path B: `sha256:ba6ab657988d965d2bbba0096a7ce94cbf843c09bf3d2e9c540eda1f9448fa7e`

Canonical JSON: UTF-8, sorted keys, compact separators, `ensure_ascii=false`.

## Assertions

`STATE_HASH_EQUAL = true`

`PATH_HASH_EQUAL = false`

`REPLAY_RESULT = MULTIPLE_PATHS_DISTINGUISHED`

The regression explicitly blocks:

`DELIVERED_FALSE -> NOBODY_TRIED`

and preserves:

- `ENDPOINT != HISTORY`
- `STATE_ROOT != EVENT_ROOT`
- `OBSERVED_RESULT != PROVEN_CAUSE`
- `NO_VISIBLE_STATE_CHANGE != NO_INTERACTION`

## Files

- `tests/receiptos_history_vectors_v0_1/AUNT_RANN_SAME_ENDPOINT_DIFFERENT_HISTORY_V0_1.json`
- `tests/receiptos_history_vectors_v0_1/README.md`
- `tests/test_receiptos_history_hash_separation_v0_1.py`

The pytest recomputes all hashes rather than trusting stored values.

Synthetic educational fixture only. No real family, wallet, routing, consent, institutional, or protocol authority is created.

`authority_created=false`