### PR TITLE
Add Congressional Quantum Gambit live receipt 001 — H.R. 7152

### DIFF
--- a/.github/workflows/congressional-quantum-gambit-live-001.yml
+++ b/.github/workflows/congressional-quantum-gambit-live-001.yml
@@ -1,0 +1,72 @@
+name: Congressional Quantum Gambit Live 001
+
+on:
+  pull_request:
+    paths:
+      - 'docs/jaywisdom/CONGRESSIONAL_QUANTUM_GAMBIT_LIVE_001_HR7152.md'
+      - 'fixtures/jaywisdom/fraud_ledger/CONGRESSIONAL_QUANTUM_GAMBIT_LIVE_001_HR7152.json'
+      - '.github/workflows/congressional-quantum-gambit-live-001.yml'
+  push:
+    paths:
+      - 'docs/jaywisdom/CONGRESSIONAL_QUANTUM_GAMBIT_LIVE_001_HR7152.md'
+      - 'fixtures/jaywisdom/fraud_ledger/CONGRESSIONAL_QUANTUM_GAMBIT_LIVE_001_HR7152.json'
+      - '.github/workflows/congressional-quantum-gambit-live-001.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate live receipt
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          p = Path('fixtures/jaywisdom/fraud_ledger/CONGRESSIONAL_QUANTUM_GAMBIT_LIVE_001_HR7152.json')
+          x = json.loads(p.read_text())
+
+          assert x['claim_scope'] == 'HOUSE_PASSAGE_ONLY'
+          assert x['observer_result'] == 'REPLAYABLE'
+          assert x['states']['house_passage_date'] == '1964-02-10'
+          assert x['states']['house_vote_yea'] == 290
+          assert x['states']['house_vote_nay'] == 130
+          assert x['dice'] == {
+              'source': 'PASS',
+              'authority': 'PASS',
+              'claim': 'PASS',
+              'money': 'NOT_REQUIRED',
+              'time': 'PASS',
+              'replay': 'PASS'
+          }
+
+          b = x['boxd']
+          assert b['manifest_state'] == 'CANDIDATE_ONLY'
+          assert b['source_urls_bound'] is True
+          assert b['source_bytes_fetched_and_frozen'] is False
+          assert b['source_digest_recomputed'] is False
+          assert b['source_byte_authentication'] == 'NOT_PERFORMED'
+
+          assert x['facts_promoted'] == 0
+          assert x['edges_inferred'] == 0
+          assert x['silent_inference'] == 'BLOCKED'
+          assert x['authority_created'] is False
+
+          required = {
+              'PASSED_HOUSE != LAW',
+              'HOUSE_PASSAGE != SENATE_PASSAGE',
+              'HOUSE_PASSAGE != ENACTMENT',
+              'SOURCE_BOUND_PUBLIC_RECORD != BOXD_BYTES_PROVEN',
+              'REPLAYABLE != LEGAL_CONCLUSION'
+          }
+          assert required.issubset(set(x['membranes']))
+
+          print('LIVE_001_HR7152=PASS')
+          print('CLAIM_SCOPE=HOUSE_PASSAGE_ONLY')
+          print('HOUSE_VOTE=290-130')
+          print('BOXD_BYTES_PROVEN=false')
+          print('AUTHORITY_CREATED=false')
+          PY

--- a/docs/jaywisdom/CONGRESSIONAL_QUANTUM_GAMBIT_LIVE_001_HR7152.md
+++ b/docs/jaywisdom/CONGRESSIONAL_QUANTUM_GAMBIT_LIVE_001_HR7152.md
@@ -1,0 +1,69 @@
+# Congressional Quantum Gambit — Live Receipt 001 — H.R. 7152
+
+Observer: `jaywisdom.base.eth`
+
+## Claim under test
+
+The U.S. House of Representatives passed H.R. 7152 — the Civil Rights Act of 1964 — on 1964-02-10 by a recorded vote of 290–130.
+
+## Six-Dice Receipt
+
+| Die | Element | Result |
+|---|---|---|
+| 1 | SOURCE | PASS |
+| 2 | AUTHORITY | PASS |
+| 3 | CLAIM | PASS |
+| 4 | MONEY | NOT_REQUIRED |
+| 5 | TIME | PASS |
+| 6 | REPLAY | PASS |
+
+## Official source convergence
+
+- National Archives, House Roll Call 32: February 10, 1964; H.R. 7152 passed 290 to 130.
+- National Archives engrossed-copy feature: final House-passed text; 290 in favor to 130 against on February 10, 1964.
+- U.S. House History, Art & Archives / Office of the Clerk: February 10, 1964; final tally 290 to 130.
+- Congress.gov actions overview: House passage 1964-02-10; Senate passage 1964-06-19; Public Law 88-352 on 1964-07-02.
+
+## Scoped disposition
+
+```text
+OBSERVER_RESULT = REPLAYABLE
+SEMANTIC_TYPE = BOUNDED_CONGRESSIONAL_EVIDENCE_GATE_DISPOSITION
+CLAIM_SCOPE = HOUSE_PASSAGE_ONLY
+HOUSE_PASSAGE_DATE = 1964-02-10
+HOUSE_VOTE = 290-130
+```
+
+## Constitutional / legislative membranes
+
+```text
+PASSED_HOUSE != LAW
+HOUSE_PASSAGE != SENATE_PASSAGE
+HOUSE_PASSAGE != ENACTMENT
+REPLAYABLE != LEGAL_CONCLUSION
+```
+
+The claim under test is House passage only. The later Senate-passage and enactment states are separately recorded only to prevent state collapse.
+
+## BoxD boundary
+
+This receipt binds source URLs but does not claim that source bytes have been frozen or authenticated.
+
+```text
+BOXD_MANIFEST = CANDIDATE_ONLY
+SOURCE_URLS_BOUND = TRUE
+SOURCE_BYTES_FETCHED_AND_FROZEN = FALSE
+SOURCE_DIGEST_RECOMPUTED = FALSE
+SOURCE_BYTE_AUTHENTICATION = NOT_PERFORMED
+
+SOURCE_BOUND_PUBLIC_RECORD != BOXD_BYTES_PROVEN
+```
+
+## Mechanical close
+
+```text
+facts_promoted = 0
+edges_inferred = 0
+silent_inference = BLOCKED
+authority_created = false
+```

--- a/fixtures/jaywisdom/fraud_ledger/CONGRESSIONAL_QUANTUM_GAMBIT_LIVE_001_HR7152.json
+++ b/fixtures/jaywisdom/fraud_ledger/CONGRESSIONAL_QUANTUM_GAMBIT_LIVE_001_HR7152.json
@@ -1,0 +1,64 @@
+{
+  "receipt_id": "CONGRESSIONAL_QUANTUM_GAMBIT_LIVE_001_HR7152",
+  "observer": "jaywisdom.base.eth",
+  "claim": "The U.S. House of Representatives passed H.R. 7152 — the Civil Rights Act of 1964 — on 1964-02-10 by a recorded vote of 290–130.",
+  "claim_scope": "HOUSE_PASSAGE_ONLY",
+  "semantic_type": "BOUNDED_CONGRESSIONAL_EVIDENCE_GATE_DISPOSITION",
+  "observer_result": "REPLAYABLE",
+  "dice": {
+    "source": "PASS",
+    "authority": "PASS",
+    "claim": "PASS",
+    "money": "NOT_REQUIRED",
+    "time": "PASS",
+    "replay": "PASS"
+  },
+  "official_sources": [
+    {
+      "source_class": "NATIONAL_ARCHIVES_HOUSE_RECORD",
+      "url": "https://www.archives.gov/exhibits/treasures_of_congress/Images/page_24/72a.html",
+      "supports": ["HOUSE_PASSAGE_DATE", "HOUSE_VOTE"]
+    },
+    {
+      "source_class": "NATIONAL_ARCHIVES_ENGROSSED_COPY_FEATURE",
+      "url": "https://www.archives.gov/legislative/features/civil-rights-1964/hr7152-engrossed-copy.html",
+      "supports": ["HOUSE_PASSAGE_DATE", "HOUSE_VOTE"]
+    },
+    {
+      "source_class": "HOUSE_HISTORY_ART_ARCHIVES_CLERK_RECORD",
+      "url": "https://history.house.gov/HouseRecord/Detail/25769811476",
+      "supports": ["HOUSE_PASSAGE_DATE", "HOUSE_VOTE"]
+    },
+    {
+      "source_class": "CONGRESS_GOV_ACTIONS_OVERVIEW",
+      "url": "https://www.congress.gov/bill/88th-congress/house-bill/7152/all-actions",
+      "supports": ["HOUSE_PASSAGE_DATE", "LATER_SENATE_PASSAGE", "LATER_ENACTMENT"]
+    }
+  ],
+  "states": {
+    "house_passage_date": "1964-02-10",
+    "house_vote_yea": 290,
+    "house_vote_nay": 130,
+    "senate_passage_date": "1964-06-19",
+    "enactment_date": "1964-07-02",
+    "public_law_number": "88-352"
+  },
+  "membranes": [
+    "PASSED_HOUSE != LAW",
+    "HOUSE_PASSAGE != SENATE_PASSAGE",
+    "HOUSE_PASSAGE != ENACTMENT",
+    "SOURCE_BOUND_PUBLIC_RECORD != BOXD_BYTES_PROVEN",
+    "REPLAYABLE != LEGAL_CONCLUSION"
+  ],
+  "boxd": {
+    "manifest_state": "CANDIDATE_ONLY",
+    "source_urls_bound": true,
+    "source_bytes_fetched_and_frozen": false,
+    "source_digest_recomputed": false,
+    "source_byte_authentication": "NOT_PERFORMED"
+  },
+  "facts_promoted": 0,
+  "edges_inferred": 0,
+  "silent_inference": "BLOCKED",
+  "authority_created": false
+}


### PR DESCRIPTION
## Purpose

Adds the first live Congressional Quantum Gambit receipt for a narrowly scoped historical claim: House passage of H.R. 7152 on 1964-02-10 by 290–130.

## Verified public-source convergence

- National Archives House roll-call record
- National Archives engrossed-copy feature
- U.S. House History, Art & Archives / Office of the Clerk
- Congress.gov action chronology

## Scope membrane

```text
CLAIM_SCOPE = HOUSE_PASSAGE_ONLY
PASSED_HOUSE != LAW
HOUSE_PASSAGE != SENATE_PASSAGE
HOUSE_PASSAGE != ENACTMENT
REPLAYABLE != LEGAL_CONCLUSION
```

## BoxD membrane

```text
BOXD_MANIFEST = CANDIDATE_ONLY
SOURCE_URLS_BOUND = TRUE
SOURCE_BYTES_FETCHED_AND_FROZEN = FALSE
SOURCE_DIGEST_RECOMPUTED = FALSE
SOURCE_BYTE_AUTHENTICATION = NOT_PERFORMED
SOURCE_BOUND_PUBLIC_RECORD != BOXD_BYTES_PROVEN
```

The receipt therefore verifies the public historical claim while refusing to claim byte-level BoxD provenance that was not performed.

This is stacked on PR #488 exact head `bb484d0f10f4311abb39173e13599e00189f84b8` and does not modify PR #488.