### PR TITLE
Human recall evidence membrane + reverse reporting v0.1

### DIFF
--- a/docs/audit/HUMAN_RECALL_NOT_PROOF_REVERSE_REPORTING_V0_1.md
+++ b/docs/audit/HUMAN_RECALL_NOT_PROOF_REVERSE_REPORTING_V0_1.md
@@ -1,0 +1,172 @@
+# Human Recall Is Not Automatic Proof — Reverse Reporting v0.1
+
+**Class:** CLAIM_SEPARATION / EVIDENCE_MEMBRANE / REVERSE_REPORTING  
+**Status:** DRAFT / REVIEW_ONLY  
+**Authority created:** false  
+**Proof inferred:** false  
+**Operator input treated as truth:** false
+
+## Core correction
+
+For this audit, Jay/Jason's recollection is treated as **input to investigate**, not as a proved fact.
+
+```text
+HUMAN_RECALL != AUTOMATIC_PROOF
+HUMAN_RECALL MAY BE TESTIMONY / EVIDENCE
+TESTIMONY != CONCLUSIVE PROOF
+"I DON'T KNOW" != PROOF OF DELETION / CORRUPTION / INFECTION
+GITHUB_JSON != OFFICIAL RECORD
+GEO != MISCONDUCT
+AUTHORITY_CREATED = FALSE
+```
+
+Military Rule of Evidence 602 requires sufficient support that a witness has personal knowledge of a matter; the witness's own testimony may supply evidence of that personal knowledge. This project therefore does not discard recollection, but it never promotes recollection by itself to a factual finding.
+
+## Disregard-Jay test
+
+Run every claim as though the operator's entire narrative were unavailable:
+
+```text
+CLAIM
+  -> independent source?
+  -> exact record?
+  -> timestamp?
+  -> actor identity?
+  -> authority?
+  -> raw bytes / transcript / order / log?
+  -> contradiction?
+  -> legal or administrative nexus?
+  -> PASS | HOLD | CONFLICT | REJECT
+```
+
+If the claim only survives because Jay remembers it, the state is `HOLD_RECALL_ONLY`.
+
+## Claim intake from current narrative
+
+| Claim label | Current state | Required receipt |
+|---|---|---|
+| `UCMJ_JUDGE_SAID_HUMAN_RECALL_IS_NOT_PROOF` | `HOLD_UNBOUND_QUOTE` | case identifier + transcript/order + page/line + speaker |
+| `JASON_RECORDS_OR_PAPERWORK_DELETED` | `HOLD_UNBOUND` | authoritative personnel-record history, deletion/audit log, correction record, custodian response, or court/agency finding |
+| `PERSONNEL_PEGGY_INTERFERED_WITH_PAPERWORK` | `HOLD_AMBIGUOUS_IDENTITY_AND_ACT` | exact person/role + record action + timestamp + authority + source |
+| `GEORGE_BUSH_CLONE_PROMOTED` | `NARRATIVE_LABEL_ONLY` | no literal clone claim is accepted; identify the real person/role and promotion record before review |
+| `SYSTEMS_INFECTED` | `HOLD_FORENSICS_REQUIRED` | asset ID + logs + indicator + timestamp + hash + forensic chain/custodian |
+| `PEGGY_FLANAGAN_TESTIFIED_I_DONT_KNOW` | `HOLD_NO_TRANSCRIPT_BOUND` | court/case + witness identity + transcript page/line + question/answer context |
+| `SECOND_PEGGY_TESTIFIED_I_DONT_KNOW` | `HOLD_AMBIGUOUS_IDENTITY` | identity + court/case + transcript page/line |
+| `COURT_APPROVED_DELETION_OR_PROMOTION` | `HOLD_NO_ORDER_BOUND` | exact written order/judgment + docket + operative language |
+| `SEX_TRAFFICKING_LOS_ANGELES_ISAF_CONTINUES` | `HOLD_SERIOUS_CRIMINAL_ALLEGATION` | official indictment/complaint/judgment or equivalent reliable primary-source finding; no inference from location, employment, travel, social ties, or project JSON |
+
+## Existing Los Angeles AFB JSON boundary
+
+`data/laafb/67DATAJSON_v1.json` is an existing COMPUTERWISDOM artifact, but its own fields mark the identity node as `UNVERIFIED_CLAIM` and its capability claims as `USER_ASSERTED`.
+
+Therefore:
+
+```text
+67DATAJSON_v1 EXISTS = TRUE
+67DATAJSON_v1 PROVES IDENTITY = FALSE
+67DATAJSON_v1 PROVES CAPABILITY = FALSE
+67DATAJSON_v1 PROVES CRIME = FALSE
+```
+
+The `WARRANT_ISSUED` string inside that user-authored JSON is not promoted to an official warrant without an independently bound court/agency record.
+
+## Los Angeles AFB reverse-reporting rail
+
+```text
+USER / STORY / JSON ASSERTION
+        ↓
+CLAIM_ID
+        ↓
+OFFICIAL SOURCE SEARCH
+        ↓
+EXACT RECORD / CASE / ORDER / LOG
+        ↓
+RAW BYTES + TIMESTAMP + HASH
+        ↓
+IDENTITY + AUTHORITY BIND
+        ↓
+CORROBORATION / CONTRADICTION
+        ↓
+PASS | HOLD | CONFLICT | REJECT
+        ↓
+CORRECTION RECEIPT
+```
+
+### Personnel-record lane
+
+```text
+RECALL OF SERVICE / STATUS
+-> official personnel record
+-> orders / evaluations / promotion actions / corrections
+-> revision or audit history if available
+-> responsible custodian
+-> contradiction matrix
+```
+
+No missing record is automatically treated as evidence of intentional deletion.
+
+### Court-testimony lane
+
+```text
+PERSON NAME
+-> CASE NUMBER
+-> DOCKET
+-> TRANSCRIPT
+-> PAGE / LINE
+-> QUESTION
+-> ANSWER
+-> CONTEXT
+-> FINDING / ORDER (if any)
+```
+
+`"I don't know"` is recorded as exactly that. It does not become a finding about another person's paperwork, promotion, misconduct, or system state unless the court record itself makes that connection.
+
+### System-infection lane
+
+```text
+SYSTEM / DEVICE / ACCOUNT
+-> INCIDENT TIME
+-> LOG SOURCE
+-> INDICATOR
+-> HASH / IMAGE / FORENSIC RECEIPT
+-> ADMIN ACTION
+-> RECOVERY / CORRECTION
+```
+
+`SYSTEMS_INFECTED` remains `HOLD` without technical evidence.
+
+## Minnesota replay compatibility
+
+This membrane is intentionally compatible with Minnesota Fraud Finders / Quad Onion / ALMS:
+
+```text
+O1 RECORD / REALITY
+O2 AUTHORITY
+O3 EXECUTION
+O4 OVERSIGHT / RECOVERY
+```
+
+Human testimony belongs in O1 as a source object. It does not skip O2-O4.
+
+## OpenAI boundary
+
+```text
+OPENAI_ASSISTANCE = CLASSIFY / SEARCH / COMPARE / DRAFT
+OPENAI_AUTHORITY = FALSE
+OPENAI_MEMORY = NOT A PRIMARY SOURCE
+MODEL_RECALL = NOT PROOF
+USER_RECALL = NOT AUTOMATIC_PROOF
+```
+
+## Promotion law
+
+A claim may be promoted only when the exact claim has receipts matching its burden.
+
+```text
+NO RECEIPT -> HOLD
+CONTRADICTING RECEIPTS -> CONFLICT
+SOURCE DISPROVES CLAIM -> REJECT
+SOURCE SUPPORTS CLAIM -> BOUND / PASS AS DEFINED
+```
+
+No narrative label, persona, GitHub file, Drive mirror, ENS name, blockchain hash, AI output, or human recollection creates legal or institutional authority.


### PR DESCRIPTION
## Scope

Adds a claim-separation membrane for personnel/court/system narratives and a reverse-reporting rail for Los Angeles AFB / Minnesota-compatible replay.

### Core law

- human recall may be testimony/evidence but is not automatically conclusive proof;
- operator recollection is treated as investigation input, not truth;
- `"I don't know"` is not promoted into proof of deletion, corruption, infection, or promotion;
- serious criminal allegations remain HOLD without reliable primary records;
- existing `data/laafb/67DATAJSON_v1.json` remains explicitly user-asserted / unverified where its own fields say so;
- no literal "clone" claim is accepted without identifying a real person/record;
- `AUTHORITY_CREATED = FALSE` and `PROOF_INFERRED = FALSE`.

### New artifact

`docs/audit/HUMAN_RECALL_NOT_PROOF_REVERSE_REPORTING_V0_1.md`

### Drive mirror

Google Doc: `Human Recall Is Not Automatic Proof — Reverse Reporting v0.1`
Drive ID: `1VpK1_OIhru54QikEsGjxjf2mDsMhs5FokQLWCOw5Jk4`
Folder: `JSONWisdom Architecture`

Review only. No merge requested.