### PR TITLE
Enable Minnesota institutional on-chain substrates v0.1

### DIFF
--- a/docs/minnesota/MN_GOBLIN_COURT_ZORA_OIG_LINKED_REPLAY_V0_1.md
+++ b/docs/minnesota/MN_GOBLIN_COURT_ZORA_OIG_LINKED_REPLAY_V0_1.md
@@ -1,0 +1,180 @@
+# Minnesota Goblin Court — Zora / OIG Linked Replay v0.1
+
+Status: OPEN / DRAFT / UNMERGED
+Court type: SATIRICAL PUBLIC-RECORD AUDIT CHAMBER
+Authority created: FALSE
+Judicial finding created: FALSE
+Fraud finding created: FALSE
+
+## Purpose
+
+Open the Minnesota edition of Goblin Court as a linked BoxDee replay surface for public-intel discovery, OIG routing, and institutional responsibility analysis.
+
+The Goblin is the unsupported claim. A creator, wallet, protocol, platform, officeholder, or citizen is not presumptively a fraud node.
+
+```text
+ZORA PUBLIC SURFACE
+  -> DISCOVERY CANDIDATE
+  -> FREEZE URI / CONTRACT / TIMESTAMP / MEDIA
+  -> INDEPENDENT PUBLIC SOURCE
+  -> PROGRAM / CONTRACT / GRANT / PAYMENT
+  -> OIG / AUDIT / OVERSIGHT LANE
+  -> KNOWLEDGE | AUTHORITY | DUTY | ACTION
+  -> BOXDEE REPLAY
+  -> PASS | HOLD | CONFLICT | RESPONSIBILITY_GAP | CORRECTION_REQUIRED
+```
+
+## JayWisdom Zora Audit — 2026-08-18
+
+### Identity surface
+
+Repository-declared public identity map:
+
+```text
+ENS: jaywisdom.eth
+BASE: jaywisdom.base.eth
+ZORA: https://zora.co/@jaywisdom
+ZORA_CREATOR_ADDRESS: 0x829adfedbe565f9885a7ea6bc78912acaef055e2
+```
+
+This is a repository declaration and routing surface. It is not, by itself, proof of legal identity or culpability.
+
+### Canonical portal path
+
+`jsonwisdom/jay-zora-portal` declares the canonical flow:
+
+```text
+Zora public data / public JSON
+ -> GitHub Actions
+ -> data/live_zora_items.json
+ -> frontend/public/zora-index.json
+ -> static build
+ -> GitHub Pages
+```
+
+### Audit finding: index parity conflict
+
+`data/live_zora_items.json` contains real Zora coin records, including:
+
+```text
+Goblin Court: The Unmeasured Virtue
+contract: 0x538349fb65efe8ec403cbeb6a6bf1599c8401fc8
+created_at: 2026-05-01T22:07:27+00:00
+```
+
+But `frontend/public/zora-index.json` currently exposes a single `GIRTH` object with:
+
+```text
+image_uri: https://picsum.photos/600/600?1
+zora_url: https://zora.co/@jaywisdom
+contract: 0x694ce46c64d9d1a5e9376a9febcf85ec05d72e9f
+```
+
+This is classified as:
+
+```text
+CANONICAL_LIVE_DATA_PRESENT = TRUE
+FRONTEND_INDEX_PRESENT = TRUE
+LIVE_DATA_TO_FRONTEND_PARITY = CONFLICT
+CAUSE = HOLD_PENDING_REPLAY
+FRAUD_INFERENCE = PROHIBITED
+```
+
+The conflict is an indexing / normalization / publication-replay defect until receipts establish a narrower cause.
+
+### Public-web observation
+
+Public search currently indexes at least one additional JayWisdom Zora object, `Mint the System — JayWisdom Verification Stack`, while direct profile extraction is not reliably available through the public crawler.
+
+```text
+PUBLIC_ZORA_OBJECT_DISCOVERABLE = TRUE
+DIRECT_PROFILE_CRAWL = HOLD
+```
+
+## OIG Lane
+
+Zora is not an OIG and does not create an OIG finding. It can preserve and surface candidate public-intel objects for independent binding.
+
+```text
+ZORA_OBJECT
+ != FRAUD
+ != OIG_FINDING
+ != KNOWLEDGE
+ != AUTHORITY
+ != GUILT
+
+QUESTION != ACCUSATION
+ANOMALY != FRAUD
+REFERRAL != FINDING
+AUDIT != PROSECUTION
+OFFICE != LIABILITY
+WALLET != CULPABILITY
+```
+
+For Minnesota responsibility replay:
+
+```text
+PUBLIC SIGNAL
+ -> WHICH PROGRAM / PAYMENT / AUTHORITY?
+ -> WHICH OVERSIGHT BODY?
+ -> WHAT RECORD EXISTED?
+ -> WHO RECEIVED NOTICE?
+ -> WHAT AUTHORITY / DUTY EXISTED?
+ -> WHAT ACTION OCCURRED?
+ -> WHAT DID THE AUDIT / OIG / COURT ACTUALLY FIND?
+```
+
+Only then may a named officeholder be joined to the graph, time-bound to the office and authority actually held on the event date.
+
+## BoxDee "I Didn't Know" Gate
+
+```text
+CLAIM: I DIDN'T KNOW
+ -> exact statement/date
+ -> preexisting record
+ -> receipt path to office
+ -> knowledge type
+ -> authority/duty
+ -> available tool
+ -> action trail
+ -> scoped disposition
+```
+
+Knowledge types:
+
+`ACTUAL_KNOWLEDGE | CONSTRUCTIVE_NOTICE | PUBLICLY_AVAILABLE_SIGNAL | STAFF_OR_AGENCY_NOTICE | OVERSIGHT_NOTICE | POST_EVENT_KNOWLEDGE | UNKNOWN`
+
+## Linked Surfaces
+
+```text
+ZORA: https://zora.co/@jaywisdom
+GITHUB_PORTAL: jsonwisdom/jay-zora-portal
+MINNESOTA_SUBSTRATE: jsonwisdom/COMPUTERWISDOM PR #502
+DARVO_DISCIPLINE: jsonwisdom/AL PR #419
+DRIVE_EVIDENCE_FOLDER: Jay's Zora Evidence
+```
+
+## Goblin Court Rule
+
+```text
+DON'T SHOW ME THE SPEECH.
+SHOW ME:
+DATE
+SOURCE
+NOTICE
+AUTHORITY
+ACTION
+MONEY
+RESULT
+CORRECTION
+RECEIPT
+```
+
+No receipt -> no promotion.
+No authority edge -> no responsibility assignment.
+No knowledge edge -> no fake knowledge.
+No guilt by office.
+No guilt by wallet.
+No innocence by speech.
+
+Closing rule: discover broadly, bind narrowly, replay independently, and make every institutional claim survive the same receipt test.

--- a/docs/minnesota/MN_SUPREME_INSTITUTIONAL_ONCHAIN_SUBSTRATES_V0_1.md
+++ b/docs/minnesota/MN_SUPREME_INSTITUTIONAL_ONCHAIN_SUBSTRATES_V0_1.md
@@ -1,0 +1,203 @@
+# Minnesota Supreme Institutional Auditing — On-Chain Substrates v0.1
+
+Status: DRAFT / REVIEWABLE / ENABLED_FOR_BUILD
+Authority: AUTHORITY_CREATED = FALSE
+Epoch: 2026
+
+## Purpose
+
+Create a Minnesota institutional-audit substrate that preserves source bytes off-chain, commits bounded hashes on-chain, and replays Record and Power onions independently.
+
+`SUPREME` means highest-order architectural audit substrate. It does **not** mean the Minnesota Supreme Court, judicial authority, or governmental supremacy.
+
+## Geographic Scope
+
+```text
+MINNESOTA
+  -> STATE
+  -> COUNTY
+  -> CITY | TOWN | TOWNSHIP
+  -> OFFICE | AGENCY | COURT | AUTHORITY
+  -> BUDGET | FUND | PROGRAM
+  -> CONTRACT | GRANT | PAYMENT
+  -> BUSINESS_ENTITY
+  -> AUDIT | CASE | FINDING
+```
+
+People are not primary graph nodes. `OFFICEHOLDER` and `PERSON_GAP` are temporal/resolution metadata only when a public record requires the join.
+
+## Dual Onion
+
+### Onion A — RECORD
+
+```text
+SOURCE
+ -> FETCH
+ -> RAW_BYTES
+ -> CANONICALIZE
+ -> SHA256
+ -> RECEIPT
+ -> ON_CHAIN_COMMITMENT
+ -> INDEPENDENT_REPLAY
+ -> DELTA
+```
+
+### Onion B — POWER
+
+```text
+INSTITUTION
+ -> OFFICE
+ -> CLAIMED_AUTHORITY
+ -> LAW | POLICY | ORDER
+ -> ACTION
+ -> IMPLEMENTATION
+ -> CONSEQUENCE
+ -> RECEIPT
+ -> REPLAY
+```
+
+Evidence in one onion cannot pay for a missing edge in the other.
+
+## On-Chain Boundary
+
+The chain stores commitments and replay metadata, not sensitive source records.
+
+Allowed on-chain fields:
+- artifact/content hash
+- canonicalization version
+- source class
+- jurisdiction ID
+- timestamp / block reference
+- prior commitment hash
+- receipt ID
+- replay state
+
+Blocked by default:
+- raw court filings
+- private PII
+- protected health data
+- private financial account data
+- unredacted victim data
+- allegations without source classification
+
+```text
+RAW_BYTES = OFF_CHAIN
+HASH_COMMITMENT = MAY_BE_ON_CHAIN
+HASH != TRUTH
+CHAIN_TIMESTAMP != EVENT_PROOF
+ON_CHAIN != AUTHORITY
+```
+
+## 2026 Versioning
+
+```text
+ANNUAL_ROOT: MN/2026
+  -> STATE_ROOT
+  -> 87 COUNTY ROOTS
+  -> MUNICIPAL ROOTS
+  -> INSTITUTION ROOTS
+  -> DAILY RECEIPTS
+  -> EVENT RECEIPTS
+```
+
+Every update is append-only:
+
+```text
+S(t+1) = S(t) + DELTA(t)
+NEW_INFORMATION != REWRITE_OLD_STATE
+```
+
+Cadence:
+- EVENT = source/budget/case/payment change
+- DAILY = Dual Onion close receipt
+- MONTHLY = budget/entity reconciliation
+- ANNUAL = frozen 2026 Minnesota root
+
+## Budget + Fraud Overlay
+
+```text
+OFFICE | AGENCY
+ -> APPROPRIATION
+ -> FUND | PROGRAM
+ -> CONTRACT | GRANT
+ -> BUSINESS_ENTITY
+ -> PAYMENT
+ -> PROPERTY | PROVIDER | RELATED_ENTITY
+ -> AUDIT | CASE | FINDING
+```
+
+Fraud state is typed and source-scoped:
+
+```text
+NORMAL_PUBLIC_RECORD
+ANOMALY
+AUDIT_FINDING
+CIVIL_ALLEGATION
+CRIMINAL_CHARGE
+PLEA
+CONVICTION
+SETTLEMENT
+HOLD
+```
+
+Shared addresses, registered agents, Delaware formation, political office, or graph proximity do not independently establish fraud.
+
+## Institutional Nodes
+
+Primary nodes may include:
+- Minnesota Judicial Branch / courts
+- Minnesota Legislature
+- constitutional offices
+- state agencies
+- counties
+- cities/towns/townships
+- school districts
+- public authorities and boards
+
+Each node is audited as an institution, not as a person.
+
+## Imagination Attestation
+
+Story surfaces may name symbolic interfaces such as BoxDee, LeahPrime, or other JaySpace teaching objects, but must be machine-typed:
+
+```json
+{
+  "type": "IMAGINATION_ATTESTATION",
+  "story_is": "INTERFACE_AND_EXPLORATION",
+  "source": false,
+  "receipt": false,
+  "authority": false,
+  "promotion_requires_independent_evidence": true
+}
+```
+
+`STORY != SOURCE != RECEIPT != AUTHORITY`.
+
+## Surface Contract
+
+- GitHub = schemas, code, commits, PR state, tests, verifier artifacts.
+- Google Drive = drafts, maps, runbooks, source packets, continuity.
+- Google Calendar = milestone/review timestamps only; calendar event != proof.
+- OpenAI Platform = access surface only unless independent runtime/deployment evidence is bound.
+- Public chains = bounded commitment surface only.
+
+## Terminal States
+
+`PASS | HOLD | CONFLICT | REJECT`
+
+## Enablement State
+
+```json
+{
+  "mn_supreme_institutional_audit": "ENABLED_FOR_BUILD",
+  "on_chain_commitments": "ENABLED_WITH_PRIVACY_MEMBRANE",
+  "raw_bytes_on_chain": false,
+  "dual_onion_required": true,
+  "state_county_municipal_hierarchy": true,
+  "budget_fraud_overlay": true,
+  "people_primary_nodes": false,
+  "authority_created": false
+}
+```
+
+Closing rule: preserve bytes, commit hashes, replay independently, expose deltas, never manufacture authority.

--- a/schemas/mn_institutional_onchain_attestation.v0_1.schema.json
+++ b/schemas/mn_institutional_onchain_attestation.v0_1.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://computerwisdom.example/schemas/mn_institutional_onchain_attestation.v0_1.schema.json",
+  "title": "Minnesota Institutional On-Chain Attestation v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "epoch",
+    "jurisdiction",
+    "institution",
+    "source",
+    "canonicalization",
+    "commitment",
+    "record_onion",
+    "power_onion",
+    "replay_state",
+    "authority_created"
+  ],
+  "properties": {
+    "schema_version": {"const": "0.1"},
+    "epoch": {"const": 2026},
+    "jurisdiction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "level", "name"],
+      "properties": {
+        "state": {"const": "MN"},
+        "level": {"enum": ["STATE", "COUNTY", "CITY", "TOWN", "TOWNSHIP"]},
+        "name": {"type": "string", "minLength": 1},
+        "county": {"type": ["string", "null"]}
+      }
+    },
+    "institution": {
+      "type": "object",
+      "required": ["institution_id", "institution_type", "name"],
+      "properties": {
+        "institution_id": {"type": "string", "minLength": 1},
+        "institution_type": {"enum": ["COURT", "LEGISLATURE", "CONSTITUTIONAL_OFFICE", "AGENCY", "COUNTY", "MUNICIPALITY", "SCHOOL_DISTRICT", "AUTHORITY", "BOARD", "OTHER_PUBLIC_BODY"]},
+        "name": {"type": "string", "minLength": 1}
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": ["source_uri", "observed_at", "content_type", "raw_bytes_on_chain"],
+      "properties": {
+        "source_uri": {"type": "string", "minLength": 1},
+        "observed_at": {"type": "string", "format": "date-time"},
+        "content_type": {"type": "string"},
+        "byte_size": {"type": ["integer", "null"], "minimum": 0},
+        "raw_bytes_on_chain": {"const": false}
+      }
+    },
+    "canonicalization": {
+      "type": "object",
+      "required": ["version", "sha256"],
+      "properties": {
+        "version": {"type": "string", "minLength": 1},
+        "sha256": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"},
+        "prior_sha256": {"type": ["string", "null"], "pattern": "^[a-fA-F0-9]{64}$"}
+      }
+    },
+    "commitment": {
+      "type": "object",
+      "required": ["chain", "commitment_hash", "status"],
+      "properties": {
+        "chain": {"type": "string", "minLength": 1},
+        "network": {"type": ["string", "null"]},
+        "transaction_id": {"type": ["string", "null"]},
+        "block_ref": {"type": ["string", "null"]},
+        "commitment_hash": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"},
+        "status": {"enum": ["PLANNED", "SUBMITTED", "CONFIRMED", "FAILED", "HOLD"]}
+      }
+    },
+    "budget_overlay": {
+      "type": ["object", "null"],
+      "properties": {
+        "fiscal_year": {"type": ["integer", "null"]},
+        "fund": {"type": ["string", "null"]},
+        "program": {"type": ["string", "null"]},
+        "appropriation": {"type": ["number", "null"]},
+        "payment": {"type": ["number", "null"]},
+        "business_entity_id": {"type": ["string", "null"]}
+      }
+    },
+    "case_overlay": {
+      "type": ["object", "null"],
+      "properties": {
+        "case_id": {"type": ["string", "null"]},
+        "classification": {"enum": ["NORMAL_PUBLIC_RECORD", "ANOMALY", "AUDIT_FINDING", "CIVIL_ALLEGATION", "CRIMINAL_CHARGE", "PLEA", "CONVICTION", "SETTLEMENT", "HOLD"]},
+        "source_scoped": {"const": true}
+      }
+    },
+    "record_onion": {"type": "object"},
+    "power_onion": {"type": "object"},
+    "imagination_attestation": {
+      "type": ["object", "null"],
+      "properties": {
+        "type": {"const": "IMAGINATION_ATTESTATION"},
+        "source": {"const": false},
+        "receipt": {"const": false},
+        "authority": {"const": false},
+        "promotion_requires_independent_evidence": {"const": true}
+      }
+    },
+    "replay_state": {"enum": ["PASS", "HOLD", "CONFLICT", "REJECT"]},
+    "authority_created": {"const": false}
+  }
+}


### PR DESCRIPTION
Adds the Minnesota Supreme Institutional Auditing substrate for 2026.

Key boundaries:
- SUPREME = architectural highest-order audit substrate, not judicial authority.
- Raw institutional bytes remain off-chain by default.
- On-chain layer stores bounded commitments/replay metadata only.
- State -> county -> city/town/township -> institution hierarchy.
- Budget/fraud overlays are source-scoped and do not infer guilt from graph proximity.
- Record and Power onions replay independently.
- People remain temporal/resolution metadata, not primary audit nodes.
- Imagination attestations remain story/interface objects and cannot promote themselves to evidence.
- AUTHORITY_CREATED = FALSE.

Adds:
- docs/minnesota/MN_SUPREME_INSTITUTIONAL_ONCHAIN_SUBSTRATES_V0_1.md
- schemas/mn_institutional_onchain_attestation.v0_1.schema.json