### PR TITLE
JAYWISDOM 0x69 Gray Baby atomic audit v0.1

### DIFF
--- a/artifacts/JAYWISDOM_B0_ANCHOR.json
+++ b/artifacts/JAYWISDOM_B0_ANCHOR.json
@@ -1,0 +1,26 @@
+{
+  "tx_hash": "0x7239f942d4818821f88d24c63140ba0aaae1e096036d746e007b2f6f0c3789e6",
+  "block_number_hex": "0x183afe0",
+  "block_number": 25407456,
+  "block_hash": "0x4686285c9bd01010b52fe9748693898e6ed50193f9743abe44f653ddffa22e81",
+  "timestamp_unix": 1737604259,
+  "timestamp_utc": "2025-01-23T03:50:59Z",
+  "from": "0x8611d9722ec5089f974eb48a7b5ccdb97e8978fb",
+  "to": "0x0ba958a449701907302e28f5955fa9d16ddc45c3",
+  "status": "0x1",
+  "gas_used": "0x442ce",
+  "proxy_address": "0x829AdfEdBe565F9885a7eA6Bc78912acAef055E2",
+  "state": "PROVEN",
+  "notes": "Morphological birth of the proxy. Immutable L2 receipt. Flips HOLD_EXACT_FETCH to PROVEN.",
+  "fetched_at": "2026-08-19T10:17:24.480473Z",
+  "provenance": {
+    "primary": "user-supplied Base RPC eth_getTransactionReceipt + eth_getBlockByNumber receipt",
+    "public_crosscheck": "BaseScan transaction pointer independently known; exact block/timestamp were not independently returned by the browser fetch in this replay"
+  },
+  "membrane": {
+    "account_deployment_is_not_first_funding": true,
+    "account_deployment_is_not_dense_scan_floor": true,
+    "authority_created": false,
+    "financial_claim_created": false
+  }
+}

--- a/docs/audits/JAYWISDOM_0X69_GRAYBABY_ATOMIC_AUDIT_V0_1.md
+++ b/docs/audits/JAYWISDOM_0X69_GRAYBABY_ATOMIC_AUDIT_V0_1.md
@@ -1,0 +1,230 @@
+# JAYWISDOM 0x69 — Gray Baby Atomic Audit v0.1
+
+Date: `2026-08-19`  
+Status: `CROSS_SURFACE_BOUND_DRAFT`  
+Audit mode: `OBSERVE -> RECEIPT -> VERIFY -> AUTHORITY -> REPLAY -> HOLD / PROVEN`  
+Authority created: `FALSE`  
+Financial claim created: `FALSE`
+
+Drive mirror: https://docs.google.com/document/d/1XTdWUiPSvWjUdHI39AS8C_XVJQAHRC9zKDDO0fb1tog/edit
+
+## Root object
+
+```text
+NETWORK = Base
+TOKEN_CONTRACT = 0x694cE46C64D9D1a5e9376A9feBcF85Ec05D72e9F
+NAME = jaywisdom
+SYMBOL = jaywisdom
+STANDARD = ERC-20 CreatorCoin minimal proxy
+DECIMALS = 18
+MAX_TOTAL_SUPPLY_DISPLAYED = 1,000,000,000
+CREATION_TX = 0x49c29d9b305a297c6a754f068fbf8ec4921e5e038b3c037757d99635da477a10
+CREATION_BLOCK = 31825577
+CREATION_TIMESTAMP = 2025-06-20T17:28:21Z
+CREATION_STATUS = SUCCESS
+FACTORY = 0x777777751622c0d3258f214F9DF38E35BF45baF3 (ZoraFactory)
+CREATORCOIN_VERSION = 1.1.0
+METADATA_URI = ipfs://bafybeibdshmigqm56zayjuhgyiniatzpexmamgoxhfeadhjujmvjspbksa
+```
+
+Primary chain sources:
+- https://basescan.org/token/0x694ce46c64d9d1a5e9376a9febcf85ec05d72e9f
+- https://basescan.org/tx/0x49c29d9b305a297c6a754f068fbf8ec4921e5e038b3c037757d99635da477a10
+
+## 0x829a role correction
+
+Address: `0x829AdfEdBe565F9885a7eA6Bc78912acAef055E2`
+
+| Relationship | State |
+|---|---|
+| `CreatorCoinCreated.caller` | `PROVEN` |
+| `CreatorCoinCreated.payoutRecipient` | `PROVEN` |
+| initial `OwnerUpdated.newOwner` | `PROVEN` |
+| `CoinPayoutRecipientUpdated.newRecipient` | `PROVEN` |
+| later `CreatorCoinRewards.creator` | `PROVEN` |
+| GitHub public-index role: Zora wallet pointer | `REPO_BOUND` |
+| creation-time `platformReferrer` | `FALSE` — event value is zero address |
+| generic/user label `referrer` | `HOLD_ROLE_AMBIGUITY` until a specific referral/trade receipt binds it |
+
+**Correction:** do not serialize `0x829a...` as the creation-time platform referrer. The chain event proves caller + payout recipient, and later creator-reward role.
+
+## Initial ownership
+
+Creation transaction emits owner additions for:
+
+```text
+0x829AdfEdBe565F9885a7eA6Bc78912acAef055E2
+0xb3B9CC668e997209e914309FF525535203EaD4dA
+0xd88A5b3622cc1708eb8E8F5c57744DFfb0B93db1
+```
+
+`0xd88A...` is publicly labeled `computerwisdom.base.eth` on BaseScan.
+
+```text
+INITIAL_OWNER_SET = PROVEN
+CURRENT_OWNER_SET = HOLD_CURRENT_READBACK
+```
+
+Initialization events do not prove that no later ownership mutations occurred.
+
+## Account-abstraction deployment path
+
+The outer transaction is an ERC-4337 bundle:
+
+```text
+Pimlico ERC-4337 Bundler 56
+  -> Entry Point 0.6.0
+    -> ZoraFactory CREATE2
+      -> JAYWISDOM CreatorCoin
+```
+
+Boundary:
+
+```text
+BUNDLER != CREATOR
+OUTER_TX_FROM != APPLICATION_CALLER
+```
+
+The `CreatorCoinCreated` event is the authoritative receipt for the application caller/payout relationship.
+
+The same outer bundle also created a separate coin, `Brielle’s beauty ritual`. This establishes **bundle co-occurrence only**. It does not prove shared creator, ownership, purpose, or project identity.
+
+## Uniswap v4 relationship
+
+```text
+POOL_MANAGER = 0x498581fF718922c3f8e6A244956aF099B2652b2b
+POOL_ID = 0xC3107E6D53CC9FA38C90A58F307094E754CCC6E7653411308C8CEB5ACE8E57FA
+CURRENCY_0 = 0x1111111111166b7FE7bd91427724B487980aFc69 ($ZORA)
+CURRENCY_1 = 0x694cE46C64D9D1a5e9376A9feBcF85Ec05D72e9F (jaywisdom)
+FEE_PIPS = 30000
+FEE = 3.00%
+TICK_SPACING = 200
+HOOK = 0xffF800B76768dA8AB6aab527021e4a6A91219040
+POOL_INITIALIZED = PROVEN
+INITIAL_LIQUIDITY_EVENT = PROVEN
+CURRENT_LIQUIDITY = HOLD_DYNAMIC_READBACK
+```
+
+Uniswap v4 uses a PoolManager singleton: pools are uniquely identified by `PoolKey` / `PoolId`, not separate pool contract addresses. The historical requirement to find a separate pool address is therefore superseded by a schema correction.
+
+Primary protocol references:
+- https://developers.uniswap.org/docs/protocols/v4/concepts/poolmanager
+- https://developers.uniswap.org/docs/protocols/v4/guides/create-pool
+- https://developers.uniswap.org/docs/protocols/v4/deployments
+- https://support.zora.co/en/articles/5654721
+
+## Initial supply flow observed
+
+```text
+Null -> JAYWISDOM token
+  1,000,000,000 jaywisdom
+
+JAYWISDOM token -> 0xffF800... hook
+  500,000,000 jaywisdom
+
+0xffF800... hook -> Uniswap v4 PoolManager
+  499,999,999.999999999999999999 jaywisdom
+```
+
+This proves initialization transfers. It does **not** prove present balances, present liquidity, price, market value, or investment performance.
+
+## GitHub reverse replay
+
+Historical source: `jsonwisdom/JOY/artifacts/L2_JAYWISDOM_TOKEN_IDENTITY_CORRECTION_V0_1.json`
+
+That receipt correctly treated `0x694c...` as a reported token contract rather than a pool, then requested independent explorer evidence. This audit closes several of those gates:
+
+```text
+TOKEN_IDENTITY: REPORTED -> PROVEN_ONCHAIN
+TOKEN_CREATION: NOT_INDEPENDENTLY_REPLAYED -> PROVEN_ONCHAIN
+POOL: UNCONFIRMED -> POOL_ID_PROVEN
+INITIAL_LIQUIDITY: UNCONFIRMED -> PROVEN_ONCHAIN
+CURRENT_LIQUIDITY: HOLD_DYNAMIC
+```
+
+Historical source: `jsonwisdom/JOY/artifacts/L0_JAY_ATOMIC_REPUTATION_RECEIPT_V0_1.json`
+
+Its historical `REPORTED / NOT_PROVEN / UNCONFIRMED` states remain preserved in-place and are superseded by this stronger direct-chain replay rather than rewritten.
+
+### Portal metadata membrane
+
+`jsonwisdom/jay-zora-portal/frontend/public/zora-index.json` currently maps this contract to `GIRTH`, `token_id: 1`, and tx hash `0xdbb81126...`.
+
+Classification:
+
+```text
+PORTAL_INDEX_ENTRY = OBSERVED
+TOKEN_ID_1_ONCHAIN = HOLD
+PORTAL_TX_HASH = HOLD_INDEPENDENT_CHAIN_REPLAY
+```
+
+This root object is an ERC-20 CreatorCoin. A portal `token_id` field is interface/index metadata unless a separate onchain object proves token-ID semantics.
+
+## Gray Baby relationship
+
+Gray Baby receipt standard PR #509 records a **different** user-confirmed Base address:
+
+`0x0bd63fe9e476bae76a334dfb94d6f3d31d49a076`
+
+PR #509 keeps independent explorer verification pending for that address.
+
+Therefore:
+
+```text
+JAYWISDOM_TOKEN == GRAYBABY_TOKEN = FALSE
+GRAYBABY_RELATION = AUDITOR / WITNESS METHOD
+DIRECT_ECONOMIC_RELATION = NOT_PROVEN
+DIRECT_CONTRACT_RELATION = NOT_PROVEN
+```
+
+Gray Baby is the audit membrane here, not silently a token relationship.
+
+## Drive replay
+
+Exact Drive searches for the JAYWISDOM token address and `0x829a...` returned no pre-existing object in this replay. The Drive mirror linked above is the new dedicated audit witness.
+
+## OpenAI Platform replay
+
+Visible target topology during replay:
+- Computer Wisdom / Default project
+- Computer Wisdom / Default project
+- Personal / Default project
+
+```text
+PLATFORM_ROLE = ACCESS / TOPOLOGY CONTEXT ONLY
+ONCHAIN_PROOF_WEIGHT = 0
+API_KEY_CREATED_BY_THIS_REPLAY = FALSE
+```
+
+## Atomic state
+
+```text
+TOKEN_CONTRACT = PROVEN
+CREATORCOIN_TYPE = PROVEN
+CREATION_TX = PROVEN
+ZORA_FACTORY_DEPLOYMENT = PROVEN
+0x829_CALLER = PROVEN
+0x829_PAYOUT_RECIPIENT = PROVEN
+0x829_CREATOR_REWARD_ROLE = PROVEN
+0x829_PLATFORM_REFERRER_AT_CREATION = FALSE
+INITIAL_OWNER_SET = PROVEN
+CURRENT_OWNER_SET = HOLD
+UNISWAP_V4_POOL_ID = PROVEN
+INITIAL_LIQUIDITY = PROVEN
+CURRENT_LIQUIDITY = HOLD
+GRAYBABY_AUDIT_RELATION = BOUND_METHOD
+GRAYBABY_TOKEN_RELATION = SEPARATE
+AUTHORITY = FALSE
+```
+
+## Doctrine
+
+```text
+CHAIN EVENT > REPO LABEL > USER LABEL
+BUNDLER != CREATOR
+POOL ID != TOKEN CONTRACT
+PUBLIC INDEX != CHAIN FACT
+SAME TRANSACTION != SAME OWNER
+TOKEN != AUTHORITY
+MISSING CURRENT READBACK -> HOLD
+```

--- a/docs/audits/JAYWISDOM_B0_INDEX_PARTITION_SCHEDULE_V0_1.md
+++ b/docs/audits/JAYWISDOM_B0_INDEX_PARTITION_SCHEDULE_V0_1.md
@@ -1,7 +1,7 @@
-# JAYWISDOM B0 Index Partition Schedule v0.1
+# JAYWISDOM B0 Index Partition Schedule v0.1.1
 
 Date: `2026-08-19`
-Status: `B0_DENSE_FLOOR_BOUND / ACCOUNT_BIRTH_EXACT_BLOCK_HOLD`
+Status: `B0_SEALED / ACCOUNT_DEPLOYMENT_PROVEN / DENSE_FLOOR_BOUND`
 Authority created: `FALSE`
 Financial claim created: `FALSE`
 
@@ -24,34 +24,59 @@ B0_FIRST_RELEVANT_ACTIVITY = earliest transaction/log/transfer involving the aud
 B0_DENSE_SCAN_FLOOR = conservative block floor for dense historical indexing
 ```
 
-User-supplied Phase 0 observation:
+## B0 exact anchor — PROVEN
+
+Canonical machine-readable receipt:
+
+`artifacts/JAYWISDOM_B0_ANCHOR.json`
+
+User-supplied Base RPC receipt (`eth_getTransactionReceipt` + `eth_getBlockByNumber`) establishes:
+
+```text
+B0_ACCOUNT_DEPLOYMENT_TX = 0x7239f942d4818821f88d24c63140ba0aaae1e096036d746e007b2f6f0c3789e6
+B0_ACCOUNT_DEPLOYMENT_BLOCK_HEX = 0x183afe0
+B0_ACCOUNT_DEPLOYMENT_BLOCK = 25,407,456
+B0_ACCOUNT_DEPLOYMENT_BLOCK_HASH = 0x4686285c9bd01010b52fe9748693898e6ed50193f9743abe44f653ddffa22e81
+B0_ACCOUNT_DEPLOYMENT_TIMESTAMP_UNIX = 1737604259
+B0_ACCOUNT_DEPLOYMENT_TIMESTAMP_UTC = 2025-01-23T03:50:59Z
+B0_TX_FROM = 0x8611d9722ec5089f974eb48a7b5ccdb97e8978fb
+B0_TX_TO = 0x0ba958a449701907302e28f5955fa9d16ddc45c3
+B0_TX_STATUS = 0x1 / SUCCESS
+B0_GAS_USED = 0x442ce
+B0_PROXY_ADDRESS = 0x829AdfEdBe565F9885a7eA6Bc78912acAef055E2
+B0_ACCOUNT_DEPLOYMENT_STATE = PROVEN
+```
+
+This flips the prior exact-fetch hold:
+
+```text
+B0_ACCOUNT_DEPLOYMENT_TX: BOUND_POINTER -> PROVEN
+B0_ACCOUNT_DEPLOYMENT_BLOCK: HOLD_EXACT_FETCH -> PROVEN / 25,407,456
+B0_ACCOUNT_DEPLOYMENT_TIMESTAMP: HOLD_EXACT_FETCH -> PROVEN / 2025-01-23T03:50:59Z
+```
+
+Provenance boundary:
+
+```text
+PRIMARY_RECEIPT = user-supplied Base RPC result
+PUBLIC_POINTER = BaseScan transaction hash already independently observed
+BROWSER_EXACT_BLOCK_TIMESTAMP_CROSSCHECK = NOT_COMPLETED_IN_THIS_REPLAY
+```
+
+The RPC receipt is the promoted primary receipt for this v0.1.1 delta. The public-browser cross-check remains a distinct witness class and is not silently claimed.
+
+## First relevant activity / dense floor
+
+The previously supplied explorer-window observation remains independently typed:
 
 ```text
 B0_FIRST_RELEVANT_ACTIVITY_CANDIDATE ~= 29,889,702
+B0_FIRST_RELEVANT_ACTIVITY_STATE = CANDIDATE / NEEDS_COMPLETE_MIN_ACROSS_EVENT_CLASSES
 B0_DENSE_SCAN_FLOOR = 29,800,000
+B0_DENSE_SCAN_FLOOR_STATE = LOCKED_WORK_FLOOR
 ```
 
-Current BaseScan observation independently confirms `0x829a...` is a CoinbaseSmartWallet proxy contract and exposes a contract-creation receipt. The creation receipt transaction hash observed from BaseScan navigation is:
-
-```text
-0x7239f942d4818821f88d24c63140ba0aaae1e096036d746e007b2f6f0c3789e6
-```
-
-The exact creation block/timestamp was not returned by the independent browser fetch in this replay. Therefore:
-
-```text
-B0_ACCOUNT_DEPLOYMENT_TX = BOUND_POINTER
-B0_ACCOUNT_DEPLOYMENT_BLOCK = HOLD_EXACT_FETCH
-B0_ACCOUNT_DEPLOYMENT_TIMESTAMP = HOLD_EXACT_FETCH
-B0_FIRST_RELEVANT_ACTIVITY_CANDIDATE = USER_SUPPLIED / NEEDS_RPC_OR_EXPORT_MIN
-B0_DENSE_SCAN_FLOOR = 29,800,000 / ACCEPTED_CONSERVATIVE_WORK_FLOOR
-```
-
-BaseScan also reports 31 regular transactions in its current address snapshot; visible regular rows extend at least to July 22, 2025. Regular transaction history is not a complete substitute for contract creation, internal calls, token transfers, or logs.
-
-Primary public explorer pointers:
-- https://basescan.org/address/0x829adfedbe565f9885a7ea6bc78912acaef055e2
-- https://basescan.org/address/0x694ce46c64d9d1a5e9376a9febcf85ec05d72e9f
+The exact account deployment at block 25,407,456 is earlier than the dense floor. This is expected and does not require moving the dense floor. The sparse completeness backstop covers the interval before dense indexing.
 
 ## Partition schedule
 
@@ -99,6 +124,8 @@ PROTOCOL FAMILIES:
 - ENS / Basename identity-resolution checkpoints where historically resolvable
 ```
 
+The interval `25,407,456 -> 29,799,999` is now an explicit sparse-backfill region. Any matching rows found there are appended as PROVEN / BOUND / HOLD / CONFLICT according to their receipts; they do not retroactively alter B0.
+
 ## Four-rail merger
 
 ```text
@@ -142,17 +169,27 @@ conflicts: []
 created_at: string
 ```
 
-## Promotion condition
+## Current promotion state
 
-The exact first relevant block is promoted only after a complete RPC/indexed-provider result or explorer export supports `MIN(blockNumber)` across the relevant event classes. Until then, `29,800,000` is the dense work floor—not a claim of wallet birth.
+```text
+B0_ACCOUNT_DEPLOYMENT = PROVEN
+B0_ACCOUNT_DEPLOYMENT_BLOCK = 25,407,456
+B0_ACCOUNT_DEPLOYMENT_TIMESTAMP = 2025-01-23T03:50:59Z
+B0_FIRST_RELEVANT_ACTIVITY_CANDIDATE = ~29,889,702 / NOT YET PROMOTED
+B0_DENSE_SCAN_FLOOR = 29,800,000 / LOCKED
+DENSE_SCANNER_EXECUTION = NOT_CLAIMED_BY_THIS_ARTIFACT
+BACKGROUND_EXECUTION = NOT_CLAIMED
+```
 
 ## Doctrine
 
 ```text
 ACCOUNT DEPLOYMENT != FIRST FUNDING
+ACCOUNT DEPLOYMENT != DENSE FLOOR
 FIRST REGULAR TX != FIRST LOG
 DENSE FLOOR != CHAIN BIRTH
 BLOCK CO-OCCURRENCE != RELATIONSHIP
 SNAPSHOT != CURRENT STATE
+USER-SUPPLIED RPC RECEIPT != INDEPENDENT BROWSER FETCH
 MISSING HISTORICAL READBACK -> HOLD
 ```

--- a/docs/audits/JAYWISDOM_B0_INDEX_PARTITION_SCHEDULE_V0_1.md
+++ b/docs/audits/JAYWISDOM_B0_INDEX_PARTITION_SCHEDULE_V0_1.md
@@ -1,0 +1,158 @@
+# JAYWISDOM B0 Index Partition Schedule v0.1
+
+Date: `2026-08-19`
+Status: `B0_DENSE_FLOOR_BOUND / ACCOUNT_BIRTH_EXACT_BLOCK_HOLD`
+Authority created: `FALSE`
+Financial claim created: `FALSE`
+
+## Canonical spine
+
+```text
+PRIMARY_TARGET = 0x829AdfEdBe565F9885a7eA6Bc78912acAef055E2
+JAYWISDOM_TOKEN = 0x694cE46C64D9D1a5e9376A9feBcF85Ec05D72e9F
+JAYWISDOM_BASE_OPERATIONAL = 0xA380552a27b0a5a2874Ea7AA52CAC09f542002E8
+NETWORK = Base / chainId 8453
+```
+
+## B0 typing
+
+Do not collapse these states:
+
+```text
+B0_ACCOUNT_DEPLOYMENT = exact CoinbaseSmartWallet proxy creation block
+B0_FIRST_RELEVANT_ACTIVITY = earliest transaction/log/transfer involving the audit spine
+B0_DENSE_SCAN_FLOOR = conservative block floor for dense historical indexing
+```
+
+User-supplied Phase 0 observation:
+
+```text
+B0_FIRST_RELEVANT_ACTIVITY_CANDIDATE ~= 29,889,702
+B0_DENSE_SCAN_FLOOR = 29,800,000
+```
+
+Current BaseScan observation independently confirms `0x829a...` is a CoinbaseSmartWallet proxy contract and exposes a contract-creation receipt. The creation receipt transaction hash observed from BaseScan navigation is:
+
+```text
+0x7239f942d4818821f88d24c63140ba0aaae1e096036d746e007b2f6f0c3789e6
+```
+
+The exact creation block/timestamp was not returned by the independent browser fetch in this replay. Therefore:
+
+```text
+B0_ACCOUNT_DEPLOYMENT_TX = BOUND_POINTER
+B0_ACCOUNT_DEPLOYMENT_BLOCK = HOLD_EXACT_FETCH
+B0_ACCOUNT_DEPLOYMENT_TIMESTAMP = HOLD_EXACT_FETCH
+B0_FIRST_RELEVANT_ACTIVITY_CANDIDATE = USER_SUPPLIED / NEEDS_RPC_OR_EXPORT_MIN
+B0_DENSE_SCAN_FLOOR = 29,800,000 / ACCEPTED_CONSERVATIVE_WORK_FLOOR
+```
+
+BaseScan also reports 31 regular transactions in its current address snapshot; visible regular rows extend at least to July 22, 2025. Regular transaction history is not a complete substitute for contract creation, internal calls, token transfers, or logs.
+
+Primary public explorer pointers:
+- https://basescan.org/address/0x829adfedbe565f9885a7ea6bc78912acaef055e2
+- https://basescan.org/address/0x694ce46c64d9d1a5e9376a9febcf85ec05d72e9f
+
+## Partition schedule
+
+### Dense historical pass
+
+```text
+START_BLOCK = 29,800,000
+FETCH_WINDOW_BLOCKS = 5,000
+WINDOW_KEY = base:<fromBlock>-<toBlock>
+ORDER = ascending blockNumber, transactionIndex, logIndex
+END = observed HEAD at execution time
+```
+
+Each 5,000-block window is immutable after receipt generation. Re-fetches create a version delta; they do not overwrite prior receipts.
+
+### Fortnight checkpoint layer
+
+Fortnight checkpoints are defined by UTC timestamps rather than an assumed fixed block count:
+
+```text
+EPOCH = [00:00:00Z day_0, 00:00:00Z day_14)
+ROOT = Merkle(events ordered by blockNumber, txIndex, logIndex, rail)
+STORE = local SQLite + exported receipt
+```
+
+The ingest process resolves the first and last Base block actually falling inside each 14-day timestamp interval. Do not approximate a fortnight as a fixed number of blocks in the canonical receipt.
+
+### Sparse completeness backstop
+
+Run a lightweight Base-genesis-to-HEAD filter for only the canonical addresses and known protocol topics. Its purpose is to catch any event before the dense floor without scanning every transaction.
+
+```text
+ADDRESSES:
+- 0x829AdfEdBe565F9885a7eA6Bc78912acAef055E2
+- 0x694cE46C64D9D1a5e9376A9feBcF85Ec05D72e9F
+- 0xA380552a27b0a5a2874Ea7AA52CAC09f542002E8
+
+PROTOCOL FAMILIES:
+- Coinbase Smart Wallet deployment / ownership
+- ERC-20 Transfer / Approval
+- ZoraFactory / CreatorCoin
+- Zora payout / creator rewards / referrer
+- Uniswap v4 PoolManager / Initialize / ModifyLiquidity / Swap
+- EAS attestation / schema events
+- ENS / Basename identity-resolution checkpoints where historically resolvable
+```
+
+## Four-rail merger
+
+```text
+RAIL_1_BASE = transactions + internal calls + logs + transfers
+RAIL_2_ZORA = profile + CreatorCoin + content coins + payouts + metadata/IPFS
+RAIL_3_EAS = schema + attestation events tied to known addresses/UIDs
+RAIL_4_IDENTITY = ENS/Basename resolution checkpoints
+
+MERGE_KEY_PRIMARY = (chainId, blockNumber, txHash, logIndex, rail)
+LEFT_JOIN_STORY_KEY = (blockNumber, txHash)
+```
+
+Never force two records into one relationship merely because they share a block or transaction.
+
+## Gray Baby state stamping
+
+Each merged row receives:
+
+```text
+PROVEN = direct primary receipt establishes the bounded event
+BOUND = cross-surface pointer is receipt-linked but broader claim excluded
+HOLD = missing dynamic/historical readback
+CONFLICT = witnesses materially disagree
+```
+
+`HOLD` rows form the retro-signing / evidence-acquisition queue. A later receipt appends a state delta; historical rows remain preserved.
+
+## Checkpoint object
+
+```yaml
+epoch_id: string
+start_timestamp_utc: string
+end_timestamp_utc: string
+first_block: integer
+last_block: integer
+rows_by_rail: {}
+merkle_root: string
+source_receipts: []
+holds: []
+conflicts: []
+created_at: string
+```
+
+## Promotion condition
+
+The exact first relevant block is promoted only after a complete RPC/indexed-provider result or explorer export supports `MIN(blockNumber)` across the relevant event classes. Until then, `29,800,000` is the dense work floor—not a claim of wallet birth.
+
+## Doctrine
+
+```text
+ACCOUNT DEPLOYMENT != FIRST FUNDING
+FIRST REGULAR TX != FIRST LOG
+DENSE FLOOR != CHAIN BIRTH
+BLOCK CO-OCCURRENCE != RELATIONSHIP
+SNAPSHOT != CURRENT STATE
+MISSING HISTORICAL READBACK -> HOLD
+```

--- a/docs/audits/JAYWISDOM_ZORA_COIN_TOPOLOGY_V0_1.md
+++ b/docs/audits/JAYWISDOM_ZORA_COIN_TOPOLOGY_V0_1.md
@@ -1,0 +1,137 @@
+# JAYWISDOM — Zora Coin Topology v0.1
+
+Date: `2026-08-19`  
+Parent audit: `JAYWISDOM_0X69_GRAYBABY_ATOMIC_AUDIT_V0_1` / PR `#511`  
+Status: `REPO_SNAPSHOT_BOUND / CURRENT_INVENTORY_HOLD`  
+Authority created: `FALSE`
+
+## Purpose
+
+Keep Jay Wisdom's Zora coin surface inside the atomic identity replay without collapsing distinct coin contracts, profile identity, wallets, or platform referral roles into one object.
+
+## Root topology
+
+```text
+JAY WISDOM / JSONWISDOM
+  |
+  +-- Zora profile: @jaywisdom
+  |     |
+  |     +-- profile Creator Coin
+  |     |     `-- 0x694cE46C64D9D1a5e9376A9feBcF85Ec05D72e9F
+  |     |
+  |     `-- created Content Coins[]
+  |           +-- independent ERC-20/post coin contract
+  |           +-- independent metadata/IPFS object
+  |           +-- independent creator/payout/referrer fields
+  |           +-- independent market/pool relationship
+  |           `-- independent receipt state
+  |
+  +-- creator/payout address seen in snapshot
+  |     `-- 0x829AdfEdBe565F9885a7eA6Bc78912acAef055E2
+  |
+  +-- GitHub index/mirror
+  |     `-- jsonwisdom/jay-zora-portal
+  |
+  `-- Base chain receipts
+        `-- each coin must replay independently
+```
+
+## Repository snapshot
+
+Source: `jsonwisdom/jay-zora-portal/discovery/zora/latest_profile_coins_response.json`
+
+Observed snapshot fields:
+
+```text
+PROFILE_HANDLE = jaywisdom
+PROFILE_CREATOR_COIN = 0x694ce46c64d9d1a5e9376a9febcf85ec05d72e9f
+CREATED_COINS_COUNT_SNAPSHOT = 923
+CREATED_COINS_COUNT_CURRENT = HOLD_DYNAMIC_READBACK
+```
+
+The count of `923` is a repository-captured Zora API/GraphQL snapshot. It must not be promoted to a present-time inventory count without a new live readback.
+
+## Sample content-coin relationship from the snapshot
+
+```text
+CONTENT_COIN = 0xc178f471cb74bf026809bf5632d3c9abc5a1fae7
+COIN_TYPE = CONTENT
+CHAIN_ID = 8453 / Base
+TOTAL_SUPPLY_SNAPSHOT = 1,000,000,000
+CREATOR_ADDRESS = 0x829adfedbe565f9885a7ea6bc78912acaef055e2
+PAYOUT_RECIPIENT = 0x829adfedbe565f9885a7ea6bc78912acaef055e2
+PLATFORM_REFERRER = 0x7bf90111ad7c22bec9e9dff8a01a44713cc1b1b6
+POOL_CURRENCY_SNAPSHOT = WETH / 0x4200000000000000000000000000000000000006
+```
+
+This proves why `referrer` cannot be treated as one identity-wide role. Referral fields are coin/event specific. For this sampled content coin, the snapshot records a nonzero platform referrer that is different from `0x829a...`. For the JAYWISDOM Creator Coin creation receipt, creation-time `platformReferrer` was the zero address.
+
+## Coin classes must remain distinct
+
+```text
+CREATOR_COIN != CONTENT_COIN
+PROFILE != WALLET
+WALLET != COIN
+COIN_A != COIN_B
+PLATFORM_REFERRER_A != GLOBAL_REFERRER
+METADATA != CURRENT_CHAIN_STATE
+REPO_SNAPSHOT != LIVE_INVENTORY
+```
+
+## Zora platform relationship
+
+Current Zora architecture treats profiles and posts as tradable coins. Zora's public documentation states that each post is a coin with a one-billion supply, and profile Creator Coins are separately represented. The public platform also describes the broader relationship among post coins, Creator Coins, and `$ZORA`.
+
+This architecture description is platform context; it does not prove any particular Jay coin's current balance, holders, liquidity, price, rewards, or ownership.
+
+## Atomic checkpoint schema
+
+Each Zora coin should replay as:
+
+```yaml
+coin_address: string
+coin_class: CREATOR | CONTENT | OTHER
+chain_id: 8453
+creator_address: string | HOLD
+payout_recipient: string | HOLD
+platform_referrer: string | ZERO | HOLD
+metadata_uri: string | HOLD
+creation_tx: string | HOLD
+creation_block: integer | HOLD
+pool_or_pool_id: string | HOLD
+current_owner_or_admin: HOLD | value
+current_liquidity: HOLD | value
+current_holders: HOLD | value
+repo_snapshot_state: OBSERVED | BOUND
+chain_state: PROVEN | BOUND | HOLD | CONFLICT
+```
+
+## Relationship to Gray Baby
+
+Gray Baby remains the witness/replay method. It does not make every Zora coin a Gray Baby object and does not infer economic linkage between separate contracts.
+
+```text
+GRAYBABY_METHOD -> AUDITS EACH COIN
+GRAYBABY_TOKEN != JAYWISDOM_CREATOR_COIN
+GRAYBABY_TOKEN != ALL_CONTENT_COINS
+```
+
+## One story, multiple checkpoints
+
+```text
+JAY WISDOM
+  -> identity labels
+  -> ENS / Basename checkpoints
+  -> wallets
+  -> Zora profile
+  -> Creator Coin
+  -> Content Coins[]
+  -> Base transactions / pools
+  -> GitHub receipts
+  -> Drive mirrors
+  -> Farcaster/X publication witnesses
+  -> OpenAI Platform topology context
+  -> GrayBabyWitness replay
+```
+
+The story may be singular. The evidence remains atomic.


### PR DESCRIPTION
Creates a dedicated append-only Gray Baby audit for the Base JAYWISDOM CreatorCoin at `0x694cE46C64D9D1a5e9376A9feBcF85Ec05D72e9F`.

Direct-chain replay closes historical HOLDs without rewriting prior receipts:
- token identity -> PROVEN_ONCHAIN
- creation via ZoraFactory -> PROVEN
- `0x829a...` -> caller + payoutRecipient + initial owner; later creator-reward role
- creation-time platformReferrer -> zero address, so generic `referrer` label remains role-ambiguous
- Uniswap v4 PoolId -> PROVEN
- initial liquidity events -> PROVEN
- current ownership/liquidity -> HOLD pending current readback

Also preserves the membrane between JAYWISDOM and the separate Gray Baby token/object in PR #509.

Drive mirror:
https://docs.google.com/document/d/1XTdWUiPSvWjUdHI39AS8C_XVJQAHRC9zKDDO0fb1tog/edit

AUTHORITY_CREATED=FALSE
FINANCIAL_CLAIM_CREATED=FALSE
MIGRATION_AUTHORIZED=FALSE