### PR TITLE
Enterprise Receipt API v0.2 — Authorized Attestation + Negative Test Pack v2

### DIFF
--- a/.github/workflows/enterprise-receipt-api-v0-2.yml
+++ b/.github/workflows/enterprise-receipt-api-v0-2.yml
@@ -17,8 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      EXACT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact checkout
+        run: test "$(git rev-parse HEAD)" = "$EXACT_HEAD_SHA"
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -38,7 +44,7 @@ jobs:
 
           receipt = {
               "format": "ENTERPRISE_RECEIPT_API_V0_2_CI_RECEIPT",
-              "git_sha": os.environ["GITHUB_SHA"],
+              "git_sha": os.environ["EXACT_HEAD_SHA"],
               "negative_test_pack": "v2",
               "test_count": 22,
               "test_result": "PASS",

--- a/.github/workflows/enterprise-receipt-api-v0-2.yml
+++ b/.github/workflows/enterprise-receipt-api-v0-2.yml
@@ -1,0 +1,59 @@
+name: Enterprise Receipt API v0.2
+
+on:
+  pull_request:
+    paths:
+      - 'jayspace-replay-sdk/enterprise/v0_2/**'
+      - '.github/workflows/enterprise-receipt-api-v0-2.yml'
+  push:
+    branches:
+      - product/enterprise-receipt-api-v0-2-negative-tests
+    paths:
+      - 'jayspace-replay-sdk/enterprise/v0_2/**'
+      - '.github/workflows/enterprise-receipt-api-v0-2.yml'
+
+jobs:
+  authorized-attestation-negative-pack:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install pinned crypto and JCS dependencies
+        run: python -m pip install -r jayspace-replay-sdk/enterprise/v0_2/requirements-ci.txt
+      - name: Run Negative Test Pack v2
+        run: |
+          python -m unittest discover \
+            -s jayspace-replay-sdk/enterprise/v0_2/tests \
+            -p 'test_*.py' -v
+      - name: Build CI receipt
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          receipt = {
+              "format": "ENTERPRISE_RECEIPT_API_V0_2_CI_RECEIPT",
+              "git_sha": os.environ["GITHUB_SHA"],
+              "negative_test_pack": "v2",
+              "test_count": 22,
+              "test_result": "PASS",
+              "cryptography_dependency": "49.0.0",
+              "jcs_dependency": "rfc8785==0.1.3",
+              "model_required": False,
+              "model_execution_performed": False,
+              "api_key_required": False,
+              "authority_created": False,
+          }
+          path = Path('/tmp/enterprise-receipt-api-v0-2-ci-receipt.json')
+          path.write_text(json.dumps(receipt, sort_keys=True, indent=2) + '\n', encoding='utf-8')
+          print(path.read_text(encoding='utf-8'))
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: enterprise-receipt-api-v0-2-ci-receipt
+          path: /tmp/enterprise-receipt-api-v0-2-ci-receipt.json

--- a/jayspace-replay-sdk/enterprise/v0_2/README.md
+++ b/jayspace-replay-sdk/enterprise/v0_2/README.md
@@ -1,0 +1,119 @@
+# Enterprise Receipt API v0.2 — Authorized Attestation + Negative Test Pack v2
+
+This layer extends `JAYSPACE_REPLAY_SDK_v0.1` with an append-only Ed25519 key lifecycle, tenant-scoped authorization, historical verification, and adversarial verification vectors.
+
+## Trust-chain invariant
+
+```text
+VALID_SIGNATURE != AUTHORIZED_SIGNATURE
+```
+
+A mathematically valid Ed25519 signature is an authorized attestation only when all policy gates are satisfied at the signing event time:
+
+```text
+SIGNATURE_VALID
+AND KEY_FINGERPRINT_MATCH
+AND KEY_ID_REGISTERED
+AND TENANT_MATCH
+AND SIGNER_ROLE_ALLOWED
+AND KEY_ACTIVE_AT_SIGNING_EVENT
+AND KEY_NOT_REVOKED_FOR_EVENT_SCOPE
+= VALID_ATTESTATION
+```
+
+## Key lifecycle
+
+Append-only event grammar:
+
+```text
+KEY_CREATED
+-> KEY_REGISTERED
+-> TENANT_BOUND
+-> ROLE_GRANTED
+-> ACTIVE
+-> SIGN
+-> ROTATED | SUSPENDED | REVOKED | EXPIRED
+```
+
+Lifecycle events do not rewrite prior receipts. Historical verification replays key state at `signed_at`.
+
+## Three identities
+
+```text
+RECEIPT_ID
+= sha256(JCS(receipt_payload))
+
+SIGNING_EVENT_ID
+= sha256(JCS({receipt_id,key_id,signed_at,signature}))
+
+KEY_EVENT_ID
+= sha256(JCS(key_event_payload))
+```
+
+`SIGNING_EVENT_ID` intentionally uses a canonical structured object rather than raw string concatenation. This removes delimiter/encoding ambiguity while preserving the intended identity of the signing act.
+
+## Signature input
+
+v0.2 signs the raw 32-byte SHA-256 digest represented by `receipt_id`.
+
+```text
+receipt_bytes = JCS(receipt_payload)
+digest = SHA256(receipt_bytes)
+receipt_id = "sha256:" + hex(digest)
+signature = Ed25519.sign(digest)
+```
+
+The non-deterministic signing time belongs only to the signature attestation and never changes `receipt_id`.
+
+## Tenant key registry
+
+Each key record contains:
+
+- `key_id`
+- raw Ed25519 public key bytes encoded as Base64
+- public-key SHA-256 fingerprint
+- append-only lifecycle events
+
+Lifecycle events bind tenant, role, activation, rotation, suspension, revocation, or expiration. A key may not authorize another tenant's receipt.
+
+## Negative Test Pack v2
+
+The test pack attacks the trust chain directly:
+
+1. valid authorized signature
+2. altered receipt payload
+3. payload-hash mismatch
+4. wrong tenant
+5. unregistered key
+6. wrong signer role
+7. suspended key
+8. revoked key
+9. expired key
+10. forged receipt ID
+11. forged Ed25519 signature
+12. rotation: historical-valid / future-invalid
+13. public-key fingerprint mismatch
+14. ruleset drift changes receipt identity
+15. model-output promotion injected into deterministic receipt payload
+16. signing-event-ID mismatch
+17. same receipt signed at two valid times keeps one receipt identity but produces two signing-event identities
+18. key-event payload tampering
+19. historical validity before revocation
+20. historical validity before suspension
+21. historical validity before expiration
+22. registry fingerprint tampering
+
+## Cryptographic implementation boundary
+
+This repository does not implement Ed25519 or RFC 8785 itself. CI uses established libraries for Ed25519 verification and JCS canonicalization. Production deployments should apply their normal dependency-vetting, key-storage, HSM/KMS, access-control, backup, and incident-response requirements.
+
+## OpenAI boundary
+
+The optional OpenAI layer remains downstream of deterministic replay and authorization. Model output may explain an already-produced receipt but cannot become `receipt_payload`, create a disposition, register a key, grant a role, bind a tenant, or authorize a signature.
+
+```text
+MODEL_OUTPUT != RECEIPT
+MODEL_OUTPUT != KEY_EVENT
+MODEL_OUTPUT != AUTHORIZED_SIGNATURE
+AUTHORITY_CREATED = FALSE
+```

--- a/jayspace-replay-sdk/enterprise/v0_2/fixtures/NEGATIVE_TEST_PACK_V2.json
+++ b/jayspace-replay-sdk/enterprise/v0_2/fixtures/NEGATIVE_TEST_PACK_V2.json
@@ -1,0 +1,30 @@
+{
+  "format": "ENTERPRISE_RECEIPT_NEGATIVE_TEST_PACK_V2",
+  "test_count": 22,
+  "authority_created": false,
+  "model_required": false,
+  "vectors": [
+    {"id": "NTP2_01", "name": "VALID_AUTHORIZED_SIGNATURE", "expected": "PASS"},
+    {"id": "NTP2_02", "name": "ALTERED_RECEIPT_PAYLOAD", "expected": "REJECT", "signal": "RECEIPT_ID_MISMATCH"},
+    {"id": "NTP2_03", "name": "PAYLOAD_HASH_MISMATCH", "expected": "REJECT", "signal": "PAYLOAD_HASH_MISMATCH"},
+    {"id": "NTP2_04", "name": "TENANT_CROSSOVER", "expected": "REJECT", "signal": "TENANT_MISMATCH"},
+    {"id": "NTP2_05", "name": "UNREGISTERED_KEY", "expected": "REJECT", "signal": "KEY_ID_UNREGISTERED"},
+    {"id": "NTP2_06", "name": "SIGNER_ROLE_NOT_GRANTED", "expected": "REJECT", "signal": "SIGNER_ROLE_NOT_ALLOWED"},
+    {"id": "NTP2_07", "name": "SUSPENDED_KEY", "expected": "REJECT", "signal": "KEY_SUSPENDED_FOR_EVENT_SCOPE"},
+    {"id": "NTP2_08", "name": "REVOKED_KEY", "expected": "REJECT", "signal": "KEY_REVOKED_FOR_EVENT_SCOPE"},
+    {"id": "NTP2_09", "name": "EXPIRED_KEY", "expected": "REJECT", "signal": "KEY_EXPIRED_FOR_EVENT_SCOPE"},
+    {"id": "NTP2_10", "name": "FORGED_RECEIPT_ID", "expected": "REJECT", "signal": "RECEIPT_ID_MISMATCH"},
+    {"id": "NTP2_11", "name": "FORGED_ED25519_SIGNATURE", "expected": "REJECT", "signal": "SIGNATURE_INVALID"},
+    {"id": "NTP2_12", "name": "ROTATION_HISTORY", "expected": "HISTORICAL_PASS_FUTURE_REJECT"},
+    {"id": "NTP2_13", "name": "PUBLIC_KEY_FINGERPRINT_MISMATCH", "expected": "REJECT", "signal": "PUBLIC_KEY_FINGERPRINT_MISMATCH"},
+    {"id": "NTP2_14", "name": "RULESET_DRIFT", "expected": "RECEIPT_ID_CHANGES"},
+    {"id": "NTP2_15", "name": "MODEL_OUTPUT_PROMOTION", "expected": "REJECT", "signal": "RECEIPT_PAYLOAD_FIELDS_INVALID"},
+    {"id": "NTP2_16", "name": "SIGNING_EVENT_ID_MISMATCH", "expected": "REJECT", "signal": "SIGNING_EVENT_ID_MISMATCH"},
+    {"id": "NTP2_17", "name": "SAME_RECEIPT_MULTIPLE_SIGNING_EVENTS", "expected": "SAME_RECEIPT_ID_DIFFERENT_SIGNING_EVENT_ID"},
+    {"id": "NTP2_18", "name": "KEY_EVENT_TAMPERING", "expected": "REJECT", "signal_prefix": "KEY_EVENT_ID_MISMATCH:"},
+    {"id": "NTP2_19", "name": "REVOKED_KEY_HISTORICAL_VALIDITY", "expected": "PASS_BEFORE_REVOCATION"},
+    {"id": "NTP2_20", "name": "SUSPENDED_KEY_HISTORICAL_VALIDITY", "expected": "PASS_BEFORE_SUSPENSION"},
+    {"id": "NTP2_21", "name": "EXPIRED_KEY_HISTORICAL_VALIDITY", "expected": "PASS_BEFORE_EXPIRATION"},
+    {"id": "NTP2_22", "name": "REGISTRY_FINGERPRINT_TAMPERING", "expected": "REJECT", "signal": "REGISTRY_FINGERPRINT_MISMATCH"}
+  ]
+}

--- a/jayspace-replay-sdk/enterprise/v0_2/requirements-ci.txt
+++ b/jayspace-replay-sdk/enterprise/v0_2/requirements-ci.txt
@@ -1,0 +1,2 @@
+cryptography==49.0.0
+rfc8785==0.1.3

--- a/jayspace-replay-sdk/enterprise/v0_2/schemas/key_registry.schema.json
+++ b/jayspace-replay-sdk/enterprise/v0_2/schemas/key_registry.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://computerwisdom.example/schemas/tenant-key-registry-v0.2.json",
+  "title": "Tenant Key Registry v0.2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["registry_version", "keys"],
+  "properties": {
+    "registry_version": {"const": "v0.2"},
+    "keys": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key_id", "public_key_base64", "public_key_fingerprint", "events"],
+        "properties": {
+          "key_id": {"type": "string", "minLength": 1},
+          "public_key_base64": {"type": "string", "minLength": 1},
+          "public_key_fingerprint": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["key_event_id", "type", "at"],
+              "properties": {
+                "key_event_id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+                "type": {
+                  "enum": [
+                    "KEY_CREATED",
+                    "KEY_REGISTERED",
+                    "TENANT_BOUND",
+                    "ROLE_GRANTED",
+                    "ROLE_REVOKED",
+                    "ACTIVE",
+                    "SIGN",
+                    "ROTATED",
+                    "SUSPENDED",
+                    "REVOKED",
+                    "EXPIRED"
+                  ]
+                },
+                "at": {"type": "string", "format": "date-time"},
+                "tenant_id": {"type": "string"},
+                "role": {
+                  "enum": ["REPLAY_SERVICE", "TENANT_SERVICE", "AUDIT_SERVICE", "ROTATION_SERVICE"]
+                },
+                "metadata": {"type": "object"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/jayspace-replay-sdk/enterprise/v0_2/schemas/signature_bundle.schema.json
+++ b/jayspace-replay-sdk/enterprise/v0_2/schemas/signature_bundle.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://computerwisdom.example/schemas/signature-bundle-v0.2.json",
+  "title": "Receipt Signature Bundle v0.2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "algorithm",
+    "key_id",
+    "public_key_fingerprint",
+    "payload_hash",
+    "signature",
+    "signed_at",
+    "signer_role",
+    "signing_event_id"
+  ],
+  "properties": {
+    "algorithm": {"const": "Ed25519"},
+    "key_id": {"type": "string", "minLength": 1},
+    "public_key_fingerprint": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "payload_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "signature": {"type": "string", "minLength": 1},
+    "signed_at": {"type": "string", "format": "date-time"},
+    "signer_role": {
+      "enum": ["REPLAY_SERVICE", "TENANT_SERVICE", "AUDIT_SERVICE", "ROTATION_SERVICE"]
+    },
+    "signing_event_id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+  }
+}

--- a/jayspace-replay-sdk/enterprise/v0_2/schemas/signed_receipt.schema.json
+++ b/jayspace-replay-sdk/enterprise/v0_2/schemas/signed_receipt.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://computerwisdom.example/schemas/signed-receipt-v0.2.json",
+  "title": "Enterprise Signed Receipt v0.2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["case_id", "disposition", "receipt_payload", "receipt_id", "signature_bundle"],
+  "properties": {
+    "case_id": {"type": "string", "minLength": 1},
+    "disposition": {"enum": ["PASS", "HOLD", "CONFLICT", "REJECT"]},
+    "receipt_payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "request_hash",
+        "replay_graph_hash",
+        "evidence_hash",
+        "ruleset_hash",
+        "ruleset_version",
+        "disposition"
+      ],
+      "properties": {
+        "case_id": {"type": "string", "minLength": 1},
+        "request_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "replay_graph_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "evidence_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "ruleset_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "ruleset_version": {"type": "string", "minLength": 1},
+        "disposition": {"enum": ["PASS", "HOLD", "CONFLICT", "REJECT"]}
+      }
+    },
+    "receipt_id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "signature_bundle": {"$ref": "signature_bundle.schema.json"}
+  }
+}

--- a/jayspace-replay-sdk/enterprise/v0_2/src/attestation_verifier.py
+++ b/jayspace-replay-sdk/enterprise/v0_2/src/attestation_verifier.py
@@ -1,0 +1,288 @@
+"""Enterprise Receipt API v0.2 authorized-attestation verifier.
+
+This module verifies deterministic receipt identity, Ed25519 signature validity,
+and tenant/key authorization at the historical signing time.
+
+It deliberately does not create replay dispositions or institutional authority.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Set
+
+import rfc8785
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+ALGORITHM = "Ed25519"
+HASH_PREFIX = "sha256:"
+ALLOWED_RECEIPT_PAYLOAD_FIELDS: Set[str] = {
+    "case_id",
+    "request_hash",
+    "replay_graph_hash",
+    "evidence_hash",
+    "ruleset_hash",
+    "ruleset_version",
+    "disposition",
+}
+ALLOWED_DISPOSITIONS = {"PASS", "HOLD", "CONFLICT", "REJECT"}
+ALLOWED_SIGNER_ROLES = {
+    "REPLAY_SERVICE",
+    "TENANT_SERVICE",
+    "AUDIT_SERVICE",
+    "ROTATION_SERVICE",
+}
+
+
+def jcs(value: Any) -> bytes:
+    return rfc8785.dumps(value)
+
+
+def sha256_id(payload: bytes) -> str:
+    return HASH_PREFIX + hashlib.sha256(payload).hexdigest()
+
+
+def raw_digest_from_sha256_id(value: str) -> bytes:
+    if not isinstance(value, str) or not value.startswith(HASH_PREFIX):
+        raise ValueError("not a sha256 identifier")
+    hex_part = value[len(HASH_PREFIX):]
+    if len(hex_part) != 64:
+        raise ValueError("sha256 identifier must contain 32 bytes")
+    return bytes.fromhex(hex_part)
+
+
+def compute_receipt_id(receipt_payload: Dict[str, Any]) -> str:
+    return sha256_id(jcs(receipt_payload))
+
+
+def compute_public_key_fingerprint(public_key_raw: bytes) -> str:
+    return sha256_id(public_key_raw)
+
+
+def compute_key_event_id(event: Dict[str, Any]) -> str:
+    payload = {key: value for key, value in event.items() if key != "key_event_id"}
+    return sha256_id(jcs(payload))
+
+
+def compute_signing_event_id(
+    receipt_id: str,
+    key_id: str,
+    signed_at: str,
+    signature_b64: str,
+) -> str:
+    event_payload = {
+        "receipt_id": receipt_id,
+        "key_id": key_id,
+        "signed_at": signed_at,
+        "signature": signature_b64,
+    }
+    return sha256_id(jcs(event_payload))
+
+
+def parse_time(value: str) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError("timestamp must be a string")
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def key_state_at(key_record: Dict[str, Any], signed_at: str) -> Dict[str, Any]:
+    target = parse_time(signed_at)
+    registered = False
+    tenant_id = None
+    roles: Set[str] = set()
+    active = False
+    revoked = False
+    expired = False
+    suspended = False
+    rotated = False
+
+    events = sorted(key_record.get("events", []), key=lambda event: parse_time(event["at"]))
+    for event in events:
+        if parse_time(event["at"]) > target:
+            break
+        event_type = event.get("type")
+        if event_type == "KEY_REGISTERED":
+            registered = True
+        elif event_type == "TENANT_BOUND":
+            tenant_id = event.get("tenant_id")
+        elif event_type == "ROLE_GRANTED":
+            role = event.get("role")
+            if role:
+                roles.add(role)
+        elif event_type == "ROLE_REVOKED":
+            role = event.get("role")
+            if role:
+                roles.discard(role)
+        elif event_type == "ACTIVE":
+            active = True
+            suspended = False
+        elif event_type == "SUSPENDED":
+            active = False
+            suspended = True
+        elif event_type == "REVOKED":
+            active = False
+            revoked = True
+        elif event_type == "EXPIRED":
+            active = False
+            expired = True
+        elif event_type == "ROTATED":
+            active = False
+            rotated = True
+
+    return {
+        "registered": registered,
+        "tenant_id": tenant_id,
+        "roles": roles,
+        "active": active,
+        "revoked": revoked,
+        "expired": expired,
+        "suspended": suspended,
+        "rotated": rotated,
+    }
+
+
+def _append(signals: List[str], signal: str) -> None:
+    if signal not in signals:
+        signals.append(signal)
+
+
+def verify_signed_receipt(
+    signed_receipt: Dict[str, Any],
+    key_registry: Dict[str, Any],
+    expected_tenant_id: str,
+) -> Dict[str, Any]:
+    signals: List[str] = []
+
+    payload = signed_receipt.get("receipt_payload")
+    if not isinstance(payload, dict):
+        return {
+            "authorized_attestation": False,
+            "disposition": "REJECT",
+            "signals": ["RECEIPT_PAYLOAD_MISSING"],
+            "authority_created": False,
+        }
+
+    if set(payload.keys()) != ALLOWED_RECEIPT_PAYLOAD_FIELDS:
+        _append(signals, "RECEIPT_PAYLOAD_FIELDS_INVALID")
+
+    if payload.get("disposition") not in ALLOWED_DISPOSITIONS:
+        _append(signals, "RECEIPT_DISPOSITION_INVALID")
+
+    computed_receipt_id = compute_receipt_id(payload)
+    receipt_id = signed_receipt.get("receipt_id")
+    if receipt_id != computed_receipt_id:
+        _append(signals, "RECEIPT_ID_MISMATCH")
+
+    bundle = signed_receipt.get("signature_bundle")
+    if not isinstance(bundle, dict):
+        _append(signals, "SIGNATURE_BUNDLE_MISSING")
+        return {
+            "authorized_attestation": False,
+            "disposition": "REJECT",
+            "signals": signals,
+            "computed_receipt_id": computed_receipt_id,
+            "authority_created": False,
+        }
+
+    if bundle.get("algorithm") != ALGORITHM:
+        _append(signals, "ALGORITHM_NOT_ALLOWED")
+
+    if bundle.get("payload_hash") != computed_receipt_id:
+        _append(signals, "PAYLOAD_HASH_MISMATCH")
+
+    key_id = bundle.get("key_id")
+    key_record = key_registry.get("keys", {}).get(key_id)
+    if not key_record:
+        _append(signals, "KEY_ID_UNREGISTERED")
+        return {
+            "authorized_attestation": False,
+            "disposition": "REJECT",
+            "signals": signals,
+            "computed_receipt_id": computed_receipt_id,
+            "authority_created": False,
+        }
+
+    try:
+        signed_at = bundle["signed_at"]
+        state = key_state_at(key_record, signed_at)
+    except (KeyError, ValueError, TypeError):
+        _append(signals, "SIGNED_AT_INVALID")
+        return {
+            "authorized_attestation": False,
+            "disposition": "REJECT",
+            "signals": signals,
+            "computed_receipt_id": computed_receipt_id,
+            "authority_created": False,
+        }
+
+    for index, event in enumerate(key_record.get("events", [])):
+        if event.get("key_event_id") != compute_key_event_id(event):
+            _append(signals, f"KEY_EVENT_ID_MISMATCH:{index}")
+
+    if not state["registered"]:
+        _append(signals, "KEY_NOT_REGISTERED_AT_SIGNING_EVENT")
+
+    if state["tenant_id"] != expected_tenant_id:
+        _append(signals, "TENANT_MISMATCH")
+
+    signer_role = bundle.get("signer_role")
+    if signer_role not in ALLOWED_SIGNER_ROLES or signer_role not in state["roles"]:
+        _append(signals, "SIGNER_ROLE_NOT_ALLOWED")
+
+    if not state["active"]:
+        _append(signals, "KEY_NOT_ACTIVE_AT_SIGNING_EVENT")
+    if state["revoked"]:
+        _append(signals, "KEY_REVOKED_FOR_EVENT_SCOPE")
+    if state["expired"]:
+        _append(signals, "KEY_EXPIRED_FOR_EVENT_SCOPE")
+    if state["suspended"]:
+        _append(signals, "KEY_SUSPENDED_FOR_EVENT_SCOPE")
+    if state["rotated"]:
+        _append(signals, "KEY_ROTATED_FOR_EVENT_SCOPE")
+
+    try:
+        public_key_raw = base64.b64decode(key_record["public_key_base64"], validate=True)
+    except Exception:
+        public_key_raw = b""
+        _append(signals, "PUBLIC_KEY_ENCODING_INVALID")
+
+    computed_fingerprint = compute_public_key_fingerprint(public_key_raw)
+    if key_record.get("public_key_fingerprint") != computed_fingerprint:
+        _append(signals, "REGISTRY_FINGERPRINT_MISMATCH")
+    if bundle.get("public_key_fingerprint") != computed_fingerprint:
+        _append(signals, "PUBLIC_KEY_FINGERPRINT_MISMATCH")
+
+    signature_b64 = bundle.get("signature")
+    try:
+        signature = base64.b64decode(signature_b64, validate=True)
+        digest = raw_digest_from_sha256_id(computed_receipt_id)
+        public_key = Ed25519PublicKey.from_public_bytes(public_key_raw)
+        public_key.verify(signature, digest)
+    except (InvalidSignature, ValueError, TypeError):
+        _append(signals, "SIGNATURE_INVALID")
+
+    expected_signing_event_id = compute_signing_event_id(
+        computed_receipt_id,
+        str(key_id),
+        signed_at,
+        str(signature_b64),
+    )
+    if bundle.get("signing_event_id") != expected_signing_event_id:
+        _append(signals, "SIGNING_EVENT_ID_MISMATCH")
+
+    authorized = not signals
+    return {
+        "authorized_attestation": authorized,
+        "disposition": "PASS" if authorized else "REJECT",
+        "signals": signals,
+        "computed_receipt_id": computed_receipt_id,
+        "computed_signing_event_id": expected_signing_event_id,
+        "authority_created": False,
+    }

--- a/jayspace-replay-sdk/enterprise/v0_2/tests/test_negative_pack_v2.py
+++ b/jayspace-replay-sdk/enterprise/v0_2/tests/test_negative_pack_v2.py
@@ -1,0 +1,266 @@
+import base64
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from attestation_verifier import (  # noqa: E402
+    compute_key_event_id,
+    compute_public_key_fingerprint,
+    compute_receipt_id,
+    compute_signing_event_id,
+    raw_digest_from_sha256_id,
+    verify_signed_receipt,
+)
+
+
+def h(label: str) -> str:
+    import hashlib
+
+    return "sha256:" + hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def event(event_type, at, **extra):
+    value = {"type": event_type, "at": at, **extra}
+    value["key_event_id"] = compute_key_event_id(value)
+    return value
+
+
+def private_key(seed_byte: int) -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(bytes([seed_byte]) * 32)
+
+
+def key_record(key_id, key, tenant, role="REPLAY_SERVICE", terminal=None, terminal_at="2026-08-18T08:10:00Z"):
+    public_raw = key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    events = [
+        event("KEY_CREATED", "2026-08-18T08:00:00Z"),
+        event("KEY_REGISTERED", "2026-08-18T08:01:00Z"),
+        event("TENANT_BOUND", "2026-08-18T08:02:00Z", tenant_id=tenant),
+        event("ROLE_GRANTED", "2026-08-18T08:03:00Z", role=role),
+        event("ACTIVE", "2026-08-18T08:04:00Z"),
+    ]
+    if terminal:
+        events.append(event(terminal, terminal_at))
+    return {
+        "key_id": key_id,
+        "public_key_base64": base64.b64encode(public_raw).decode("ascii"),
+        "public_key_fingerprint": compute_public_key_fingerprint(public_raw),
+        "events": events,
+    }
+
+
+def payload(ruleset_version="v1.0.0", ruleset_hash=None):
+    return {
+        "case_id": "enterprise-case-001",
+        "request_hash": h("request"),
+        "replay_graph_hash": h("graph"),
+        "evidence_hash": h("evidence"),
+        "ruleset_hash": ruleset_hash or h("ruleset-v1"),
+        "ruleset_version": ruleset_version,
+        "disposition": "PASS",
+    }
+
+
+def sign_receipt(payload_value, key_id, key, registry, signed_at="2026-08-18T08:06:00Z", role="REPLAY_SERVICE"):
+    receipt_id = compute_receipt_id(payload_value)
+    signature = key.sign(raw_digest_from_sha256_id(receipt_id))
+    signature_b64 = base64.b64encode(signature).decode("ascii")
+    fingerprint = registry["keys"][key_id]["public_key_fingerprint"]
+    signing_event_id = compute_signing_event_id(receipt_id, key_id, signed_at, signature_b64)
+    return {
+        "case_id": payload_value["case_id"],
+        "disposition": payload_value["disposition"],
+        "receipt_payload": copy.deepcopy(payload_value),
+        "receipt_id": receipt_id,
+        "signature_bundle": {
+            "algorithm": "Ed25519",
+            "key_id": key_id,
+            "public_key_fingerprint": fingerprint,
+            "payload_hash": receipt_id,
+            "signature": signature_b64,
+            "signed_at": signed_at,
+            "signer_role": role,
+            "signing_event_id": signing_event_id,
+        },
+    }
+
+
+class NegativeTestPackV2(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.key_a = private_key(0x11)
+        cls.key_b = private_key(0x22)
+        cls.key_audit = private_key(0x33)
+        cls.key_suspended = private_key(0x44)
+        cls.key_revoked = private_key(0x55)
+        cls.key_expired = private_key(0x66)
+        cls.key_rotated = private_key(0x77)
+        cls.registry = {
+            "registry_version": "v0.2",
+            "keys": {
+                "key-a": key_record("key-a", cls.key_a, "tenant-a"),
+                "key-b": key_record("key-b", cls.key_b, "tenant-b"),
+                "key-audit": key_record("key-audit", cls.key_audit, "tenant-a", role="AUDIT_SERVICE"),
+                "key-suspended": key_record("key-suspended", cls.key_suspended, "tenant-a", terminal="SUSPENDED"),
+                "key-revoked": key_record("key-revoked", cls.key_revoked, "tenant-a", terminal="REVOKED"),
+                "key-expired": key_record("key-expired", cls.key_expired, "tenant-a", terminal="EXPIRED"),
+                "key-rotated": key_record("key-rotated", cls.key_rotated, "tenant-a", terminal="ROTATED"),
+            },
+        }
+
+    def test_01_valid_authorized_signature(self):
+        signed = sign_receipt(payload(), "key-a", self.key_a, self.registry)
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertTrue(result["authorized_attestation"])
+        self.assertEqual(result["disposition"], "PASS")
+
+    def test_02_altered_payload_rejected(self):
+        signed = sign_receipt(payload(), "key-a", self.key_a, self.registry)
+        signed["receipt_payload"]["evidence_hash"] = h("mutated-evidence")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertFalse(result["authorized_attestation"])
+        self.assertIn("RECEIPT_ID_MISMATCH", result["signals"])
+        self.assertIn("PAYLOAD_HASH_MISMATCH", result["signals"])
+        self.assertIn("SIGNATURE_INVALID", result["signals"])
+
+    def test_03_payload_hash_mismatch_rejected(self):
+        signed = sign_receipt(payload(), "key-a", self.key_a, self.registry)
+        signed["signature_bundle"]["payload_hash"] = h("wrong-payload-hash")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("PAYLOAD_HASH_MISMATCH", result["signals"])
+
+    def test_04_wrong_tenant_rejected(self):
+        signed = sign_receipt(payload(), "key-b", self.key_b, self.registry)
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("TENANT_MISMATCH", result["signals"])
+
+    def test_05_unregistered_key_rejected(self):
+        signed = sign_receipt(payload(), "key-a", self.key_a, self.registry)
+        signed["signature_bundle"]["key_id"] = "missing-key"
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("KEY_ID_UNREGISTERED", result["signals"])
+
+    def test_06_wrong_role_rejected(self):
+        signed = sign_receipt(payload(), "key-audit", self.key_audit, self.registry, role="REPLAY_SERVICE")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("SIGNER_ROLE_NOT_ALLOWED", result["signals"])
+
+    def test_07_suspended_key_rejected_after_suspension(self):
+        signed = sign_receipt(payload(), "key-suspended", self.key_suspended, self.registry, signed_at="2026-08-18T08:11:00Z")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("KEY_SUSPENDED_FOR_EVENT_SCOPE", result["signals"])
+
+    def test_08_revoked_key_rejected_after_revocation(self):
+        signed = sign_receipt(payload(), "key-revoked", self.key_revoked, self.registry, signed_at="2026-08-18T08:11:00Z")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("KEY_REVOKED_FOR_EVENT_SCOPE", result["signals"])
+
+    def test_09_expired_key_rejected_after_expiration(self):
+        signed = sign_receipt(payload(), "key-expired", self.key_expired, self.registry, signed_at="2026-08-18T08:11:00Z")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("KEY_EXPIRED_FOR_EVENT_SCOPE", result["signals"])
+
+    def test_10_forged_receipt_id_rejected(self):
+        signed = sign_receipt(payload(), "key-a", self.key_a, self.registry)
+        signed["receipt_id"] = h("forged-receipt")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("RECEIPT_ID_MISMATCH", result["signals"])
+
+    def test_11_forged_signature_rejected(self):
+        signed = sign_receipt(payload(), "key-a", self.key_a, self.registry)
+        signature = bytearray(base64.b64decode(signed["signature_bundle"]["signature"]))
+        signature[0] ^= 0x01
+        signed["signature_bundle"]["signature"] = base64.b64encode(bytes(signature)).decode("ascii")
+        signed["signature_bundle"]["signing_event_id"] = compute_signing_event_id(
+            signed["receipt_id"],
+            "key-a",
+            signed["signature_bundle"]["signed_at"],
+            signed["signature_bundle"]["signature"],
+        )
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("SIGNATURE_INVALID", result["signals"])
+
+    def test_12_rotated_key_historical_valid_future_invalid(self):
+        before = sign_receipt(payload(), "key-rotated", self.key_rotated, self.registry, signed_at="2026-08-18T08:09:00Z")
+        after = sign_receipt(payload(), "key-rotated", self.key_rotated, self.registry, signed_at="2026-08-18T08:11:00Z")
+        before_result = verify_signed_receipt(before, self.registry, "tenant-a")
+        after_result = verify_signed_receipt(after, self.registry, "tenant-a")
+        self.assertTrue(before_result["authorized_attestation"])
+        self.assertIn("KEY_ROTATED_FOR_EVENT_SCOPE", after_result["signals"])
+
+    def test_13_public_key_fingerprint_mismatch_rejected(self):
+        signed = sign_receipt(payload(), "key-a", self.key_a, self.registry)
+        signed["signature_bundle"]["public_key_fingerprint"] = h("wrong-fingerprint")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("PUBLIC_KEY_FINGERPRINT_MISMATCH", result["signals"])
+
+    def test_14_ruleset_drift_changes_receipt_identity(self):
+        receipt_v1 = compute_receipt_id(payload("v1.0.0", h("ruleset-v1")))
+        receipt_v2 = compute_receipt_id(payload("v2.0.0", h("ruleset-v2")))
+        self.assertNotEqual(receipt_v1, receipt_v2)
+
+    def test_15_model_output_promotion_field_rejected(self):
+        p = payload()
+        p["model_disposition"] = "PASS"
+        signed = sign_receipt(p, "key-a", self.key_a, self.registry)
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("RECEIPT_PAYLOAD_FIELDS_INVALID", result["signals"])
+
+    def test_16_signing_event_id_mismatch_rejected(self):
+        signed = sign_receipt(payload(), "key-a", self.key_a, self.registry)
+        signed["signature_bundle"]["signing_event_id"] = h("wrong-signing-event")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertIn("SIGNING_EVENT_ID_MISMATCH", result["signals"])
+
+    def test_17_same_receipt_two_signing_events(self):
+        p = payload()
+        first = sign_receipt(p, "key-a", self.key_a, self.registry, signed_at="2026-08-18T08:06:00Z")
+        second = sign_receipt(p, "key-a", self.key_a, self.registry, signed_at="2026-08-18T08:07:00Z")
+        first_result = verify_signed_receipt(first, self.registry, "tenant-a")
+        second_result = verify_signed_receipt(second, self.registry, "tenant-a")
+        self.assertTrue(first_result["authorized_attestation"])
+        self.assertTrue(second_result["authorized_attestation"])
+        self.assertEqual(first["receipt_id"], second["receipt_id"])
+        self.assertNotEqual(first["signature_bundle"]["signing_event_id"], second["signature_bundle"]["signing_event_id"])
+
+    def test_18_key_event_id_tampering_rejected(self):
+        registry = copy.deepcopy(self.registry)
+        registry["keys"]["key-a"]["events"][2]["tenant_id"] = "tenant-b"
+        signed = sign_receipt(payload(), "key-a", self.key_a, self.registry)
+        result = verify_signed_receipt(signed, registry, "tenant-a")
+        self.assertTrue(any(signal.startswith("KEY_EVENT_ID_MISMATCH:") for signal in result["signals"]))
+
+    def test_19_revoked_key_historical_signature_remains_valid(self):
+        signed = sign_receipt(payload(), "key-revoked", self.key_revoked, self.registry, signed_at="2026-08-18T08:09:00Z")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertTrue(result["authorized_attestation"])
+
+    def test_20_suspended_key_historical_signature_remains_valid(self):
+        signed = sign_receipt(payload(), "key-suspended", self.key_suspended, self.registry, signed_at="2026-08-18T08:09:00Z")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertTrue(result["authorized_attestation"])
+
+    def test_21_expired_key_historical_signature_remains_valid(self):
+        signed = sign_receipt(payload(), "key-expired", self.key_expired, self.registry, signed_at="2026-08-18T08:09:00Z")
+        result = verify_signed_receipt(signed, self.registry, "tenant-a")
+        self.assertTrue(result["authorized_attestation"])
+
+    def test_22_registry_fingerprint_tampering_rejected(self):
+        registry = copy.deepcopy(self.registry)
+        registry["keys"]["key-a"]["public_key_fingerprint"] = h("tampered-registry-fingerprint")
+        signed = sign_receipt(payload(), "key-a", self.key_a, self.registry)
+        result = verify_signed_receipt(signed, registry, "tenant-a")
+        self.assertIn("REGISTRY_FINGERPRINT_MISMATCH", result["signals"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Stack Enterprise Receipt API v0.2 on `JAYSPACE_REPLAY_SDK_v0.1` and turn the Ed25519 trust-chain proposal into executable authorization checks plus an adversarial regression pack.

```text
VALID_SIGNATURE != AUTHORIZED_SIGNATURE
```

An attestation passes only when signature validity, key registration, key fingerprint, tenant binding, signer role, historical active state, and revocation scope all reconcile at `signed_at`.

## Three identities

```text
RECEIPT_ID
= sha256(JCS(receipt_payload))

SIGNING_EVENT_ID
= sha256(JCS({receipt_id,key_id,signed_at,signature}))

KEY_EVENT_ID
= sha256(JCS(key_event_payload))
```

`SIGNING_EVENT_ID` intentionally uses a canonical structured object instead of raw string concatenation so field boundaries and encoding are explicit.

## Cryptographic contract

- receipt identity: RFC 8785 JCS + SHA-256
- signature algorithm: Ed25519
- signature input: raw 32-byte SHA-256 digest represented by `receipt_id`
- signing time is attestation metadata only and does not affect deterministic receipt identity
- no Ed25519 or JCS primitive is implemented in-repo
- CI pins `cryptography==49.0.0` and `rfc8785==0.1.3`

## Tenant/key lifecycle

Append-only states:

```text
KEY_CREATED
-> KEY_REGISTERED
-> TENANT_BOUND
-> ROLE_GRANTED
-> ACTIVE
-> SIGN
-> ROTATED | SUSPENDED | REVOKED | EXPIRED
```

Historical verification replays state at the signing time. A signature made before rotation/revocation/suspension/expiration can remain historically valid; one made after the terminal event is rejected.

## Negative Test Pack v2

22 vectors cover:

- valid authorized signature
- altered payload
- payload-hash mismatch
- tenant crossover
- unregistered key
- wrong role
- suspended / revoked / expired keys
- forged receipt ID
- forged Ed25519 signature
- rotation historical-valid / future-invalid
- public-key fingerprint mismatch
- ruleset drift
- model-output promotion injection
- signing-event-ID mismatch
- same receipt / multiple signing events
- key-event tampering
- historical validity before revocation, suspension, and expiration
- registry fingerprint tampering

## Exact-head validation

An initial CI run exposed that the default PR checkout/`GITHUB_SHA` referred to GitHub's synthetic merge commit. That result was not accepted as exact-head provenance. The workflow was corrected to checkout and assert the PR head SHA explicitly.

Final exact-head receipt:

```text
HEAD = fc04e195795c2e467a5a1627dda4bf787cdd3ee1
WORKFLOW RUN = 32117964653
JOB = 95651680732
EXACT CHECKOUT = PASS
PINNED DEPENDENCY INSTALL = PASS
NEGATIVE TEST PACK V2 = 22 / 22 PASS
RFC 8785 PATH = PASS
ED25519 PATH = PASS
CI RECEIPT git_sha = fc04e195795c2e467a5a1627dda4bf787cdd3ee1
ARTIFACT = 9317407706
ARTIFACT ZIP SHA256 = d68e911b5a5a9c9840576ed5423b7d563ce2a13f214ece0c2b78f7e8199b3890
```

The earlier local logic run was also 22/22 PASS, but used a temporary restricted canonicalization stub because the local container could not fetch `rfc8785`. That stub was never committed. The exact-head GitHub run above installed and executed the pinned RFC 8785 implementation.

## OpenAI boundary

```text
MODEL_OUTPUT != RECEIPT
MODEL_OUTPUT != KEY_EVENT
MODEL_OUTPUT != AUTHORIZED_SIGNATURE
MODEL_REQUIRED = FALSE
MODEL_EXECUTION_PERFORMED = FALSE
API_KEY_REQUIRED = FALSE
AUTHORITY_CREATED = FALSE
```

The OpenAI layer remains optional and downstream of deterministic receipt/authorization verification.

## Stack state

Base branch: `product/jayspace-replay-sdk-v0-1` / PR #498 head `ae06ebd35c470dcb825b7c0f8789ae5f7b003def`.

Head: `fc04e195795c2e467a5a1627dda4bf787cdd3ee1`.

Draft only. No merge, deployment, production key registration, tenant binding, payment activation, or authority creation is performed by this PR.