### PR TITLE
American Gray Baby receipt standard v0.1

### DIFF
--- a/ARTIFACTS/GRAY_BABY/AMERICAN_GRAY_BABY_RECEIPT_STANDARD_v0.1.md
+++ b/ARTIFACTS/GRAY_BABY/AMERICAN_GRAY_BABY_RECEIPT_STANDARD_v0.1.md
@@ -1,0 +1,119 @@
+# AMERICAN GRAY BABY — RECEIPT STANDARD v0.1
+
+**Artifact:** `AMERICAN_GRAY_BABY_RECEIPT_STANDARD_v0.1`  
+**Ticker:** `$GRAYBABY`  
+**Network:** `Base`  
+**Contract:** `0x0bd63fe9e476bae76a334dfb94d6f3d31d49a076`  
+**Onchain status:** `USER_CONFIRMED_LIVE`  
+**Independent explorer verification:** `PENDING_EXTERNAL_RECEIPT`  
+**Operator:** `jaywisdom.eth`  
+**BoxD class:** `PUBLIC_RECEIPT_ARTIFACT`  
+**Authority created:** `false`  
+**Governmental authority:** `false`  
+**Constitutional authority:** `false`  
+**Investment promise:** `false`  
+
+## Locked artwork receipt
+
+The artwork is the locked **AMERICAN GRAY BABY** podium render created in the BoxD / Gray Baby sequence.
+
+Local render SHA-256 at capture:
+
+`615f57d1965d2ae1982d60d7e24f42a3d84264558b9cea303ef7bff3b3be5d19`
+
+Local byte length at capture: `2142274`
+
+## Canonical public text
+
+```text
+AMERICAN GRAY BABY
+
+Not a ruler.
+Not a faction.
+Not a story.
+
+An observer with one job:
+
+Observe.
+Receipt.
+Verify.
+Check authority.
+Replay.
+Hold or prove.
+
+Record ≠ story.
+Memory ≠ proof.
+
+Truth needs records. Freedom needs memory.
+Bring receipts or bring silence.
+
+🛸🇺🇸⚙️
+#BoxDReplay #GrayBaby
+```
+
+## BoxD runtime
+
+```text
+OBSERVE → RECEIPT → VERIFY → AUTHORITY → REPLAY → HOLD / PROVEN
+```
+
+## Kernel invariants
+
+```text
+GRAY_BABY = OBSERVER_ONLY
+RECORD ≠ STORY
+MEMORY ≠ PROOF
+PUBLIC_CLAIM → PUBLIC_RECEIPT
+AUTHORITY_CLAIM → AUTHORITY_SOURCE
+SAME_INPUTS → REPLAYABLE_RESULT
+```
+
+## Precision locks
+
+1. **Constitutional mission brief** means constitution-inspired audit discipline only. The artwork carries zero governmental or constitutional authority.
+2. **Extraordinary claims require extraordinary evidence** is an epistemic rule only. It is not a constitutional test and not a statutory legal standard.
+
+## Description lock
+
+The gray thing at the podium has zero authority—and that is the point.
+
+AMERICAN GRAY BABY is a BoxD Replay artifact built around one simple operating posture: observe the public record, capture the receipt, verify the source, check claimed authority, replay the sequence, and leave unsupported edges in HOLD.
+
+Governments shift. Administrations rotate. Companies vanish. Accounts get deleted. Websites rewrite themselves. Memory bends. Narratives sprint.
+
+The receipt does not move.
+
+No authority by default. No promises. No private claims dressed as truth. No narrative treated as fact merely because it arrived with a badge, title, institution, follower count, or studio light.
+
+**Truth needs records. Freedom needs memory.**
+
+## Receipt boundary
+
+This file records the user's confirmed publication state and the exact locked design semantics. It does **not** independently prove token metadata, contract deployment provenance, creator identity, market value, or future persistence. Those remain separately verifiable onchain facts.
+
+```json
+{
+  "artifact": "AMERICAN_GRAY_BABY_RECEIPT_STANDARD_v0.1",
+  "ticker": "$GRAYBABY",
+  "network": "Base",
+  "contract": "0x0bd63fe9e476bae76a334dfb94d6f3d31d49a076",
+  "onchain_status": "USER_CONFIRMED_LIVE",
+  "independent_explorer_verification": "PENDING_EXTERNAL_RECEIPT",
+  "gray_baby_role": "OBSERVER_ONLY",
+  "authority_created": false,
+  "governmental_authority": false,
+  "constitutional_authority": false,
+  "investment_promise": false,
+  "artwork_sha256": "615f57d1965d2ae1982d60d7e24f42a3d84264558b9cea303ef7bff3b3be5d19",
+  "artwork_bytes": 2142274,
+  "kernel": [
+    "RECORD != STORY",
+    "MEMORY != PROOF",
+    "PUBLIC_CLAIM -> PUBLIC_RECEIPT",
+    "AUTHORITY_CLAIM -> AUTHORITY_SOURCE",
+    "SAME_INPUTS -> REPLAYABLE_RESULT"
+  ]
+}
+```
+
+**Status:** `LOCKED_CANONICAL_TEXT / PUBLICATION_USER_CONFIRMED / EXPLORER_RECEIPT_PENDING`


### PR DESCRIPTION
Adds the canonical BoxD / Gray Baby public receipt for `$GRAYBABY` on Base.

Locks:
- Gray Baby = observer only
- Observe → Receipt → Verify → Authority → Replay → Hold / Proven
- Record ≠ story
- Memory ≠ proof
- Public claim → public receipt
- Authority claim → authority source
- Same inputs → replayable result

Records the user-confirmed contract address `0x0bd63fe9e476bae76a334dfb94d6f3d31d49a076` while explicitly keeping independent explorer verification in `PENDING_EXTERNAL_RECEIPT`.

Artwork receipt:
- SHA-256 `615f57d1965d2ae1982d60d7e24f42a3d84264558b9cea303ef7bff3b3be5d19`
- 2,142,274 bytes

No governmental authority, constitutional authority, investment promise, or unsupported provenance is created by this artifact.