### PR TITLE
Add Purposeful White House Double Reverse Onion v0.1

### DIFF
--- a/.github/workflows/purposeful-white-house-replay-v0-1.yml
+++ b/.github/workflows/purposeful-white-house-replay-v0-1.yml
@@ -1,0 +1,37 @@
+name: Purposeful White House Replay v0.1
+
+on:
+  pull_request:
+    paths:
+      - 'docs/jaywisdom/PURPOSEFUL_WHITE_HOUSE_DOUBLE_REVERSE_ONION_V0_1.md'
+      - 'schemas/jaywisdom/purposeful_white_house_replay.v0_1.schema.json'
+      - 'fixtures/jaywisdom/fraud_ledger/PURPOSEFUL_WHITE_HOUSE_REPLAY_TEST_VECTORS_V0_1.json'
+      - 'tools/verify_purposeful_white_house_replay_v0_1.py'
+      - 'agents/purposeful_white_house/agent_contract.json'
+      - '.github/workflows/purposeful-white-house-replay-v0-1.yml'
+  push:
+    paths:
+      - 'docs/jaywisdom/PURPOSEFUL_WHITE_HOUSE_DOUBLE_REVERSE_ONION_V0_1.md'
+      - 'schemas/jaywisdom/purposeful_white_house_replay.v0_1.schema.json'
+      - 'fixtures/jaywisdom/fraud_ledger/PURPOSEFUL_WHITE_HOUSE_REPLAY_TEST_VECTORS_V0_1.json'
+      - 'tools/verify_purposeful_white_house_replay_v0_1.py'
+      - 'agents/purposeful_white_house/agent_contract.json'
+      - '.github/workflows/purposeful-white-house-replay-v0-1.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse JSON contracts
+        run: |
+          python3 -m json.tool schemas/jaywisdom/purposeful_white_house_replay.v0_1.schema.json >/dev/null
+          python3 -m json.tool fixtures/jaywisdom/fraud_ledger/PURPOSEFUL_WHITE_HOUSE_REPLAY_TEST_VECTORS_V0_1.json >/dev/null
+          python3 -m json.tool agents/purposeful_white_house/agent_contract.json >/dev/null
+      - name: Deterministic purpose replay
+        run: |
+          python3 tools/verify_purposeful_white_house_replay_v0_1.py \
+            fixtures/jaywisdom/fraud_ledger/PURPOSEFUL_WHITE_HOUSE_REPLAY_TEST_VECTORS_V0_1.json

--- a/agents/purposeful_white_house/agent_contract.json
+++ b/agents/purposeful_white_house/agent_contract.json
@@ -1,0 +1,42 @@
+{
+  "contract_id": "PURPOSEFUL_WHITE_HOUSE_AGENT_CONTRACT_V0_1",
+  "subject": "PRESIDENCY",
+  "purpose": "Neutral public-purpose evidence replay",
+  "mode": "READ_ONLY_ANALYSIS",
+  "semantic_type": "BOUNDED_PUBLIC_PURPOSE_EVIDENCE_DISPOSITION",
+  "allowed": [
+    "extract source-bound claims",
+    "map constitutional and statutory authority references",
+    "map appropriations and resource references",
+    "compare declared purpose to observable result",
+    "classify evidence state as REJECTED, CONFLICT, GAP, HOLD, or REPLAYABLE",
+    "produce educational replay explanations"
+  ],
+  "forbidden": [
+    "score a president",
+    "score a political party",
+    "designate hero or villain",
+    "invent legal authority",
+    "create authorization",
+    "create a legal conclusion",
+    "create guilt or innocence findings",
+    "treat a White House statement as self-authenticating proof",
+    "treat REPLAYABLE as proof of lawfulness, wisdom, success, innocence, or guilt",
+    "execute consequential external actions without separate human authorization"
+  ],
+  "required_membranes": [
+    "PRESIDENT != COUNTRY",
+    "WHITE_HOUSE != GOVERNMENT",
+    "EXECUTIVE != CONGRESS",
+    "COMMAND != OWNERSHIP",
+    "ELECTION != UNLIMITED_AUTHORITY",
+    "DECLARED_PURPOSE != OBSERVED_RESULT",
+    "REPLAYABLE != LEGAL_CONCLUSION"
+  ],
+  "party_score": null,
+  "president_score": null,
+  "public_purpose_audit": true,
+  "authority_created": false,
+  "consequential_action_requires_human_authorization": true,
+  "human_authorization_present": false
+}

--- a/docs/jaywisdom/PURPOSEFUL_WHITE_HOUSE_DOUBLE_REVERSE_ONION_V0_1.md
+++ b/docs/jaywisdom/PURPOSEFUL_WHITE_HOUSE_DOUBLE_REVERSE_ONION_V0_1.md
@@ -1,0 +1,147 @@
+# PURPOSEFUL WHITE HOUSE — DOUBLE REVERSE ONION v0.1
+
+## Purpose
+
+Audit the Presidency as an office, not as a personality contest.
+
+```text
+THE PRESIDENCY
+↓
+WHY DOES THIS OFFICE EXIST?
+↓
+WHAT AUTHORITY WAS GRANTED?
+↓
+WHAT PURPOSE WAS THAT AUTHORITY FOR?
+↓
+WHAT ACTION OCCURRED?
+↓
+WHAT PUBLIC VALUE RESULTED?
+↓
+CAN THE PEOPLE REPLAY IT?
+```
+
+Presidents are test vectors, not the architecture.
+
+```text
+PRESIDENT != COUNTRY
+WHITE_HOUSE != GOVERNMENT
+EXECUTIVE != CONGRESS
+COMMAND != OWNERSHIP
+ELECTION != UNLIMITED_AUTHORITY
+PARTY_SCORE = NONE
+PRESIDENT_SCORE = NONE
+PUBLIC_PURPOSE_AUDIT = TRUE
+AUTHORITY_CREATED = FALSE
+```
+
+## Onion One — Constitutional Purpose
+
+Source-bound constitutional anchors:
+
+- Constitution Preamble: public-purpose framing; not an independent grant of presidential power.
+- Article I §1: legislative power is vested in Congress.
+- Article I §9 cl. 7: Treasury withdrawals require appropriations made by law; receipts/expenditures are to be publicly accounted for.
+- Article II §1: executive power is vested in the President; the oath binds execution of the office to preserving, protecting, and defending the Constitution.
+- Article II §2: Commander-in-Chief authority; pardons; treaties and principal appointments with Senate advice/consent.
+- Article II §3: State of the Union information/recommendations; receive ambassadors; Take Care that the laws be faithfully executed; commission officers.
+- Article II §4: impeachment/removal boundary.
+- 20th Amendment §1: presidential terms end and successors' terms begin at a fixed constitutional transition point.
+
+Official anchors:
+- https://www.archives.gov/founding-docs/constitution-transcript
+- https://www.archives.gov/founding-docs/amendments-11-27
+
+`PEACEFUL_TRANSFER` is modeled as a continuity/public-service invariant supported by constitutional transition rules; it is not invented as a freestanding Article II power.
+
+## Onion Two — Public Purpose
+
+Every action uses the same neutral forward trace:
+
+```text
+PUBLIC_NEED
+↓
+LEGAL_AUTHORITY
+↓
+DECLARED_PURPOSE
+↓
+RESOURCES
+↓
+EXECUTION
+↓
+MEASURABLE_RESULT
+↓
+PUBLIC_RECEIPT
+↓
+CORRECTION_OR_APPEAL
+```
+
+Then replay backward:
+
+```text
+RESULT
+↑
+ACTION
+↑
+RESOURCE
+↑
+AUTHORIZATION
+↑
+LAW
+↑
+CONSTITUTIONAL_PURPOSE
+```
+
+## Dispositions
+
+```text
+REJECTED   malformed or personality/authority boundary violated
+CONFLICT   source-bound claims materially contradict
+GAP        required edge is missing or reverse trace breaks
+HOLD       claim exists but is not adequately source-bound
+REPLAYABLE complete source-bound trace with no unresolved contradiction
+```
+
+Deterministic precedence:
+
+`REJECTED > CONFLICT > GAP > HOLD > REPLAYABLE`
+
+`REPLAYABLE` means the evidence trail can be reproduced. It does **not** mean lawful, wise, successful, constitutional, innocent, guilty, good, or bad.
+
+## Positive Audit Education
+
+Positive means the experiment actively searches for reproducible public value and correction, not praise.
+
+Questions:
+
+- What worked?
+- What was source-bound to lawful authority?
+- What was transparent?
+- What was measurable?
+- What was corrected?
+- What survived a change of office-holder?
+- What served the public?
+- What purpose was declared?
+- What actually happened?
+
+The last two questions are intentionally distinct:
+
+`DECLARED_PURPOSE != OBSERVED_RESULT`
+
+## Gray Baby question
+
+Can a six-year-old follow authority, money, action, result, receipt, and correction without being told whom to trust?
+
+## Machine law
+
+```text
+PURPOSEFUL_WHITE_HOUSE
+=
+CONSTITUTION
+× PUBLIC_SERVICE
+× EVIDENCE
+× ACCOUNTABILITY
+× CONTINUITY
+× CORRECTION
+```
+
+The office stays. The human changes. The evidence path must remain replayable.

--- a/fixtures/jaywisdom/fraud_ledger/PURPOSEFUL_WHITE_HOUSE_REPLAY_TEST_VECTORS_V0_1.json
+++ b/fixtures/jaywisdom/fraud_ledger/PURPOSEFUL_WHITE_HOUSE_REPLAY_TEST_VECTORS_V0_1.json
@@ -1,0 +1,120 @@
+{
+  "suite": "PURPOSEFUL_WHITE_HOUSE_REPLAY_TEST_VECTORS_V0_1",
+  "semantic_type": "BOUNDED_PUBLIC_PURPOSE_EVIDENCE_DISPOSITION",
+  "vectors": [
+    {
+      "id": "T01_COMPLETE_TRACE",
+      "expected": "REPLAYABLE",
+      "record": {
+        "subject": "PRESIDENCY",
+        "public_purpose_audit": true,
+        "authority_created": false,
+        "party_score": null,
+        "president_score": null,
+        "reverse_trace_complete": true,
+        "forward_trace": {
+          "public_need": {"status": "SOURCE_BOUND", "source_refs": ["SRC-NEED"]},
+          "legal_authority": {"status": "SOURCE_BOUND", "source_refs": ["SRC-LAW"]},
+          "declared_purpose": {"status": "SOURCE_BOUND", "source_refs": ["SRC-PURPOSE"]},
+          "resources": {"status": "SOURCE_BOUND", "source_refs": ["SRC-RESOURCE"]},
+          "execution": {"status": "SOURCE_BOUND", "source_refs": ["SRC-ACTION"]},
+          "measurable_result": {"status": "SOURCE_BOUND", "source_refs": ["SRC-RESULT"]},
+          "public_receipt": {"status": "SOURCE_BOUND", "source_refs": ["SRC-RECEIPT"]},
+          "correction_or_appeal": {"status": "NOT_REQUIRED", "note": "No correction event asserted."}
+        }
+      }
+    },
+    {
+      "id": "T02_MISSING_AUTHORITY_EDGE",
+      "expected": "GAP",
+      "record": {
+        "subject": "PRESIDENCY", "public_purpose_audit": true, "authority_created": false,
+        "party_score": null, "president_score": null, "reverse_trace_complete": true,
+        "forward_trace": {
+          "public_need": {"status": "SOURCE_BOUND"},
+          "declared_purpose": {"status": "SOURCE_BOUND"},
+          "resources": {"status": "SOURCE_BOUND"},
+          "execution": {"status": "SOURCE_BOUND"},
+          "measurable_result": {"status": "SOURCE_BOUND"},
+          "public_receipt": {"status": "SOURCE_BOUND"},
+          "correction_or_appeal": {"status": "NOT_REQUIRED"}
+        }
+      }
+    },
+    {
+      "id": "T03_CONTRADICTION",
+      "expected": "CONFLICT",
+      "record": {
+        "subject": "PRESIDENCY", "public_purpose_audit": true, "authority_created": false,
+        "party_score": null, "president_score": null, "reverse_trace_complete": true,
+        "forward_trace": {
+          "public_need": {"status": "SOURCE_BOUND"}, "legal_authority": {"status": "SOURCE_BOUND"},
+          "declared_purpose": {"status": "CONFLICT"}, "resources": {"status": "SOURCE_BOUND"},
+          "execution": {"status": "SOURCE_BOUND"}, "measurable_result": {"status": "SOURCE_BOUND"},
+          "public_receipt": {"status": "SOURCE_BOUND"}, "correction_or_appeal": {"status": "NOT_REQUIRED"}
+        }
+      }
+    },
+    {
+      "id": "T04_UNSUPPORTED_RESULT",
+      "expected": "HOLD",
+      "record": {
+        "subject": "PRESIDENCY", "public_purpose_audit": true, "authority_created": false,
+        "party_score": null, "president_score": null, "reverse_trace_complete": true,
+        "forward_trace": {
+          "public_need": {"status": "SOURCE_BOUND"}, "legal_authority": {"status": "SOURCE_BOUND"},
+          "declared_purpose": {"status": "SOURCE_BOUND"}, "resources": {"status": "SOURCE_BOUND"},
+          "execution": {"status": "SOURCE_BOUND"}, "measurable_result": {"status": "HOLD"},
+          "public_receipt": {"status": "SOURCE_BOUND"}, "correction_or_appeal": {"status": "NOT_REQUIRED"}
+        }
+      }
+    },
+    {
+      "id": "T05_PARTY_SCORE_FORBIDDEN",
+      "expected": "REJECTED",
+      "record": {
+        "subject": "PRESIDENCY", "public_purpose_audit": true, "authority_created": false,
+        "party_score": 1, "president_score": null, "reverse_trace_complete": true, "forward_trace": {}
+      }
+    },
+    {
+      "id": "T06_PRESIDENT_SCORE_FORBIDDEN",
+      "expected": "REJECTED",
+      "record": {
+        "subject": "PRESIDENCY", "public_purpose_audit": true, "authority_created": false,
+        "party_score": null, "president_score": 1, "reverse_trace_complete": true, "forward_trace": {}
+      }
+    },
+    {
+      "id": "T07_AUTHORITY_CREATION_FORBIDDEN",
+      "expected": "REJECTED",
+      "record": {
+        "subject": "PRESIDENCY", "public_purpose_audit": true, "authority_created": true,
+        "party_score": null, "president_score": null, "reverse_trace_complete": true, "forward_trace": {}
+      }
+    },
+    {
+      "id": "T08_PERSONALITY_FIELD_FORBIDDEN",
+      "expected": "REJECTED",
+      "record": {
+        "subject": "PRESIDENCY", "public_purpose_audit": true, "authority_created": false,
+        "party_score": null, "president_score": null, "president_name": "TEST PERSON",
+        "reverse_trace_complete": true, "forward_trace": {}
+      }
+    },
+    {
+      "id": "T09_REVERSE_PATH_BREAK",
+      "expected": "GAP",
+      "record": {
+        "subject": "PRESIDENCY", "public_purpose_audit": true, "authority_created": false,
+        "party_score": null, "president_score": null, "reverse_trace_complete": false,
+        "forward_trace": {
+          "public_need": {"status": "SOURCE_BOUND"}, "legal_authority": {"status": "SOURCE_BOUND"},
+          "declared_purpose": {"status": "SOURCE_BOUND"}, "resources": {"status": "SOURCE_BOUND"},
+          "execution": {"status": "SOURCE_BOUND"}, "measurable_result": {"status": "SOURCE_BOUND"},
+          "public_receipt": {"status": "SOURCE_BOUND"}, "correction_or_appeal": {"status": "NOT_REQUIRED"}
+        }
+      }
+    }
+  ]
+}

--- a/schemas/jaywisdom/purposeful_white_house_replay.v0_1.schema.json
+++ b/schemas/jaywisdom/purposeful_white_house_replay.v0_1.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jsonwisdom.example/schemas/purposeful_white_house_replay.v0_1.schema.json",
+  "title": "Purposeful White House Replay v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "subject",
+    "public_purpose_audit",
+    "authority_created",
+    "party_score",
+    "president_score",
+    "forward_trace",
+    "reverse_trace_complete"
+  ],
+  "properties": {
+    "subject": {"const": "PRESIDENCY"},
+    "public_purpose_audit": {"const": true},
+    "authority_created": {"const": false},
+    "party_score": {"type": "null"},
+    "president_score": {"type": "null"},
+    "test_vector_id": {"type": ["string", "null"]},
+    "forward_trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "public_need": {"$ref": "#/$defs/edge"},
+        "legal_authority": {"$ref": "#/$defs/edge"},
+        "declared_purpose": {"$ref": "#/$defs/edge"},
+        "resources": {"$ref": "#/$defs/edge"},
+        "execution": {"$ref": "#/$defs/edge"},
+        "measurable_result": {"$ref": "#/$defs/edge"},
+        "public_receipt": {"$ref": "#/$defs/edge"},
+        "correction_or_appeal": {"$ref": "#/$defs/edge"}
+      }
+    },
+    "reverse_trace_complete": {"type": "boolean"}
+  },
+  "$defs": {
+    "edge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "enum": ["SOURCE_BOUND", "HOLD", "GAP", "CONFLICT", "NOT_REQUIRED"]
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        },
+        "note": {"type": "string"}
+      }
+    }
+  }
+}

--- a/tools/verify_purposeful_white_house_replay_v0_1.py
+++ b/tools/verify_purposeful_white_house_replay_v0_1.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_EDGES = [
+    "public_need",
+    "legal_authority",
+    "declared_purpose",
+    "resources",
+    "execution",
+    "measurable_result",
+    "public_receipt",
+    "correction_or_appeal",
+]
+
+FORBIDDEN_KEYS = {
+    "president_name",
+    "political_party",
+    "candidate_score",
+    "personality_score",
+    "approval_score",
+    "hero",
+    "villain",
+}
+
+
+def contains_forbidden_key(value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in FORBIDDEN_KEYS:
+                return True
+            if contains_forbidden_key(child):
+                return True
+    elif isinstance(value, list):
+        return any(contains_forbidden_key(v) for v in value)
+    return False
+
+
+def classify(record):
+    if not isinstance(record, dict):
+        return "REJECTED"
+    if record.get("subject") != "PRESIDENCY":
+        return "REJECTED"
+    if record.get("public_purpose_audit") is not True:
+        return "REJECTED"
+    if record.get("authority_created") is not False:
+        return "REJECTED"
+    if record.get("party_score") is not None:
+        return "REJECTED"
+    if record.get("president_score") is not None:
+        return "REJECTED"
+    if contains_forbidden_key(record):
+        return "REJECTED"
+
+    trace = record.get("forward_trace")
+    if not isinstance(trace, dict):
+        return "GAP"
+
+    if any(edge not in trace for edge in REQUIRED_EDGES):
+        return "GAP"
+
+    statuses = []
+    for edge in REQUIRED_EDGES:
+        payload = trace.get(edge)
+        if not isinstance(payload, dict):
+            return "GAP"
+        statuses.append(payload.get("status"))
+
+    # Deterministic precedence after envelope validation.
+    if "CONFLICT" in statuses:
+        return "CONFLICT"
+    if "GAP" in statuses:
+        return "GAP"
+    if record.get("reverse_trace_complete") is not True:
+        return "GAP"
+    if "HOLD" in statuses:
+        return "HOLD"
+
+    allowed_complete = {"SOURCE_BOUND", "NOT_REQUIRED"}
+    if all(status in allowed_complete for status in statuses):
+        return "REPLAYABLE"
+
+    return "REJECTED"
+
+
+def main(path):
+    suite = json.loads(Path(path).read_text(encoding="utf-8"))
+    vectors = suite.get("vectors", [])
+    failures = []
+
+    for vector in vectors:
+        actual = classify(vector.get("record"))
+        expected = vector.get("expected")
+        ok = actual == expected
+        print(f"{vector.get('id')}: expected={expected} actual={actual} {'PASS' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(vector.get("id"))
+
+    print(f"TOTAL={len(vectors)} PASS={len(vectors) - len(failures)} FAIL={len(failures)}")
+    print("party_score_none_enforced=true")
+    print("president_score_none_enforced=true")
+    print("authority_created_false_enforced=true")
+    print("semantic_type=BOUNDED_PUBLIC_PURPOSE_EVIDENCE_DISPOSITION")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    fixture = sys.argv[1] if len(sys.argv) > 1 else "fixtures/jaywisdom/fraud_ledger/PURPOSEFUL_WHITE_HOUSE_REPLAY_TEST_VECTORS_V0_1.json"
+    raise SystemExit(main(fixture))


### PR DESCRIPTION
## Purpose

Replays the Presidency by institutional purpose rather than president, party, personality, or news cycle.

## Package

- constitutional-purpose doctrine with official National Archives anchors
- neutral forward/reverse public-purpose trace
- fail-closed schema
- 9 synthetic test vectors
- deterministic standard-library verifier
- exact package CI workflow
- bounded AI agent contract

## Core membranes

```text
PRESIDENT != COUNTRY
WHITE_HOUSE != GOVERNMENT
EXECUTIVE != CONGRESS
COMMAND != OWNERSHIP
ELECTION != UNLIMITED_AUTHORITY
DECLARED_PURPOSE != OBSERVED_RESULT
REPLAYABLE != LEGAL_CONCLUSION
```

## Dispositions

```text
REJECTED > CONFLICT > GAP > HOLD > REPLAYABLE
```

`REPLAYABLE` means the evidence path is reproducible; it does not establish lawfulness, wisdom, success, innocence, guilt, praise, or blame.

## Neutrality

```text
party_score = null
president_score = null
public_purpose_audit = true
authority_created = false
```

This is a stacked draft based on PR #488 head `bb484d0f10f4311abb39173e13599e00189f84b8`. It does not modify or merge PR #488.