### PR TITLE
Add typed authority membrane v0.1

### DIFF
--- a/fixtures/jaywisdom/authority/authority_membrane_v0_1.json
+++ b/fixtures/jaywisdom/authority/authority_membrane_v0_1.json
@@ -1,0 +1,72 @@
+{
+  "format": "JSONWISDOM_AUTHORITY_MEMBRANE_V0.1",
+  "identity_lattice": [
+    "HUMAN",
+    "IDENTITY_LABEL",
+    "ADDRESS_CONTROL",
+    "IDENTITY_BINDING",
+    "ATTESTATION",
+    "RECEIPT",
+    "VERIFICATION",
+    "HUMAN_OR_INSTITUTIONAL_AUTHORITY"
+  ],
+  "identity_binding": {
+    "identity_root": "JAYWISDOM.eth",
+    "operator_identity": "jaywisdom.base.eth",
+    "github_identity": "jsonwisdom",
+    "binding_status": "DECLARED_PENDING_EXTERNAL_WITNESS",
+    "binding_hash": "a934eb17ce56014155802c2df566f68b878511e71c41c8d722370ed703480be7"
+  },
+  "authority_types": {
+    "protocol_authority": {
+      "meaning": "A deterministic verifier or protocol may treat a replay result as final inside that named protocol only.",
+      "scope": "machine protocol / verifier semantics",
+      "state": "TYPE_DEFINED",
+      "does_not_imply": [
+        "human authority",
+        "institutional authority",
+        "legal identity",
+        "universal truth"
+      ]
+    },
+    "evidence_authority": {
+      "meaning": "Evidence may carry source-scoped or receipt-scoped weight under an explicit evidence policy.",
+      "scope": "evidence evaluation only",
+      "state": "TYPE_DEFINED",
+      "does_not_imply": [
+        "truth by itself",
+        "human authority",
+        "institutional authority",
+        "identity proof"
+      ]
+    },
+    "human_authority": {
+      "meaning": "Permission or decision power explicitly granted by a human within a defined scope.",
+      "scope": "human decision rights",
+      "state": "NOT_CREATED",
+      "does_not_imply": [
+        "institutional authority"
+      ]
+    },
+    "institutional_authority": {
+      "meaning": "Authority attributable to a recognized institution within an explicit jurisdiction and scope.",
+      "scope": "institutional / jurisdictional decision rights",
+      "state": "NOT_CREATED",
+      "does_not_imply": [
+        "human identity",
+        "universal truth"
+      ]
+    }
+  },
+  "non_collapse_rules": [
+    "CONTROL != IDENTITY",
+    "IDENTITY != AUTHORITY",
+    "ATTESTATION_ABOUT_ADDRESS != SIGNATURE_BY_ADDRESS",
+    "CONVENIENCE_LABEL != VERIFIED_CLAIM",
+    "PROTOCOL_AUTHORITY != HUMAN_AUTHORITY",
+    "PROTOCOL_AUTHORITY != INSTITUTIONAL_AUTHORITY",
+    "EVIDENCE_AUTHORITY != HUMAN_AUTHORITY",
+    "VERIFICATION != HUMAN_OR_INSTITUTIONAL_AUTHORITY"
+  ],
+  "authority_created": false
+}

--- a/schemas/jaywisdom/authority_membrane.v0_1.schema.json
+++ b/schemas/jaywisdom/authority_membrane.v0_1.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jsonwisdom.local/schemas/jaywisdom/authority_membrane.v0_1.schema.json",
+  "title": "JSONWisdom Typed Authority Membrane v0.1",
+  "description": "Separates identity, evidence, verification, and typed authority so no layer silently promotes into human or institutional authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "identity_lattice",
+    "identity_binding",
+    "authority_types",
+    "non_collapse_rules",
+    "authority_created"
+  ],
+  "properties": {
+    "format": {
+      "const": "JSONWISDOM_AUTHORITY_MEMBRANE_V0.1"
+    },
+    "identity_lattice": {
+      "type": "array",
+      "prefixItems": [
+        {"const": "HUMAN"},
+        {"const": "IDENTITY_LABEL"},
+        {"const": "ADDRESS_CONTROL"},
+        {"const": "IDENTITY_BINDING"},
+        {"const": "ATTESTATION"},
+        {"const": "RECEIPT"},
+        {"const": "VERIFICATION"},
+        {"const": "HUMAN_OR_INSTITUTIONAL_AUTHORITY"}
+      ],
+      "items": false,
+      "minItems": 8,
+      "maxItems": 8,
+      "description": "Ordered distinctions only. Array position does not imply promotion."
+    },
+    "identity_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "identity_root",
+        "operator_identity",
+        "github_identity",
+        "binding_status",
+        "binding_hash"
+      ],
+      "properties": {
+        "identity_root": {"const": "JAYWISDOM.eth"},
+        "operator_identity": {"const": "jaywisdom.base.eth"},
+        "github_identity": {"const": "jsonwisdom"},
+        "binding_status": {"const": "DECLARED_PENDING_EXTERNAL_WITNESS"},
+        "binding_hash": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "authority_types": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "protocol_authority",
+        "evidence_authority",
+        "human_authority",
+        "institutional_authority"
+      ],
+      "properties": {
+        "protocol_authority": {"$ref": "#/$defs/authority_type"},
+        "evidence_authority": {"$ref": "#/$defs/authority_type"},
+        "human_authority": {"$ref": "#/$defs/authority_type"},
+        "institutional_authority": {"$ref": "#/$defs/authority_type"}
+      }
+    },
+    "non_collapse_rules": {
+      "type": "array",
+      "minItems": 4,
+      "items": {"type": "string"}
+    },
+    "authority_created": {
+      "const": false
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "authority_type": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "meaning",
+        "scope",
+        "state",
+        "does_not_imply"
+      ],
+      "properties": {
+        "meaning": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state": {
+          "enum": [
+            "TYPE_DEFINED",
+            "NOT_CREATED",
+            "DECLARED_WITHIN_SCOPE",
+            "VERIFIED_WITHIN_SCOPE",
+            "GRANTED_WITHIN_SCOPE",
+            "REVOKED"
+          ]
+        },
+        "does_not_imply": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string"}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changed
- adds `schemas/jaywisdom/authority_membrane.v0_1.schema.json`
- adds `fixtures/jaywisdom/authority/authority_membrane_v0_1.json`
- types protocol, evidence, human, and institutional authority separately
- preserves the repo-observed identity binding hash and `DECLARED_PENDING_EXTERNAL_WITNESS` state

## Why
The existing identity threshold doctrine already separates control, identity, attestation, and authority, but the word `authority` can carry different meanings across verifier/protocol language and human or institutional decision rights. This patch makes those authority classes machine-distinguishable.

## Hard boundaries
- `CONTROL != IDENTITY`
- `IDENTITY != AUTHORITY`
- `ATTESTATION_ABOUT_ADDRESS != SIGNATURE_BY_ADDRESS`
- `PROTOCOL_AUTHORITY != HUMAN_AUTHORITY`
- `PROTOCOL_AUTHORITY != INSTITUTIONAL_AUTHORITY`
- `VERIFICATION != HUMAN_OR_INSTITUTIONAL_AUTHORITY`
- `authority_created=false`

## Validation
The fixture was validated locally against the Draft 2020-12 JSON Schema before publication, then both branch files were read back through the GitHub connector.

This PR is intentionally draft. Merge remains a human decision.